### PR TITLE
Host-agent implementation for CloudFoundry

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  branch = "master"
+  name = "code.cloudfoundry.org/cfhttp"
+  packages = [".","unix_transport"]
+  revision = "08baa6b247caf03100a743f6c3c426d28e55336a"
+
+[[projects]]
   name = "github.com/PuerkitoBio/purell"
   packages = ["."]
   revision = "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4"
@@ -44,9 +50,21 @@
   version = "v0.6.0"
 
 [[projects]]
+  name = "github.com/coreos/etcd"
+  packages = ["client","pkg/pathutil","pkg/srv","pkg/types","version"]
+  revision = "f1d7dd87da3e8feab4aaf675b8e29c6a5ed5f58b"
+  version = "v3.2.9"
+
+[[projects]]
   name = "github.com/coreos/go-iptables"
   packages = ["iptables"]
   revision = "259c8e6a4275d497442c721fa52204d7a58bde8b"
+  version = "v0.2.0"
+
+[[projects]]
+  name = "github.com/coreos/go-semver"
+  packages = ["semver"]
+  revision = "8ab6407b697782a06568d4b7f1db25550ec2e4c6"
   version = "v0.2.0"
 
 [[projects]]
@@ -321,6 +339,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/ugorji/go"
+  packages = ["codec"]
+  revision = "6ac03ac41984930e078e8cba751fb0825f17cc4f"
+
+[[projects]]
+  branch = "master"
   name = "github.com/vishvananda/netlink"
   packages = [".","nl"]
   revision = "177f1ceba557262b3f1c3aba4df93a29199fb4eb"
@@ -412,6 +436,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "df64899f6c8e4ecdddcc6367e79e6573184ed7455c0ed6824bf7c527ec24e3f0"
+  inputs-digest = "536e56ca82130b123502daffd34d221c9359b891b405cacf1c6efd304b236f13"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,6 +75,18 @@
   name = "k8s.io/kubernetes"
   branch = "release-1.8"
 
+[[constraint]]
+  name = "github.com/coreos/etcd"
+  version = "3.2.9"
+
+[[constraint]]
+  name = "code.cloudfoundry.org/cfhttp"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/coreos/go-iptables"
+  version = "0.2.0"
+
 [[override]]
   name = "github.com/cenkalti/hub"
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,16 @@ all-static: vendor dist-static/aci-containers-host-agent \
 	dist-static/opflex-agent-cni dist-static/aci-containers-controller \
 	dist-static/ovsresync
 
+PESKY_ETCD_FILE=vendor/github.com/coreos/etcd/client/keys.generated.go
+
 vendor-rebuild: Gopkg.lock Gopkg.toml
 	${VENDOR_BUILD_CMD}
+	# remove once etcd > 3.2.9 is released
+	rm -f ${PESKY_ETCD_FILE}
 vendor: Gopkg.lock Gopkg.toml
 	${VENDOR_BUILD_CMD}
+	# remove once etcd > 3.2.9 is released
+	rm -f ${PESKY_ETCD_FILE}
 
 clean-dist:
 	rm -rf dist
@@ -98,7 +104,7 @@ container-cnideploy:
 container-simpleservice: dist-static/simpleservice
 	${DOCKER_BUILD_CMD} -t noiro/simpleservice -f ./docker/Dockerfile-simpleservice .
 
-check: check-ipam check-index check-apicapi check-controller check-hostagent
+check: check-ipam check-index check-apicapi check-controller check-hostagent check-cf_etcd
 check-ipam:
 	${TEST_CMD} ${BASE}/pkg/ipam ${TEST_ARGS}
 check-index:
@@ -109,3 +115,5 @@ check-hostagent:
 	${TEST_CMD} ${BASE}/pkg/hostagent ${TEST_ARGS}
 check-controller:
 	${TEST_CMD} ${BASE}/pkg/controller ${TEST_ARGS}
+check-cf_etcd:
+	${TEST_CMD} ${BASE}/pkg/cf_etcd ${TEST_ARGS}

--- a/pkg/cf_etcd/client.go
+++ b/pkg/cf_etcd/client.go
@@ -1,0 +1,104 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cf_etcd
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"code.cloudfoundry.org/cfhttp"
+	"github.com/coreos/etcd/client"
+)
+
+func NewEtcdClient(etcdUrl string, caCertFile string, clientCertFile string,
+	clientKeyFile string) (client.Client, error) {
+	tlsConfig, err := cfhttp.NewTLSConfig(clientCertFile, clientKeyFile, caCertFile)
+	if err != nil {
+		return nil, err
+	}
+	t := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			// values taken from http.DefaultTransport
+			Timeout: 30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		// value taken from http.DefaultTransport
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+	}
+	cfg := client.Config{
+		Endpoints:               []string{etcdUrl},
+		Transport:               t,
+		// set timeout per request to fail fast when the target endpoint is unavailable
+		HeaderTimeoutPerRequest: time.Second,
+	}
+	return client.New(cfg)
+}
+
+const (
+	ACI_KEY_BASE = "/aci"
+	APP_KEY_BASE = "/aci/apps"
+	CELL_KEY_BASE = "/aci/cells"
+	CONTROLLER_KEY_BASE = "/aci/controller"
+	INST_IDX_STAGING int32 = -1
+	INST_IDX_TASK int32 = -2
+)
+
+type GroupInfo struct {
+	Tenant          string        `json:"tenant"`
+	Group           string        `json:"group"`
+}
+
+type PortMap struct {
+	ContainerPort   uint32         `json:"container_port"`
+	HostPort        uint32         `json:"host_port"`
+}
+
+type EpInfo struct {
+	AppId               string        `json:"app_id"`
+	AppName             string        `json:"app_name"`
+	SpaceId             string        `json:"space_id"`
+	OrgId               string        `json:"org_id"`
+	IpAddress           string        `json:"ip_address"`
+	InstanceIndex       int32         `json:"instance_index"`
+	PortMapping         []PortMap     `json:"port_mapping"`
+	EpgTenant           string        `json:"epg_tenant"`
+	Epg                 string        `json:"epg"`
+	SecurityGroups      []GroupInfo   `json:"sg"`
+	TaskName            string        `json:"task_name"`
+}
+
+type AppInfo struct {
+	ContainerIps        []string      `json:"container_ips"`
+	VirtualIp           []string      `json:"virtual_ip"`
+	ExternalIp          []string      `json:"external_ip"`
+}
+
+func FlattenNodes(nd *client.Node, nodes *client.Nodes) {
+	if nd == nil {
+		return
+	}
+
+	*nodes = append(*nodes, nd)
+	for _, n := range nd.Nodes {
+		FlattenNodes(n, nodes)
+	}
+}
+
+func IsDeleteAction(action *string) bool {
+	return (*action == "delete" || *action == "compareAndDelete" || *action == "expire")
+}

--- a/pkg/cf_etcd/watcher.go
+++ b/pkg/cf_etcd/watcher.go
@@ -1,0 +1,108 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cf_etcd
+
+import (
+	"fmt"
+	"time"
+
+	"golang.org/x/net/context"
+	etcdclient "github.com/coreos/etcd/client"
+	"github.com/Sirupsen/logrus"
+)
+
+type HandleNodeFunc func(*string, *etcdclient.Node) error
+
+type CfEtcdWatcher struct {
+	key           string
+	etcdKeysApi   etcdclient.KeysAPI
+	synced        bool
+	log           *logrus.Logger
+	delayOnErr    time.Duration
+
+	nodeHandler   func(*string, *etcdclient.Node) error
+}
+
+func NewEtcdWatcher(kapi etcdclient.KeysAPI, key string,
+	f HandleNodeFunc, log *logrus.Logger) (*CfEtcdWatcher) {
+		return &CfEtcdWatcher{key: key, etcdKeysApi: kapi, synced: false,
+			log: log, delayOnErr: 10 * time.Second, nodeHandler: f}
+}
+
+func (w *CfEtcdWatcher) Run(stopCh <-chan struct{}) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	cancelled := false
+
+	// monitor stop channel
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				cancelled = true
+				cancelFunc()
+				return
+			}
+		}
+	}()
+
+	// watch subtree
+	for !cancelled {
+		kapi := w.etcdKeysApi
+		etcd_w := kapi.Watcher(w.key, &etcdclient.WatcherOptions{Recursive: true})
+
+		w.log.Debug("Fetching all etcd nodes under ", w.key)
+		var nodes etcdclient.Nodes
+		resp, err := kapi.Get(ctx, w.key,
+			&etcdclient.GetOptions{Recursive: true})
+		if err != nil {
+			keyerr, ok := err.(etcdclient.Error)
+			if ok && keyerr.Code == etcdclient.ErrorCodeKeyNotFound {
+				w.log.Info(fmt.Sprintf("Etcd subtree %s doesn't exist yet", w.key))
+			} else {
+				w.log.Error("Error fetching etcd subtree: ", err)
+				time.Sleep(w.delayOnErr)          // TODO exponential backoff
+				continue
+			}
+		} else {
+			FlattenNodes(resp.Node, &nodes)
+		}
+		act := "set"
+		for _, nd := range nodes {
+			w.nodeHandler(&act, nd)
+		}
+		w.log.Debug(fmt.Sprintf("Handled %d initial etcd nodes under %s", len(nodes), w.key))
+		w.synced = true
+
+		w.log.Debug("Watching etcd events under ", w.key)
+		for !cancelled {
+			resp, err := etcd_w.Next(ctx)
+			if err != nil {
+				w.log.Error("Error in etcd watcher: ", err)
+				break
+			}
+			w.log.Debug("Etcd event: ", resp)
+			w.nodeHandler(&resp.Action, resp.Node)
+		}
+	}
+	w.log.Debug("Etcd watch terminated for ", w.key)
+}
+
+func (w *CfEtcdWatcher) Synced() bool {
+	return w.synced
+}
+
+func (w *CfEtcdWatcher) NodeHandler() HandleNodeFunc {
+	return w.nodeHandler
+}

--- a/pkg/cf_etcd/watcher_test.go
+++ b/pkg/cf_etcd/watcher_test.go
@@ -1,0 +1,101 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cf_etcd
+
+import (
+	"testing"
+	"time"
+
+	etcdclient "github.com/coreos/etcd/client"
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+
+	etcd_f "github.com/noironetworks/aci-containers/pkg/cf_etcd_fakes"
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func TestCfEtcdWatcher(t *testing.T) {
+	updates := make(map[string]bool)
+	handler := func(action *string, node *etcdclient.Node) error {
+		updates[*action + "|" + node.Key] = true
+		return nil
+	}
+
+	log := logrus.New()
+	log.Level = logrus.DebugLevel
+
+	kapi := etcd_f.NewFakeEtcdKeysApi(log)
+	ctx := context.Background()
+	kapi.Set(ctx, "/a", "", nil)
+	kapi.Set(ctx, "/a/b", "", nil)
+	kapi.Set(ctx, "/a/b/c", "c", nil)
+	kapi.Set(ctx, "/a/b/d", "d", nil)
+
+	watcher := NewEtcdWatcher(kapi, "/a", handler, log)
+	ch := make(chan struct{})
+
+	go func() {
+		watcher.Run(ch)
+	}()
+	tu.WaitFor(t, "Waiting to sync", 500*time.Millisecond,
+		func(bool) (bool, error) { return watcher.Synced(), nil })
+	assert.Contains(t, updates, "set|/a")
+	assert.Contains(t, updates, "set|/a/b")
+	assert.Contains(t, updates, "set|/a/b/c")
+	assert.Contains(t, updates, "set|/a/b/d")
+
+	updates = make(map[string]bool)
+	kapi.FakeWatcher.Enqueue(&etcdclient.Response{
+		Node: &etcdclient.Node{Key: "/a/b/e", Value: "e"},
+		Action: "set"})
+	tu.WaitFor(t, "Waiting for update - set new", 500*time.Millisecond,
+		func(bool) (bool, error) { return updates["set|/a/b/e"], nil })
+
+	kapi.FakeWatcher.Enqueue(&etcdclient.Response{
+		Node: &etcdclient.Node{Key: "/a/b/c", Value: "c1"},
+		Action: "set"})
+	tu.WaitFor(t, "Waiting for update - set existing", 500*time.Millisecond,
+		func(bool) (bool, error) { return updates["set|/a/b/c"], nil })
+
+	kapi.FakeWatcher.Enqueue(&etcdclient.Response{
+		Node: &etcdclient.Node{Key: "/a/b/d", Value: ""},
+		Action: "delete"})
+	tu.WaitFor(t, "Waiting for update - delete", 500*time.Millisecond,
+		func(bool) (bool, error) { return updates["delete|/a/b/d"], nil })
+
+	close(ch)
+}
+
+func TestCfEtcdWatcherCancel(t *testing.T) {
+	log := logrus.New()
+	log.Level = logrus.DebugLevel
+
+	handler := func(action *string, node *etcdclient.Node) error { return nil }
+	kapi := etcd_f.NewFakeEtcdKeysApi(log)
+
+	watcher := NewEtcdWatcher(kapi, "/a", handler, log)
+	ch := make(chan struct{})
+	runEnded := false
+	go func() {
+		watcher.Run(ch)
+		runEnded = true
+	}()
+	tu.WaitFor(t, "Waiting to sync", 500*time.Millisecond,
+		func(bool) (bool, error) { return watcher.Synced(), nil })
+	close(ch)
+	tu.WaitFor(t, "Waiting for Run() to end", 1000*time.Millisecond,
+		func(bool) (bool, error) { return runEnded, nil })
+}

--- a/pkg/cf_etcd_fakes/etcd.go
+++ b/pkg/cf_etcd_fakes/etcd.go
@@ -1,0 +1,135 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Fake etcd client structures for unit-tests
+
+package cf_etcd_fakes
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	etcdclient "github.com/coreos/etcd/client"
+	"github.com/Sirupsen/logrus"
+	"golang.org/x/net/context"
+)
+
+
+type FakeEtcdKeysApi struct {
+	data         map[string]string
+	log          *logrus.Logger
+	FakeWatcher  *FakeEtcdWatcher
+}
+
+type FakeEtcdWatcher struct {
+	blockFor    time.Duration
+	queue       chan *etcdclient.Response
+}
+
+func NewFakeEtcdKeysApi(log *logrus.Logger) *FakeEtcdKeysApi {
+	return &FakeEtcdKeysApi{
+		data: make(map[string]string),
+		log: log,
+		FakeWatcher: NewFakeEtcdWatcher()}
+}
+
+func NewFakeEtcdWatcher() *FakeEtcdWatcher {
+	return &FakeEtcdWatcher{blockFor: 5 * time.Second,
+		queue: make(chan *etcdclient.Response, 100)}
+}
+
+func (k *FakeEtcdKeysApi) Get(ctx context.Context, key string, opts *etcdclient.GetOptions) (*etcdclient.Response, error) {
+	v, ok := k.data[key]
+	if ok {
+		parent := &etcdclient.Node{Key: key, Value: v}
+		if opts != nil && opts.Recursive {
+			for ik, iv := range k.data {
+				if strings.HasPrefix(ik, key + "/") {
+					parent.Nodes = append(parent.Nodes, &etcdclient.Node{Key: ik, Value: iv})
+				}
+			}
+		}
+		return &etcdclient.Response{Node: parent}, nil
+	}
+	return nil, etcdclient.Error{Code: etcdclient.ErrorCodeKeyNotFound}
+}
+
+func (k *FakeEtcdKeysApi) Set(ctx context.Context, key, value string, opts *etcdclient.SetOptions) (*etcdclient.Response, error) {
+	k.log.Debug(fmt.Sprintf("Setting %s = %s", key, value))
+	k.data[key] = value
+	return nil, nil
+}
+
+func (k *FakeEtcdKeysApi) Delete(ctx context.Context, key string, opts *etcdclient.DeleteOptions) (*etcdclient.Response, error) {
+	if opts != nil && opts.Recursive {
+		for ik, _ := range k.data {
+			if strings.HasPrefix(ik, key) {
+				delete(k.data, ik)
+			}
+		}
+	} else {
+		delete(k.data, key)
+	}
+	return nil, nil
+}
+
+func (k *FakeEtcdKeysApi) Create(ctx context.Context, key, value string) (*etcdclient.Response, error) {
+	return k.Set(ctx, key, value, nil)
+}
+
+func (k *FakeEtcdKeysApi) CreateInOrder(ctx context.Context, dir, value string, opts *etcdclient.CreateInOrderOptions) (*etcdclient.Response, error) {
+	return nil, fmt.Errorf("Not Implemented")
+}
+
+func (k *FakeEtcdKeysApi) Update(ctx context.Context, key, value string) (*etcdclient.Response, error) {
+	return k.Set(ctx, key, value, nil)
+}
+
+func (k *FakeEtcdKeysApi) Watcher(key string, opts *etcdclient.WatcherOptions) etcdclient.Watcher {
+	return k.FakeWatcher
+}
+
+func (k *FakeEtcdKeysApi) Equals(key string, expectedValue interface{}) bool {
+	str, ok := expectedValue.(string)
+	if !ok {
+		bytes, err := json.Marshal(expectedValue)
+		if err != nil {
+			panic(err.Error())
+		}
+		str = string(bytes)
+	}
+	found, ok := k.data[key]
+	return ok && found == str
+}
+
+func (w *FakeEtcdWatcher) Next(ctx context.Context) (*etcdclient.Response, error) {
+	timer := time.NewTimer(w.blockFor)
+	for {
+		select {
+		case <-timer.C:
+			return nil, nil
+		case resp := <-w.queue:
+			return resp, nil
+		case <-ctx.Done():
+			return nil, context.Canceled
+		}
+	}
+	return nil, nil
+}
+
+func (w *FakeEtcdWatcher) Enqueue(resp *etcdclient.Response) {
+	w.queue <- resp
+}

--- a/pkg/hostagent/cf_apps.go
+++ b/pkg/hostagent/cf_apps.go
@@ -1,0 +1,329 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"reflect"
+
+	etcdclient "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func (env *CfEnvironment) updateContainerMetadata(metadataKey *string) {
+	ctId := extractContainerIdFromMetadataKey(metadataKey)
+	if ctId == "" {
+		return
+	}
+
+	env.agent.indexMutex.Lock()
+	md, ok := env.agent.epMetadata[*metadataKey]
+	env.agent.indexMutex.Unlock()
+
+	kapi := env.etcdKeysApi
+	key := etcd.CONTROLLER_KEY_BASE + "/containers/" + ctId
+	var err error
+	if !ok {
+		_, err = kapi.Delete(context.Background(), key, &etcdclient.DeleteOptions{Recursive: true})
+		if err != nil {
+			keyerr, ok := err.(etcdclient.Error)
+			if ok && keyerr.Code == etcdclient.ErrorCodeKeyNotFound {
+				env.log.Info(fmt.Sprintf("Etcd subtree %s doesn't exist yet", key))
+				err = nil
+			}
+		}
+	} else {
+		if md[ctId] != nil && md[ctId].Ifaces != nil {
+			var md_json []byte
+			md_json, err = json.Marshal(md[ctId].Ifaces)
+			if err == nil {
+				_, err = kapi.Set(context.Background(), key + "/metadata", string(md_json), nil)
+			}
+		}
+	}
+	if err != nil {
+		env.log.Error("Failed to update container metadata in etcd: ", err)
+	}
+}
+
+func (env *CfEnvironment) cfAppContainerChanged(ctId *string, ep *etcd.EpInfo) {
+	if ep == nil {
+		return
+	}
+	metaKey := "_cf_/" + *ctId
+
+	epGroup := &md.OpflexGroup{PolicySpace: ep.EpgTenant, Name: ep.Epg}
+	secGroup := make([]md.OpflexGroup, len(ep.SecurityGroups))
+	for i, s := range ep.SecurityGroups {
+		secGroup[i].PolicySpace = s.Tenant
+		secGroup[i].Name = s.Group
+	}
+
+	epAttributes := make(map[string]string)
+	if ep.AppName != "" {
+		if ep.InstanceIndex == etcd.INST_IDX_TASK {
+			if ep.TaskName != "" {
+				epAttributes["vm-name"] = ep.AppName + " (task " + ep.TaskName + ")"
+			} else {
+				epAttributes["vm-name"] = ep.AppName + " (task)"
+			}
+		} else if ep.InstanceIndex < 0 {
+			epAttributes["vm-name"] = ep.AppName + " (staging)"
+		} else {
+			epAttributes["vm-name"] = fmt.Sprintf("%s (%d)", ep.AppName, ep.InstanceIndex)
+		}
+	} else {
+		epAttributes["vm-name"] = *ctId
+	}
+	epAttributes["app-id"] = ep.AppId
+	epAttributes["space-id"] = ep.SpaceId
+	epAttributes["org-id"] = ep.OrgId
+	epAttributes["container-id"] = *ctId
+
+	// Update iptables rules and container ports-set
+	cportset := make(map[uint32]struct{})
+	env.indexLock.Lock()
+	for p, _ := range env.cfNetContainerPorts {
+		cportset[p] = struct{}{}
+	}
+	// pre-routing DNAT rules
+	env.updatePreNatRule(ctId, ep, ep.PortMapping)
+	// post-routing SNAT rules
+	for _, pmap := range ep.PortMapping {
+		cport := fmt.Sprintf("%d", pmap.ContainerPort)
+		err := env.iptbl.AppendUnique("nat", NAT_POST_CHAIN, "-o", env.cfconfig.CfNetOvsPort, "-p", "tcp",
+									 "-m", "tcp", "--dport", cport, "-j", "SNAT", "--to-source",
+									 env.cfconfig.CfNetIntfAddress)
+		if err != nil {
+			env.log.Warning("Failed to add post-routing iptables rule: ", err)
+		}
+		cportset[pmap.ContainerPort] = struct{}{}
+	}
+	cfnet_update := !reflect.DeepEqual(env.cfNetContainerPorts, cportset)
+	if cfnet_update {
+		env.cfNetContainerPorts = cportset
+	}
+	env.indexLock.Unlock()
+
+	env.agent.indexMutex.Lock()
+	env.agent.epChanged(ctId, &metaKey, epGroup, secGroup, epAttributes, nil)
+	if cfnet_update {
+		env.updateLegacyCfNetService(cportset)
+	}
+	env.agent.indexMutex.Unlock()
+}
+
+// must be called with env.indexLock
+func (env *CfEnvironment) updatePreNatRule(ctId *string, ep *etcd.EpInfo, portmap []etcd.PortMap) {
+	ctIp := net.ParseIP(ep.IpAddress)
+	if ctIp == nil || (env.cfNetv4 && ctIp.To4() == nil) {
+		return
+	}
+	old_pm := env.ctPortMap[*ctId]
+	new_pm := make(map[uint32]uint32)
+	for _, ch := range portmap {
+		err := env.iptbl.AppendUnique("nat", NAT_PRE_CHAIN, "-d", env.cfconfig.CellAddress, "-p", "tcp",
+									 "--dport", fmt.Sprintf("%d", ch.HostPort),
+									 "-j", "DNAT", "--to-destination",
+									 ep.IpAddress + ":" + fmt.Sprintf("%d", ch.ContainerPort))
+		if err != nil {
+			env.log.Warning(fmt.Sprintf("Failed to add pre-routing iptables rule for %d: %v", *ctId, err))
+		}
+		new_pm[ch.HostPort] = ch.ContainerPort
+		delete(old_pm, ch.HostPort)
+	}
+	for hp, cp := range old_pm {
+		args := []string{"-d", env.cfconfig.CellAddress, "-p", "tcp", "--dport",
+						 fmt.Sprintf("%d", hp), "-j", "DNAT", "--to-destination",
+						 ep.IpAddress + ":" + fmt.Sprintf("%d", cp)}
+		exist, _ := env.iptbl.Exists("nat", NAT_PRE_CHAIN, args...)
+		if !exist {
+			continue
+		}
+		err := env.iptbl.Delete("nat", NAT_PRE_CHAIN, args...)
+		if err != nil {
+			env.log.Warning(fmt.Sprintf("Failed to delete pre-routing iptables rule for %d: %v", *ctId, err))
+		}
+	}
+	env.ctPortMap[*ctId] = new_pm
+}
+
+func (env *CfEnvironment) cfAppContainerDeleted(ctId *string, ep *etcd.EpInfo) {
+	env.agent.indexMutex.Lock()
+	env.agent.epDeleted(ctId)
+	env.agent.indexMutex.Unlock()
+
+	if ep == nil {
+		return
+	}
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	env.updatePreNatRule(ctId, ep, nil)
+	delete(env.ctPortMap, *ctId)
+}
+
+func (env *CfEnvironment) updateLegacyCfNetService(portmap map[uint32]struct{}) error {
+	// should be called with agent.indexMutex held
+	uuid := "cf-net-" + env.cfconfig.CellID
+	new_svc := opflexService{Uuid: uuid,
+							DomainPolicySpace: env.agent.config.AciVrfTenant,
+							DomainName: env.agent.config.AciVrf,
+							ServiceMac: env.cfNetLink.Attrs().HardwareAddr.String(),
+							InterfaceName: env.cfconfig.CfNetOvsPort}
+	for p, _ := range portmap {
+		svc_map := opflexServiceMapping{ServiceIp: env.cfconfig.CfNetIntfAddress,
+									   ServicePort: uint16(p),
+									   NextHopIps: make([]string, 0)}
+		new_svc.ServiceMappings = append(new_svc.ServiceMappings, svc_map)
+	}
+	exist, ok := env.agent.opflexServices[uuid]
+	if !ok || !reflect.DeepEqual(*exist, new_svc) {
+		env.log.Debug("Updating CF legacy-networking service ", uuid)
+		env.agent.opflexServices[uuid] = &new_svc
+		env.agent.scheduleSyncServices()
+	}
+	return nil
+}
+
+func (env *CfEnvironment) cfAppDeleted(appId *string, app *etcd.AppInfo) {
+	env.agent.indexMutex.Lock()
+	defer env.agent.indexMutex.Unlock()
+	uuid := *appId
+	_, vip_ok := env.agent.opflexServices[uuid]
+	if vip_ok {
+		env.log.Debug("Removing service CF app vip/ext-ip ", uuid)
+		delete(env.agent.opflexServices, uuid)
+	}
+	uuid += "-external"
+	_, ext_ip_ok := env.agent.opflexServices[uuid]
+	if ext_ip_ok {
+		env.log.Debug("Removing service CF app vip/ext-ip ", uuid)
+		delete(env.agent.opflexServices, uuid)
+	}
+	if vip_ok || ext_ip_ok {
+		env.agent.scheduleSyncServices()
+	}
+}
+
+// 0 -> ipv4, 1 -> ipv6, anything else -> invalid IP
+func getIpType(ip_str string) int {
+	ip := net.ParseIP(ip_str)
+	if ip == nil {
+		return -1
+	}
+	if ip.To4() != nil {
+		return 0
+	}
+	if ip.To16() != nil {
+		return 1
+	}
+	return -2
+}
+
+func (env *CfEnvironment) cfAppIdChanged(appId *string) {
+	env.indexLock.Lock()
+	appInfo := env.appIdx[*appId]
+	env.indexLock.Unlock()
+	if appInfo != nil {
+		env.cfAppChanged(appId, appInfo)
+	}
+}
+
+func (env *CfEnvironment) cfAppChanged(appId *string, app *etcd.AppInfo) {
+	env.updateCfAppServiceEp(appId, app, false)
+	env.updateCfAppServiceEp(appId, app, true)
+}
+
+func (env *CfEnvironment) updateCfAppServiceEp(appId *string, app *etcd.AppInfo, external bool) {
+	agent := env.agent
+	uuid := *appId
+	if external {
+		uuid += "-external"
+	}
+	appas := opflexService{
+		Uuid:              uuid,
+		DomainPolicySpace: agent.config.AciVrfTenant,
+		DomainName:        agent.config.AciVrf,
+		ServiceMode:       "loadbalancer",
+		ServiceMappings:   make([]opflexServiceMapping, 0),
+	}
+	if external && agent.config.UplinkIface != "" && agent.serviceEp.Mac != "" &&
+		(agent.serviceEp.Ipv4 != nil || agent.serviceEp.Ipv6 != nil) {
+
+		appas.InterfaceName = agent.config.UplinkIface
+		appas.InterfaceVlan = uint16(agent.config.ServiceVlan)
+		appas.ServiceMac = agent.serviceEp.Mac
+		if agent.serviceEp.Ipv4 != nil {
+			appas.InterfaceIp = agent.serviceEp.Ipv4.String()
+		} else {
+			appas.InterfaceIp = agent.serviceEp.Ipv6.String()    // TODO dual stack?
+		}
+	}
+	ips := app.VirtualIp
+	if external {
+		ips = app.ExternalIp
+	}
+	localContainerIps := make([]string, 0)
+	agent.indexMutex.Lock()
+	defer agent.indexMutex.Unlock()
+	if external {
+		for _, c := range env.epIdx {
+			if c != nil && c.AppId == *appId {
+				localContainerIps = append(localContainerIps, c.IpAddress)
+			}
+		}
+	}
+	for _, vip := range ips {
+		ipt := getIpType(vip)
+		if ipt != 0 && ipt != 1 {
+			continue
+		}
+		sm := opflexServiceMapping{
+			ServiceIp:  vip,
+			NextHopIps: make([]string, 0),
+			Conntrack:  true,
+		}
+		containers := app.ContainerIps
+		if external {
+			containers = localContainerIps
+		}
+		for _, cip := range containers {
+			if ipt != getIpType(cip) {
+				continue
+			}
+			sm.NextHopIps = append(sm.NextHopIps, cip)
+		}
+		if len(sm.NextHopIps) > 0 {
+			appas.ServiceMappings = append(appas.ServiceMappings, sm)
+		}
+	}
+	valid := len(appas.ServiceMappings) > 0
+
+	exist, ok := env.agent.opflexServices[uuid]
+	if valid && (!ok || !reflect.DeepEqual(*exist, appas)) {
+		env.log.Debug("Updating CF app vip/ext-ip service ", uuid)
+		env.agent.opflexServices[uuid] = &appas
+		env.agent.scheduleSyncServices()
+	} else if !valid && ok {
+		env.log.Debug("Removing CF app vip/ext-ip service ", uuid)
+		delete(env.agent.opflexServices, uuid)
+		env.agent.scheduleSyncServices()
+	}
+}

--- a/pkg/hostagent/cf_apps_test.go
+++ b/pkg/hostagent/cf_apps_test.go
@@ -1,0 +1,195 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func TestCfContainerUpdate(t *testing.T) {
+	env := testCfEnvironment(t)
+	exists := false
+
+	id := "one"
+	ep := getTestEpInfo()
+	env.epIdx[id] = ep
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata()
+	expected_ep := getExpectedOpflexEp()
+	expected_svc := getExpectedOpflexServiceForLegacyNet(env)
+
+	// create
+	env.cfAppContainerChanged(&id, ep)
+	// check opflex-EP
+	assert.Equal(t, expected_ep, env.agent.opflexEps["one"][0])
+	// check iptables rules for legacy networking
+	exists, _ = env.iptbl.Exists("nat", NAT_PRE_CHAIN,
+		"-d 10.10.0.5 -p tcp --dport 60010 -j DNAT --to-destination 10.255.0.45:8080")
+	assert.True(t, exists)
+	exists, _ = env.iptbl.Exists("nat", NAT_PRE_CHAIN,
+		"-d 10.10.0.5 -p tcp --dport 60011 -j DNAT --to-destination 10.255.0.45:2222")
+	assert.True(t, exists)
+	exists, _ = env.iptbl.Exists("nat", NAT_POST_CHAIN,
+		"-o cf-net-legacy -p tcp -m tcp --dport 8080 -j SNAT --to-source 169.254.169.254")
+	assert.True(t, exists)
+	exists, _ = env.iptbl.Exists("nat", NAT_POST_CHAIN,
+		"-o cf-net-legacy -p tcp -m tcp --dport 2222 -j SNAT --to-source 169.254.169.254")
+	assert.True(t, exists)
+	// check opflex service for legacy networking
+	checkOpflexService(t, expected_svc, env.agent.opflexServices["cf-net-cell1"])
+
+	// update
+	ep.Epg = "epg2"
+	ep.SecurityGroups = append(ep.SecurityGroups, etcd.GroupInfo{Tenant: "e", Group: "sg3"})
+	ep.PortMapping = []etcd.PortMap{
+		etcd.PortMap{ContainerPort: 8080, HostPort: 60010},
+		etcd.PortMap{ContainerPort: 9443, HostPort: 60012}}
+	expected_ep.EndpointGroup = "epg2"
+	expected_ep.SecurityGroup = append(expected_ep.SecurityGroup,
+		md.OpflexGroup{PolicySpace: "e", Name: "sg3"})
+	expected_svc.ServiceMappings = append(expected_svc.ServiceMappings,
+		opflexServiceMapping{
+			ServiceIp: "169.254.169.254",
+			ServicePort: 9443,
+			NextHopIps: make([]string, 0)})
+	env.cfAppContainerChanged(&id, ep)
+	assert.Equal(t, expected_ep, env.agent.opflexEps["one"][0])
+	exists, _ = env.iptbl.Exists("nat", NAT_PRE_CHAIN,
+		"-d 10.10.0.5 -p tcp --dport 60010 -j DNAT --to-destination 10.255.0.45:8080")
+	assert.True(t, exists)
+	exists, _ = env.iptbl.Exists("nat", NAT_PRE_CHAIN,
+		"-d 10.10.0.5 -p tcp --dport 60012 -j DNAT --to-destination 10.255.0.45:9443")
+	assert.True(t, exists)
+	exists, _ = env.iptbl.Exists("nat", NAT_POST_CHAIN,
+		"-o cf-net-legacy -p tcp -m tcp --dport 8080 -j SNAT --to-source 169.254.169.254")
+	assert.True(t, exists)
+	exists, _ = env.iptbl.Exists("nat", NAT_POST_CHAIN,
+		"-o cf-net-legacy -p tcp -m tcp --dport 9443 -j SNAT --to-source 169.254.169.254")
+	assert.True(t, exists)
+	exists, _ = env.iptbl.Exists("nat", NAT_PRE_CHAIN,
+		"-d 10.10.0.5 -p tcp --dport 60011 -j DNAT --to-destination 10.255.0.45:2222")
+	assert.False(t, exists)
+	checkOpflexService(t, expected_svc, env.agent.opflexServices["cf-net-cell1"])
+
+	// delete
+	delete(env.epIdx, id)
+	delete(env.agent.epMetadata, "_cf_/one")
+	env.cfAppContainerDeleted(&id, ep)
+	_, ok := env.agent.opflexEps["one"]
+	assert.False(t, ok)
+	exists, _ = env.iptbl.Exists("nat", NAT_PRE_CHAIN,
+		"-d 10.10.0.5 -p tcp --dport 60010 -j DNAT --to-destination 10.255.0.45:8080")
+	assert.False(t, exists)
+	exists, _ = env.iptbl.Exists("nat", NAT_PRE_CHAIN,
+		"-d 10.10.0.5 -p tcp --dport 60012 -j DNAT --to-destination 10.255.0.45:9443")
+	assert.False(t, exists)
+	checkOpflexService(t, expected_svc, env.agent.opflexServices["cf-net-cell1"])
+}
+
+func TestCfStagingContainerUpdate(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	id := "one"
+	ep := getTestEpInfo()
+	ep.InstanceIndex = etcd.INST_IDX_STAGING
+	env.epIdx[id] = ep
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata()
+	expected_ep := getExpectedOpflexEp()
+	expected_ep.Attributes["vm-name"] = "a1-name (staging)"
+
+	// create
+	env.cfAppContainerChanged(&id, ep)
+	assert.Equal(t, expected_ep, env.agent.opflexEps["one"][0])
+
+	// delete
+	delete(env.epIdx, id)
+	delete(env.agent.epMetadata, "_cf_/one")
+	env.cfAppContainerDeleted(&id, ep)
+	_, ok := env.agent.opflexEps["one"]
+	assert.False(t, ok)
+}
+
+func TestCfTaskContainerUpdate(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	id := "one"
+	ep := getTestEpInfo()
+	ep.InstanceIndex = etcd.INST_IDX_TASK
+	ep.TaskName = "errand"
+	env.epIdx[id] = ep
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata()
+	expected_ep := getExpectedOpflexEp()
+	expected_ep.Attributes["vm-name"] = "a1-name (task errand)"
+
+	// create
+	env.cfAppContainerChanged(&id, ep)
+	assert.Equal(t, expected_ep, env.agent.opflexEps["one"][0])
+
+	// delete
+	delete(env.epIdx, id)
+	delete(env.agent.epMetadata, "_cf_/one")
+	env.cfAppContainerDeleted(&id, ep)
+	_, ok := env.agent.opflexEps["one"]
+	assert.False(t, ok)
+}
+
+func TestCfAppUpdate(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	id := "a1"
+	ep := getTestEpInfo()
+	app := getTestAppInfo()
+	env.epIdx["one"] = ep
+	env.appIdx[id] = app
+
+	exp_vip_svc := getExpectedOpflexServiceForApp(id, false, app.VirtualIp, app.ContainerIps)
+	exp_ext_svc := getExpectedOpflexServiceForApp(id, true, app.ExternalIp, []string{"10.255.0.45"})
+
+	// create
+	env.cfAppChanged(&id, app)
+	checkOpflexService(t, exp_vip_svc, env.agent.opflexServices[id])
+	checkOpflexService(t, exp_ext_svc, env.agent.opflexServices[id + "-external"])
+
+	// remove vip & ext-ip
+	app.VirtualIp = nil
+	app.ExternalIp = nil
+	env.cfAppIdChanged(&id)
+	_, vip_ok := env.agent.opflexServices[id]
+	_, ext_ok := env.agent.opflexServices[id + "-external"]
+	assert.False(t, vip_ok)
+	assert.False(t, ext_ok)
+
+	// update vip & ext-ip
+	app.ContainerIps = []string{"10.255.0.10", "10.255.0.11", "10.255.0.46"}
+	app.VirtualIp = []string{"10.254.0.6"}
+	app.ExternalIp = []string{"150.150.0.3"}
+	ep.IpAddress = "10.255.0.46"
+	exp_vip_svc = getExpectedOpflexServiceForApp(id, false, app.VirtualIp, app.ContainerIps)
+	exp_ext_svc = getExpectedOpflexServiceForApp(id, true, app.ExternalIp, []string{"10.255.0.46"})
+	env.cfAppChanged(&id, app)
+	checkOpflexService(t, exp_vip_svc, env.agent.opflexServices[id])
+	checkOpflexService(t, exp_ext_svc, env.agent.opflexServices[id + "-external"])
+
+	// delete app
+	env.cfAppDeleted(&id, app)
+	_, vip_ok = env.agent.opflexServices[id]
+	_, ext_ok = env.agent.opflexServices[id + "-external"]
+	assert.False(t, vip_ok)
+	assert.False(t, ext_ok)
+}

--- a/pkg/hostagent/cf_common_test.go
+++ b/pkg/hostagent/cf_common_test.go
@@ -1,0 +1,269 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"encoding/json"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/net/context"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	etcd_f "github.com/noironetworks/aci-containers/pkg/cf_etcd_fakes"
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func testCfEnvironment(t *testing.T) *CfEnvironment {
+	env := CfEnvironment{cfNetContainerPorts: make(map[uint32]struct{}),
+		indexLock: &sync.Mutex{}}
+	env.epIdx = make(map[string]*etcd.EpInfo)
+	env.appIdx = make(map[string]*etcd.AppInfo)
+	env.ctPortMap = make(map[string]map[uint32]uint32)
+	log := logrus.New()
+	log.Level = logrus.DebugLevel
+	log.Formatter = &logrus.TextFormatter{
+		DisableColors: true,
+	}
+	node := "cell1"
+	agent := NewHostAgent(
+		&HostAgentConfig{
+			HostAgentNodeConfig: HostAgentNodeConfig{UplinkIface: "eth1"},
+			AciVrfTenant: "common",
+			AciVrf: "cf",
+			ServiceVlan: 4001},
+		&env,
+		log)
+	agent.serviceEp.Mac = "de:ad:be:ef:00:00"
+	agent.serviceEp.Ipv4 = net.ParseIP("10.150.0.2")
+	env.agent = agent
+	env.log = log
+
+	env.cfconfig = &CfConfig{CellID: node, CellAddress: "10.10.0.5",
+		CfNetOvsPort: "cf-net-legacy", CfNetIntfAddress: "169.254.169.254"}
+	env.iptbl = &fakeIpTables{rules: make(map[string]struct{})}
+	env.cfNetLink = &fakeNetlinkLink{fakeMac: "cc:ff:00:55:ee:dd"}
+	env.etcdKeysApi = etcd_f.NewFakeEtcdKeysApi(log)
+	return &env
+}
+
+func (e *CfEnvironment) fakeEtcdKeysApi() *etcd_f.FakeEtcdKeysApi {
+	return e.etcdKeysApi.(*etcd_f.FakeEtcdKeysApi)
+}
+
+func (e *CfEnvironment) GetContainerMetadata(ctId string) map[string]*md.ContainerMetadata {
+	key := etcd.CONTROLLER_KEY_BASE + "/containers/" + ctId + "/metadata"
+	resp, err := e.etcdKeysApi.Get(context.Background(), key, nil)
+	if err == nil {
+		meta := md.ContainerMetadata{
+			Id: md.ContainerId{Namespace: "_cf_", Pod: ctId, ContId: ctId}}
+		er := json.Unmarshal([]byte(resp.Node.Value), &meta.Ifaces)
+		if er != nil {
+			panic(er.Error())
+		}
+		res := make(map[string]*md.ContainerMetadata)
+		res[ctId] = &meta
+		return res
+	}
+	return nil
+}
+
+type fakeIpTables struct{
+	rules map[string]struct{}
+}
+
+func (ipt *fakeIpTables) key(table, chain string, rulespec ...string) string {
+	return table + "|" + chain + "|" + strings.Join(rulespec, " ")
+}
+
+func (ipt *fakeIpTables) Exists(table, chain string, rulespec ...string) (bool, error) {
+	_, ok := ipt.rules[ipt.key(table, chain, rulespec...)]
+	return ok, nil
+}
+
+func (ipt *fakeIpTables) AppendUnique(table, chain string, rulespec ...string) error {
+	k := ipt.key(table, chain, rulespec...)
+	_, ok := ipt.rules[k]
+	if !ok {
+		ipt.rules[k] = struct{}{}
+	}
+	return nil
+}
+
+func (ipt *fakeIpTables) Delete(table, chain string, rulespec ...string) error {
+	delete(ipt.rules, ipt.key(table, chain, rulespec...))
+	return nil
+}
+
+func (ipt *fakeIpTables) ClearChain(table, chain string) error {
+	for k, _ := range ipt.rules {
+		if strings.HasPrefix(k, table + "|" + chain + "|") {
+			delete(ipt.rules, k)
+		}
+	}
+	return nil
+}
+
+type fakeNetlinkLink struct {
+	fakeMac string
+}
+
+func (l *fakeNetlinkLink) Attrs() *netlink.LinkAttrs {
+	a := netlink.NewLinkAttrs()
+	a.HardwareAddr, _ = net.ParseMAC(l.fakeMac)
+	return &a
+}
+
+func (l *fakeNetlinkLink) Type() string {
+	return "fake"
+}
+
+func getTestEpInfo() *etcd.EpInfo {
+	ep := &etcd.EpInfo{
+		AppId: "a1",
+		AppName: "a1-name",
+		SpaceId: "sp1",
+		OrgId: "org1",
+		IpAddress: "10.255.0.45",
+		InstanceIndex: 1,
+		PortMapping: []etcd.PortMap{
+			etcd.PortMap{ContainerPort: 8080, HostPort: 60010},
+			etcd.PortMap{ContainerPort: 2222, HostPort: 60011}},
+		EpgTenant: "cf",
+		Epg: "epg1",
+		SecurityGroups: []etcd.GroupInfo{
+			etcd.GroupInfo{Tenant: "c", Group: "sg1"},
+			etcd.GroupInfo{Tenant: "d", Group: "sg2"}},
+	}
+	return ep
+}
+
+func getTestEpMetadata() map[string]*md.ContainerMetadata {
+	meta := make(map[string]*md.ContainerMetadata)
+	meta["one"] = &md.ContainerMetadata{
+		Id: md.ContainerId{Namespace: "_cf_", Pod: "one", ContId: "one"},
+		Ifaces: []*md.ContainerIfaceMd{
+			&md.ContainerIfaceMd{
+				HostVethName: "veth1",
+				Mac: "1:2:3:4:5:6",
+				IPs: []md.ContainerIfaceIP{
+					md.ContainerIfaceIP{
+						Address: net.IPNet{
+							IP: net.ParseIP("10.255.0.45")}}}}}}
+	return meta
+}
+
+func getExpectedOpflexEp() *opflexEndpoint {
+	expected_ep := &opflexEndpoint{
+		Uuid:              "one_one_veth1",
+		MacAddress:        "1:2:3:4:5:6",
+		IpAddress:         []string{"10.255.0.45"},
+		AccessIface:       "veth1",
+		AccessUplinkIface: "pa-veth1",
+		IfaceName:         "pi-veth1",
+		SecurityGroup:     []md.OpflexGroup{
+			md.OpflexGroup{PolicySpace: "c", Name: "sg1"},
+			md.OpflexGroup{PolicySpace: "d", Name: "sg2"}},
+		EgPolicySpace:     "cf",
+		EndpointGroup:     "epg1",
+	}
+	attrs := make(map[string]string)
+	attrs["app-id"] = "a1"
+	attrs["container-id"] = "one"
+	attrs["interface-name"] = "veth1"
+	attrs["org-id"] = "org1"
+	attrs["space-id"] = "sp1"
+	attrs["vm-name"] = "a1-name (1)"
+	expected_ep.Attributes = attrs
+	return expected_ep
+}
+
+func getExpectedOpflexServiceForLegacyNet(env *CfEnvironment) *opflexService {
+	expected_svc := &opflexService{
+		Uuid: "cf-net-cell1",
+		DomainPolicySpace: "common",
+		DomainName: "cf",
+		ServiceMac: env.cfNetLink.(*fakeNetlinkLink).fakeMac,
+		InterfaceName: "cf-net-legacy"}
+	svc_map1 := opflexServiceMapping{
+		ServiceIp: "169.254.169.254",
+		ServicePort: 8080,
+		NextHopIps: make([]string, 0)}
+	svc_map2 := opflexServiceMapping{
+		ServiceIp: "169.254.169.254",
+		ServicePort: 2222,
+		NextHopIps: make([]string, 0)}
+	expected_svc.ServiceMappings = []opflexServiceMapping{svc_map1, svc_map2}
+	return expected_svc
+}
+
+func checkOpflexService(t *testing.T, exp, actual *opflexService) {
+	exp_map := exp.ServiceMappings
+	exp.ServiceMappings = nil
+	actual_map := actual.ServiceMappings
+	actual.ServiceMappings = nil
+
+	assert.Equal(t, exp, actual)
+	assert.Equal(t, len(exp_map), len(actual_map))
+	for _, em := range exp_map {
+		assert.Contains(t, actual_map, em)
+	}
+
+	exp.ServiceMappings = exp_map
+	actual.ServiceMappings = actual_map
+}
+
+func getTestAppInfo() *etcd.AppInfo {
+	app := &etcd.AppInfo{
+		ContainerIps: []string{"10.255.0.10", "10.255.0.45"},
+		VirtualIp: []string{"10.254.0.5"},
+		ExternalIp: []string{"150.150.0.3"},
+	}
+	return app
+}
+
+func getExpectedOpflexServiceForApp(appId string, external bool, vips, ips []string) *opflexService {
+	uuid := appId
+	if external {
+		uuid += "-external"
+	}
+	expected_svc := &opflexService{
+		Uuid: uuid,
+		DomainPolicySpace: "common",
+		DomainName: "cf",
+		ServiceMode: "loadbalancer",
+		ServiceMappings: make([]opflexServiceMapping, 0),
+	}
+	if external {
+		expected_svc.InterfaceName = "eth1"
+		expected_svc.InterfaceVlan = 4001
+		expected_svc.ServiceMac = "de:ad:be:ef:00:00"
+		expected_svc.InterfaceIp = "10.150.0.2"
+	}
+	for _, vip := range vips {
+		sm := opflexServiceMapping{
+			ServiceIp:  vip,
+			NextHopIps: ips,
+			Conntrack:  true,
+		}
+		expected_svc.ServiceMappings = append(expected_svc.ServiceMappings, sm)
+	}
+	return expected_svc
+}

--- a/pkg/hostagent/cf_environment.go
+++ b/pkg/hostagent/cf_environment.go
@@ -15,32 +15,301 @@
 package hostagent
 
 import (
-	"github.com/Sirupsen/logrus"
+	"encoding/json"
+	"fmt"
+	"errors"
+	"io/ioutil"
+	"net"
+	"strings"
+	"sync"
+	"syscall"
 
+	etcdclient "github.com/coreos/etcd/client"
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/Sirupsen/logrus"
+	"github.com/vishvananda/netlink"
+	"k8s.io/client-go/tools/cache"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	"github.com/noironetworks/aci-containers/pkg/ipam"
 	md "github.com/noironetworks/aci-containers/pkg/metadata"
 )
 
+const (
+	NAT_PRE_CHAIN = "aci-nat-pre"
+	NAT_POST_CHAIN = "aci-nat-post"
+)
+
+// wrapper over thirdparty implementation that can be overridden for unit-tests
+type IPTables interface {
+	Exists(table, chain string, rulespec ...string) (bool, error)
+	AppendUnique(table, chain string, rulespec ...string) error
+	Delete(table, chain string, rulespec ...string) error
+	ClearChain(table, chain string) error
+}
+
 type CfEnvironment struct {
+	agent        *HostAgent
+	cfconfig     *CfConfig
+	etcdKeysApi  etcdclient.KeysAPI
+
+	indexLock    sync.Locker
+	epIdx        map[string]*etcd.EpInfo
+	appIdx       map[string]*etcd.AppInfo
+
+	iptbl        IPTables
+	ctPortMap    map[string]map[uint32]uint32
+	cfNetv4      bool
+	cfNetLink    netlink.Link
+	cfNetContainerPorts    map[uint32]struct{}
+
+	log          *logrus.Logger
+}
+
+type CfConfig struct {
+	CellID                             string                `json:"cell_id,omitempty"`
+	CellAddress                        string                `json:"cell_address,omitempty"`
+
+	EtcdUrl                            string                `json:"etcd_url,omitempty"`
+	EtcdCACertFile                     string                `json:"etcd_ca_cert_file"`
+	EtcdClientCertFile                 string                `json:"etcd_client_cert_file"`
+	EtcdClientKeyFile                  string                `json:"etcd_client_key_file"`
+
+	CfNetOvsPort                       string                `json:"cf_net_ovs_port"`
+	CfNetIntfAddress                   string                `json:"cf_net_interface_address"`
 }
 
 func NewCfEnvironment(config *HostAgentConfig, log *logrus.Logger) (*CfEnvironment, error) {
-	return &CfEnvironment{}, nil
+	if config.CfConfig == "" {
+		err := errors.New("Path to CloudFoundry config file is empty")
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	cfconfig := &CfConfig{}
+	log.Info("Loading CF configuration from ", config.CfConfig)
+	raw, err := ioutil.ReadFile(config.CfConfig)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(raw, cfconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	log.WithFields(logrus.Fields{
+		"cfconfig":  config.CfConfig,
+		"cell-id":   cfconfig.CellID,
+	}).Info("Setting up CloudFoundry environment")
+
+	etcdClient, err := etcd.NewEtcdClient(cfconfig.EtcdUrl, cfconfig.EtcdCACertFile,
+		cfconfig.EtcdClientCertFile, cfconfig.EtcdClientKeyFile)
+	if err != nil {
+		log.Error("Failed to create Etcd client: ", err)
+		return nil, err
+	}
+	etcdKeysApi := etcdclient.NewKeysAPI(etcdClient)
+
+	return &CfEnvironment{etcdKeysApi: etcdKeysApi, log: log,
+		cfconfig: cfconfig, indexLock: &sync.Mutex{}}, nil
 }
 
 func (env *CfEnvironment) Init(agent *HostAgent) error {
-	return nil
+	env.agent = agent
+	env.epIdx = make(map[string]*etcd.EpInfo)
+	env.appIdx = make(map[string]*etcd.AppInfo)
+	env.ctPortMap = make(map[string]map[uint32]uint32)
+	env.cfNetContainerPorts = make(map[uint32]struct{})
+	if env.cfconfig.CfNetOvsPort != "" {
+		env.agent.ignoreOvsPorts[env.agent.config.IntBridgeName] = []string{env.cfconfig.CfNetOvsPort}
+	}
+	cellIp := net.ParseIP(env.cfconfig.CellAddress)
+	if cellIp == nil {
+		err := fmt.Errorf("Invalid cell IP address")
+		return err
+	}
+	env.cfNetv4 = cellIp.To4() != nil
+	var err error
+	if env.cfNetv4 {
+		env.iptbl, err = iptables.NewWithProtocol(iptables.ProtocolIPv4)
+	} else {
+		env.iptbl, err = iptables.NewWithProtocol(iptables.ProtocolIPv6)
+	}
+	return err
 }
 
 func (env *CfEnvironment) PrepareRun(stopCh <-chan struct{}) error {
+	err := env.setupInterfaceForLegacyCfNet()
+	if err != nil {
+		env.log.Error("Error setting up interface for legacy CF networking: ", err)
+		return err
+	}
+	err = env.setupIpTablesForLegacyCfNet()
+	if err != nil {
+		env.log.Error("Error setting up IPTables for legacy CF networking: ", err)
+		return err
+	}
+	etcd_cell_w := NewCfEtcdCellWatcher(env)
+	etcd_app_w := NewCfEtcdAppWatcher(env)
+	go etcd_cell_w.Run(stopCh)
+	go etcd_app_w.Run(stopCh)
+	cache.WaitForCacheSync(stopCh, etcd_cell_w.Synced, etcd_app_w.Synced)
+
+	if env.agent.podNetAnnotation == "" {
+		env.log.Info("Cell network info node not found in etcd, using default pool")
+		defIpPool := env.getDefaultIpPool()
+		env.agent.updateIpamAnnotation(defIpPool)
+	}
 	return nil
 }
 
 func (env *CfEnvironment) CniDeviceChanged(metadataKey *string, id *md.ContainerId) {
+	// TODO Find a better way to identify containers that we want to hide
+	if strings.Contains(*metadataKey, "executor-healthcheck-") {
+		return
+	}
+	env.updateContainerMetadata(metadataKey)
+
+	ctId := id.Pod
+	env.indexLock.Lock()
+	ep := env.epIdx[ctId]
+	env.indexLock.Unlock()
+
+	if ep == nil {
+		env.log.Debug("No EP info for container ", ctId)
+		return
+	}
+	env.cfAppContainerChanged(&ctId, ep)
 }
 
 func (env *CfEnvironment) CniDeviceDeleted(metadataKey *string, id *md.ContainerId) {
+	env.updateContainerMetadata(metadataKey)
+	env.cfAppContainerDeleted(&id.Pod, nil)
+}
+
+func extractContainerIdFromMetadataKey(metadataKey *string) string {
+	parts := strings.SplitN(*metadataKey, "/", 2)
+	if len(parts) < 2 || parts[0] != "_cf_" {
+		return ""
+	}
+	return parts[1]
 }
 
 func (env *CfEnvironment) CheckPodExists(metadataKey *string) (bool, error) {
-return false, nil
+	ctId := extractContainerIdFromMetadataKey(metadataKey)
+	if ctId == "" {
+		return false, nil
+	}
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	ep := env.epIdx[ctId]
+	return (ep != nil), nil
+}
+
+func (env *CfEnvironment) getDefaultIpPool() (string) {
+	ipa4 := ipam.New()
+	ipa6 := ipam.New()
+
+	for _, nc := range env.agent.config.NetConfig {
+		ip := nc.Subnet.IP.To4()
+		num_ones, _ := nc.Subnet.Mask.Size()
+		mask := net.CIDRMask(num_ones, 32)
+		gw := nc.Gateway.To4()
+		ipa := ipa4
+		if ip == nil {
+			ip = nc.Subnet.IP.To16()
+			mask = net.CIDRMask(num_ones, 128)
+			gw = nc.Gateway.To16()
+			ipa = ipa6
+			if ip == nil {
+				continue
+			}
+		}
+		last := make(net.IP, len(ip))
+		for i := 0; i < len(ip); i++ {
+			last[i] = ip[i] | ^mask[i]
+		}
+		// TODO add a random offset to start address
+		ipa.AddRange(ip, last)
+		// remove the start address and gateway address
+		ipa.RemoveIp(ip)
+		ipa.RemoveIp(gw)
+	}
+
+	netips := md.NetIps{V4: ipa4.FreeList, V6: ipa6.FreeList}
+	raw, err := json.Marshal(&netips)
+	if err != nil {
+		env.log.Error("Could not create default ip-pool", err)
+		return ""
+	}
+	env.log.Debug("Setting default IP pool to ", string(raw))
+	return string(raw)
+}
+
+func (env *CfEnvironment) setupInterfaceForLegacyCfNet() error {
+	// Assign ip to interface that receives legacy CF networking traffic
+	intfIp := net.ParseIP(env.cfconfig.CfNetIntfAddress)
+	if intfIp == nil || (env.cfNetv4 && intfIp.To4() == nil) {
+		err := fmt.Errorf("CF legacy network interface IP is not a valid IP address")
+		return err
+	}
+	link, err := netlink.LinkByName(env.cfconfig.CfNetOvsPort)
+	if err != nil {
+		return err
+	}
+	linkAddr := netlink.Addr{IPNet: netlink.NewIPNet(intfIp)}
+	linkAddr.Scope = syscall.IFA_LOCAL
+	fam := netlink.FAMILY_V4
+	if !env.cfNetv4 {
+		fam = netlink.FAMILY_V6
+	}
+	allAddr, err := netlink.AddrList(link, fam)
+	if err != nil {
+		return err
+	}
+	addrFound := false
+	for _, a := range allAddr {
+		if a.Equal(linkAddr) {
+			addrFound = true
+			break
+		}
+	}
+	if !addrFound {
+		if err := netlink.AddrAdd(link, &linkAddr); err != nil {
+			return err
+		}
+	}
+	if err := netlink.LinkSetUp(link); err != nil {
+		return err
+	}
+
+	// set routing rules to redirect traffic to the interface
+	for _, n := range env.agent.config.NetConfig {
+		dst := net.IPNet{IP: n.Subnet.IP, Mask: n.Subnet.Mask}
+		route := netlink.Route{Dst: &dst, Gw: intfIp}
+		if err := netlink.RouteReplace(&route); err != nil {
+			return err
+		}
+	}
+	env.cfNetLink = link
+	return nil
+}
+
+func (env *CfEnvironment) setupIpTablesForLegacyCfNet() error {
+	// clear or create our iptables rule chains
+	if err := env.iptbl.ClearChain("nat", NAT_PRE_CHAIN); err != nil {
+		return err
+	}
+	if err := env.iptbl.ClearChain("nat", NAT_POST_CHAIN); err != nil {
+		return err
+	}
+	// Link our chains from the pre/post-routing chains
+	if err := env.iptbl.AppendUnique("nat", "PREROUTING", "-j", NAT_PRE_CHAIN); err != nil {
+		return err
+	}
+	if err := env.iptbl.AppendUnique("nat", "POSTROUTING", "-j", NAT_POST_CHAIN); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/hostagent/cf_environment_test.go
+++ b/pkg/hostagent/cf_environment_test.go
@@ -1,0 +1,73 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func TestCfCniDeviceOps(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	id := md.ContainerId{Namespace: "_cf_", Pod: "one", ContId: "one"}
+	mdKey := "_cf_/one"
+	ep := getTestEpInfo()
+	env.epIdx["one"] = ep
+	meta := getTestEpMetadata()
+	env.agent.epMetadata[mdKey] = meta
+
+	env.CniDeviceChanged(&mdKey, &id)
+
+	assert.Equal(t, meta, env.GetContainerMetadata("one"))
+	_, ok := env.agent.opflexEps["one"]
+	assert.True(t, ok)
+
+	delete(env.agent.epMetadata, mdKey)
+	delete(env.epIdx, "one")
+	env.CniDeviceDeleted(&mdKey, &id)
+
+	assert.Nil(t, env.GetContainerMetadata("one"))
+	_, ok = env.agent.opflexEps["one"]
+	assert.False(t, ok)
+
+}
+
+func TestCfSetupIpTables(t *testing.T) {
+	env := testCfEnvironment(t)
+	env.iptbl.AppendUnique("nat", NAT_PRE_CHAIN, "foo bar")
+	env.iptbl.AppendUnique("nat", NAT_PRE_CHAIN, "foo1 bar1")
+	env.iptbl.AppendUnique("nat", NAT_POST_CHAIN, "foo2 bar2")
+	env.iptbl.AppendUnique("nat", NAT_POST_CHAIN, "foo3 bar2")
+
+	env.setupIpTablesForLegacyCfNet()
+	exist := false
+
+	exist, _ = env.iptbl.Exists("nat", "PREROUTING", "-j", NAT_PRE_CHAIN)
+	assert.True(t, exist)
+	exist, _ = env.iptbl.Exists("nat", "POSTROUTING", "-j", NAT_POST_CHAIN)
+	assert.True(t, exist)
+	exist, _ = env.iptbl.Exists("nat", NAT_PRE_CHAIN, "foo bar")
+	assert.False(t, exist)
+	exist, _ = env.iptbl.Exists("nat", NAT_PRE_CHAIN, "foo1 bar1")
+	assert.False(t, exist)
+	exist, _ = env.iptbl.Exists("nat", NAT_POST_CHAIN, "foo2 bar2")
+	assert.False(t, exist)
+	exist, _ = env.iptbl.Exists("nat", NAT_POST_CHAIN, "foo3 bar3")
+	assert.False(t, exist)
+}

--- a/pkg/hostagent/cf_etcd_watcher.go
+++ b/pkg/hostagent/cf_etcd_watcher.go
@@ -1,0 +1,188 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package hostagent
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	etcdclient "github.com/coreos/etcd/client"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	"github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func NewCfEtcdCellWatcher(env *CfEnvironment) *etcd.CfEtcdWatcher {
+	cellKey := etcd.CELL_KEY_BASE + "/" + env.cfconfig.CellID
+	cellNetKey := cellKey + "/network"
+	cellSvcKey := cellKey + "/service"
+	ctBaseKey := cellKey + "/containers/"
+
+	handleEtcdNode := func (action *string, node *etcdclient.Node) error {
+		if node.Key == cellKey {
+			return env.handleEtcdCellNode(action, node)
+		} else if node.Key == cellNetKey {
+			return env.handleEtcdCellNetworkNode(action, node)
+		} else if node.Key == cellSvcKey {
+			return env.handleEtcdCellServiceNode(action, node)
+		} else if strings.HasPrefix(node.Key, ctBaseKey) {
+			return env.handleEtcdContainerNode(action, node)
+		}
+		return nil
+	}
+
+	return etcd.NewEtcdWatcher(env.etcdKeysApi, cellKey, handleEtcdNode, env.log)
+}
+
+func NewCfEtcdAppWatcher(env *CfEnvironment) *etcd.CfEtcdWatcher {
+	key := etcd.APP_KEY_BASE
+
+	handleEtcdNode := func (action *string, node *etcdclient.Node) error {
+		if strings.HasPrefix(node.Key, etcd.APP_KEY_BASE + "/") {
+			return env.handleEtcdAppNode(action, node)
+		}
+		return nil
+	}
+
+	return etcd.NewEtcdWatcher(env.etcdKeysApi, key, handleEtcdNode, env.log)
+}
+
+func (env *CfEnvironment) handleEtcdCellNode(action *string, node *etcdclient.Node) error {
+	if etcd.IsDeleteAction(action) {
+		env.handleEtcdCellNetworkNode(action, nil)
+		env.handleEtcdCellServiceNode(action, nil)
+	}
+	return nil
+}
+
+func (env *CfEnvironment) handleEtcdCellNetworkNode(action *string, node *etcdclient.Node) error {
+	if etcd.IsDeleteAction(action) {
+		env.agent.updateIpamAnnotation("[]")
+	} else {
+		env.agent.updateIpamAnnotation(node.Value)
+	}
+	return nil
+}
+
+func (env *CfEnvironment) handleEtcdCellServiceNode(action *string, node *etcdclient.Node) error {
+	var newServiceEp metadata.ServiceEndpoint
+	updated := false
+	agent := env.agent
+	if etcd.IsDeleteAction(action) {
+		agent.indexMutex.Lock()
+		agent.serviceEp = newServiceEp
+		agent.indexMutex.Unlock()
+		updated = true
+	} else {
+		err := json.Unmarshal([]byte(node.Value), &newServiceEp)
+		if err != nil {
+			env.log.Error("Error deserializing cell service node value: ", err)
+			return err
+		} else {
+			agent.indexMutex.Lock()
+			if !reflect.DeepEqual(newServiceEp, agent.serviceEp) {
+				env.log.Info("Cell service EP updated: ", node.Value)
+				agent.serviceEp = newServiceEp
+				updated = true
+			}
+			agent.indexMutex.Unlock()
+		}
+	}
+	if updated {
+		// update service files for all apps that have a container
+		apps := make(map[string]struct{})
+		env.indexLock.Lock()
+		for _, ep := range env.epIdx {
+			if ep != nil {
+				apps[ep.AppId] = struct{}{}
+			}
+		}
+		env.indexLock.Unlock()
+		// TODO Use a queue for updating all apps
+		go func() {
+			for id, _ := range apps {
+				env.cfAppIdChanged(&id)
+			}
+		}()
+	}
+	return nil
+}
+
+func (env *CfEnvironment) handleEtcdContainerNode(action *string, node *etcdclient.Node) error {
+	epNode := strings.HasSuffix(node.Key, "/ep")
+	key_parts := strings.Split(node.Key, "/")
+	ctId := key_parts[len(key_parts) - 2]
+	if !epNode {
+		ctId = key_parts[len(key_parts) - 1]
+	}
+	deleted := etcd.IsDeleteAction(action)
+	if epNode && !deleted {
+		var ep etcd.EpInfo
+		err := json.Unmarshal([]byte(node.Value), &ep)
+		if err != nil {
+			env.log.Error("Error deserializing container node value: ", err)
+			return err
+		}
+
+		env.log.Info(fmt.Sprintf("Etcd udpate event for Container %s - %+v", ctId, ep))
+
+		env.indexLock.Lock()
+		env.epIdx[ctId] = &ep
+		env.indexLock.Unlock()
+
+		env.cfAppContainerChanged(&ctId, &ep)
+	}
+	if deleted {
+		env.log.Info("Etcd delete event for Container ", ctId)
+		env.indexLock.Lock()
+		ep := env.epIdx[ctId]
+		delete(env.epIdx, ctId)
+		env.indexLock.Unlock()
+
+		env.cfAppContainerDeleted(&ctId, ep)
+	}
+	return nil
+}
+
+func (env *CfEnvironment) handleEtcdAppNode(action *string, node *etcdclient.Node) error {
+	key_parts := strings.Split(node.Key, "/")
+	appId := key_parts[len(key_parts) - 1]
+	deleted := etcd.IsDeleteAction(action)
+	if !deleted {
+		var app etcd.AppInfo
+		err := json.Unmarshal([]byte(node.Value), &app)
+		if err != nil {
+			env.log.Error("Error deserializing app node value: ", err)
+			return err
+		}
+
+		env.log.Info(fmt.Sprintf("Etcd udpate event for App %s - %+v", appId, app))
+		env.indexLock.Lock()
+		env.appIdx[appId] = &app
+		env.indexLock.Unlock()
+
+		env.cfAppChanged(&appId, &app)
+	} else {
+		env.log.Info("Etcd delete event for App ", appId)
+		env.indexLock.Lock()
+		app := env.appIdx[appId]
+		delete(env.appIdx, appId)
+		env.indexLock.Unlock()
+
+		env.cfAppDeleted(&appId, app)
+	}
+	return nil
+}

--- a/pkg/hostagent/cf_etcd_watcher_test.go
+++ b/pkg/hostagent/cf_etcd_watcher_test.go
@@ -1,0 +1,127 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	etcdclient "github.com/coreos/etcd/client"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func TestCfHandleEtcdContainerNode(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := NewCfEtcdCellWatcher(env).NodeHandler()
+	op := "create"
+
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata()
+	ep := getTestEpInfo()
+	ep_str, _ := json.Marshal(ep)
+	node := &etcdclient.Node{Key: "/aci/cells/cell1/containers/one/ep", Value: string(ep_str)}
+
+	handler(&op, node)
+	assert.Equal(t, ep, env.epIdx["one"])
+	assert.NotNil(t, env.agent.opflexEps["one"])
+
+	op = "delete"
+	node.Key = "/aci/cells/cell1/containers/one"
+	handler(&op, node)
+	assert.Nil(t, env.epIdx["one"])
+	assert.Nil(t, env.agent.opflexEps["one"])
+}
+
+func TestCfHandleEtcdAppNode(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := NewCfEtcdAppWatcher(env).NodeHandler()
+	op := "create"
+
+	env.epIdx["one"] = getTestEpInfo()
+	app := getTestAppInfo()
+	app_str, _ := json.Marshal(app)
+	node := &etcdclient.Node{Key: "/aci/apps/a1", Value: string(app_str)}
+
+	handler(&op, node)
+	assert.Equal(t, app, env.appIdx["a1"])
+	assert.NotNil(t, env.agent.opflexServices["a1"])
+	assert.NotNil(t, env.agent.opflexServices["a1-external"])
+
+	op = "delete"
+	handler(&op, node)
+	assert.Nil(t, env.appIdx["a1"])
+	assert.Nil(t, env.agent.opflexServices["a1"])
+	assert.Nil(t, env.agent.opflexServices["a1-external"])
+}
+
+func TestCfHandleEtcdCellNetworkNode(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := NewCfEtcdCellWatcher(env).NodeHandler()
+	op := "create"
+
+	pod_ip := md.NetIps{}
+	pod_ip.V4 = append(pod_ip.V4,
+		ipam.IpRange{Start: net.ParseIP("10.255.0.2"), End: net.ParseIP("10.255.0.127")},
+		ipam.IpRange{Start: net.ParseIP("10.255.1.2"), End: net.ParseIP("10.255.1.127")})
+	pod_ip.V6 = append(pod_ip.V6,
+		ipam.IpRange{Start: net.ParseIP("::ff02"), End: net.ParseIP("::ffef")},
+		ipam.IpRange{Start: net.ParseIP("::fe02"), End: net.ParseIP("::feef")})
+	pod_ann, _ := json.Marshal(pod_ip)
+
+	node := &etcdclient.Node{Key: "/aci/cells/cell1/network", Value: string(pod_ann)}
+	handler(&op, node)
+	assert.Equal(t, string(pod_ann), env.agent.podNetAnnotation)
+
+	op = "delete"
+	node.Key = "/aci/cells/cell1"
+	handler(&op, node)
+	assert.Equal(t, "[]", env.agent.podNetAnnotation)
+}
+
+func TestCfHandleEtcdCellServiceNode(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := NewCfEtcdCellWatcher(env).NodeHandler()
+	op := "create"
+
+	env.epIdx["one"] = getTestEpInfo()
+	env.appIdx["a1"] = getTestAppInfo()
+
+	svc_ep := md.ServiceEndpoint{Mac: "de:ad:be:ef:00:01", Ipv4: net.ParseIP("10.150.0.10")}
+	svc_ep_str, _ := json.Marshal(svc_ep)
+	node := &etcdclient.Node{Key: "/aci/cells/cell1/service", Value: string(svc_ep_str)}
+
+	handler(&op, node)
+	assert.Equal(t, svc_ep, env.agent.serviceEp)
+	tu.WaitFor(t, "Ext-IP service ep created", 500*time.Millisecond,
+		func(last bool) (bool, error) {
+			return env.agent.opflexServices["a1-external"] != nil, nil
+	})
+
+	op = "delete"
+	node.Key = "/aci/cells/cell1"
+	handler(&op, node)
+	assert.Equal(t, "", env.agent.serviceEp.Mac)
+	assert.Nil(t, env.agent.serviceEp.Ipv4)
+	tu.WaitFor(t, "Ext-IP service ep removed", 500*time.Millisecond,
+		func(last bool) (bool, error) {
+			svc := env.agent.opflexServices["a1-external"]
+			return (svc != nil && svc.ServiceMac == "" && svc.InterfaceIp == ""), nil
+	})
+}


### PR DESCRIPTION
This change implements CfEnvironment to allow
the agent to run in ClodFoundry deplopyments.
The etcd key-value store available in CloudFoundry
is used as the basis for creating EP and Service
files; this information is written by the
controller and the agent mostly reacts by creating
the appropriate EP and Service files.
To support legacy CloudFoundry networking
(non-CNI networking), the agent also configures
iptables rules.

Signed-off-by: Amit Bose <amitbose@gmail.com>