### PR TITLE
CloudFoundry support in controller

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,9 +3,21 @@
 
 [[projects]]
   branch = "master"
+  name = "code.cloudfoundry.org/bbs"
+  packages = [".","encryption","events","events/eventfakes","fake_bbs","format","models"]
+  revision = "14a3dfe09f49730daba6bca42470dd73aa0316f4"
+
+[[projects]]
+  branch = "master"
   name = "code.cloudfoundry.org/cfhttp"
   packages = [".","unix_transport"]
   revision = "08baa6b247caf03100a743f6c3c426d28e55336a"
+
+[[projects]]
+  branch = "master"
+  name = "code.cloudfoundry.org/lager"
+  packages = ["."]
+  revision = "0bfa98e49e7a976af91e918d47978f07c00b081f"
 
 [[projects]]
   name = "github.com/PuerkitoBio/purell"
@@ -27,6 +39,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/bmizerany/pat"
+  packages = ["."]
+  revision = "6226ea591a40176dd3ff9cd8eff81ed6ca721a00"
+
+[[projects]]
+  branch = "master"
   name = "github.com/cenkalti/hub"
   packages = ["."]
   revision = "11382a9960d39b0ecda16fd01c424c11ff765a34"
@@ -36,6 +54,12 @@
   name = "github.com/cenkalti/rpc2"
   packages = [".","jsonrpc"]
   revision = "c51a77e5f664b4a8a69bce4270d14204f94d51f9"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/cloudfoundry-community/go-cfclient"
+  packages = ["."]
+  revision = "8f0d96bb9f0ac0af44d6cf8fab9b36c4b50a5610"
 
 [[projects]]
   name = "github.com/containernetworking/cni"
@@ -134,8 +158,14 @@
   revision = "f3f9494671f93fcff853e3c6e9e948b3eb71e590"
 
 [[projects]]
+  name = "github.com/go-sql-driver/mysql"
+  packages = ["."]
+  revision = "a0583e0143b1624142adab07e0e97fe106d99561"
+  version = "v1.3"
+
+[[projects]]
   name = "github.com/gogo/protobuf"
-  packages = ["proto","sortkeys"]
+  packages = ["gogoproto","proto","protoc-gen-gogo/descriptor","sortkeys"]
   revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
   version = "v0.5"
 
@@ -242,6 +272,12 @@
   revision = "2a92e673c9a6302dd05c3a691ae1f24aef46457d"
 
 [[projects]]
+  name = "github.com/mattn/go-sqlite3"
+  packages = ["."]
+  revision = "5160b48509cf5c877bc22c11c373f8c7738cdb38"
+  version = "v1.3.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
@@ -276,6 +312,12 @@
   packages = ["."]
   revision = "5f041e8faa004a95c88a202771f4cc3e991971e6"
   version = "v2.0.1"
+
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -326,8 +368,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/stretchr/objx"
+  packages = ["."]
+  revision = "1a9d0bb9f541897e62256577b352fdbc1fb4fd94"
+
+[[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = ["assert","mock"]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -336,6 +384,12 @@
   name = "github.com/tatsushid/go-fastping"
   packages = ["."]
   revision = "d7bb493dee3e090e2ffb6914adddf17c1e7c026c"
+
+[[projects]]
+  name = "github.com/tedsuo/rata"
+  packages = ["."]
+  revision = "0649c23705dfb45a9693b668c4fc1c0666f485d9"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -357,6 +411,12 @@
 
 [[projects]]
   branch = "master"
+  name = "github.com/vito/go-sse"
+  packages = ["sse"]
+  revision = "fd69d275caac5d78d793e77ddbe9bd2001d9b88d"
+
+[[projects]]
+  branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
   revision = "9419663f5a44be8b34ca85f08abc5fe1be11f8a3"
@@ -364,8 +424,14 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["bpf","context","http2","http2/hpack","icmp","idna","internal/iana","internal/socket","ipv4","ipv6","lex/httplex"]
+  packages = ["bpf","context","context/ctxhttp","http2","http2/hpack","icmp","idna","internal/iana","internal/socket","ipv4","ipv6","lex/httplex"]
   revision = "a04bdaca5b32abe1c069418fb7088ae607de5bd0"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/oauth2"
+  packages = [".","clientcredentials","internal"]
+  revision = "bb50c06baba3d0c76f9d125c0719093e315b5b44"
 
 [[projects]]
   branch = "master"
@@ -378,6 +444,12 @@
   name = "golang.org/x/text"
   packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable","width"]
   revision = "c01e4764d870b77f8abe5096ee19ad20d80e8075"
+
+[[projects]]
+  name = "google.golang.org/appengine"
+  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
+  version = "v1.0.0"
 
 [[projects]]
   name = "gopkg.in/inf.v0"
@@ -436,6 +508,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "536e56ca82130b123502daffd34d221c9359b891b405cacf1c6efd304b236f13"
+  inputs-digest = "9a5e022f46b774ff9d0f753da29dc63468d1f3c8855088bd6ac1a21389f06e69"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -76,6 +76,14 @@
   branch = "release-1.8"
 
 [[constraint]]
+  name = "code.cloudfoundry.org/bbs"
+  branch = "master"
+
+[[constraint]]
+  name = "github.com/cloudfoundry-community/go-cfclient"
+  branch = "master"
+
+[[constraint]]
   name = "github.com/coreos/etcd"
   version = "3.2.9"
 
@@ -86,6 +94,14 @@
 [[constraint]]
   name = "github.com/coreos/go-iptables"
   version = "0.2.0"
+
+[[constraint]]
+  name = "github.com/go-sql-driver/mysql"
+  version = "1.3.0"
+
+[[constraint]]
+  name = "github.com/mattn/go-sqlite3"
+  version = "1.2.0"
 
 [[override]]
   name = "github.com/cenkalti/hub"

--- a/pkg/cfapi/auth.go
+++ b/pkg/cfapi/auth.go
@@ -1,0 +1,162 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cfapi
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type TokenInfo struct {
+	Scope    []string `json:"scope"`
+	UserId   string   `json:"user_id"`
+	UserName string   `json:"user_name"`
+}
+
+func (t *TokenInfo) IsNetworkAdmin() bool {
+	for _, s := range t.Scope {
+		if s == "network.admin" {
+			return true
+		}
+	}
+	return false
+}
+
+type CfAuthClient interface {
+	FetchTokenInfo(token string) (*TokenInfo, error)
+}
+
+type cfAuthUaa struct {
+	http.Client
+	ApiUrl       string
+	ClientName   string
+	ClientSecret string
+}
+
+func NewCfAuthClient(uaaApiUrl, caCertFile, clientName, clientSecret string) (CfAuthClient, error) {
+	certBytes, err := ioutil.ReadFile(caCertFile)
+	if err != nil {
+		return nil, err
+	}
+	caCertPool := x509.NewCertPool()
+	if ok := caCertPool.AppendCertsFromPEM(certBytes); !ok {
+		return nil, fmt.Errorf("Failed to load UAA CA Cert")
+	}
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    caCertPool,
+	}
+	t := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			// values taken from http.DefaultTransport
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		// value taken from http.DefaultTransport
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+	}
+
+	auth := cfAuthUaa{Client: http.Client{Transport: t, Timeout: 30 * time.Second},
+		ApiUrl: uaaApiUrl, ClientName: clientName, ClientSecret: clientSecret}
+	return &auth, nil
+}
+
+func (auth *cfAuthUaa) FetchTokenInfo(token string) (*TokenInfo, error) {
+	reqURL := auth.ApiUrl + "/check_token"
+	body := "token=" + token
+
+	req, err := http.NewRequest("POST", reqURL, strings.NewReader(body))
+	req.SetBasicAuth(auth.ClientName, auth.ClientSecret)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := auth.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusBadRequest {
+		return nil, nil
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var ti TokenInfo
+	err = json.Unmarshal(resBody, &ti)
+	if err != nil {
+		return nil, err
+	}
+	return &ti, nil
+}
+
+func ExtractToken(req *http.Request) string {
+	auth := req.Header["Authorization"]
+	if len(auth) < 1 {
+		return ""
+	}
+
+	token := auth[0]
+	token = strings.TrimPrefix(token, "Bearer ")
+	token = strings.TrimPrefix(token, "bearer ")
+	return token
+}
+
+func HasAccess(cc CcClient, auth CfAuthClient, req *http.Request, kind, id, access string) (bool, error) {
+	tok := ExtractToken(req)
+	if tok == "" {
+		return false, nil
+	}
+	ti, err := auth.FetchTokenInfo(tok)
+	if err != nil {
+		return false, err
+	}
+	if ti == nil {
+		return false, nil
+	}
+	if kind == "app" {
+		sp, err := cc.GetAppSpace(id)
+		if err != nil {
+			return false, nil // TODO handle app-not-found different from other errors
+		}
+		id = sp
+		kind = "space"
+	}
+	if ti.IsNetworkAdmin() {
+		return true, nil
+	}
+	ur, err := cc.GetUserRoleInfo(ti.UserId)
+	if err != nil {
+		return false, err
+	}
+	if kind == "space" && access == "read" {
+		return ur.CanReadSpace(id), nil
+	} else if kind == "space" && access == "write" {
+		return ur.CanWriteSpace(id), nil
+	} else if kind == "org" && access == "read" {
+		return ur.CanReadOrg(id), nil
+	} else if kind == "org" && access == "write" {
+		return ur.CanWriteOrg(id), nil
+	}
+	return false, nil
+}

--- a/pkg/cfapi/ccapi.go
+++ b/pkg/cfapi/ccapi.go
@@ -1,0 +1,224 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cfapi
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"strings"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+)
+
+type CcClient interface {
+	GetSpaceByGuid(spaceGUID string) (cfclient.Space, error)
+
+	ListSecGroupsBySpace(spaceGuid string, staging bool) ([]cfclient.SecGroup, error)
+
+	GetIsolationSegmentByGUID(guid string) (*cfclient.IsolationSegment, error)
+
+	GetOrgDefaultIsolationSegment(orgGuid string) (string, error)
+
+	GetSpaceIsolationSegment(spaceGuid string) (string, error)
+
+	GetUserRoleInfo(userGuid string) (*UserRoleInfo, error)
+
+	GetAppSpace(appGuid string) (string, error)
+
+	ListOrgs() ([]cfclient.Org, error)
+
+	ListSpaces() ([]cfclient.Space, error)
+
+	ListApps() ([]cfclient.App, error)
+
+	ListSecGroups() ([]cfclient.SecGroup, error)
+}
+
+type ccClientImpl struct {
+	cfclient.Client
+}
+
+func NewCcClient(apiUrl string, username string, password string) (CcClient, error) {
+	ccConfig := &cfclient.Config{
+		ApiAddress:        apiUrl,
+		Username:          username,
+		Password:          password,
+		SkipSslValidation: true,
+	}
+	cfc, err := cfclient.NewClient(ccConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &ccClientImpl{*cfc}, nil
+}
+
+func (ccClient *ccClientImpl) ListSecGroupsBySpace(spaceGuid string, staging bool) ([]cfclient.SecGroup, error) {
+	stageStr := ""
+	if staging {
+		stageStr = "staging_"
+	}
+	requestURL := "/v2/spaces/" + spaceGuid + "/" + stageStr + "security_groups"
+	var secGroups []cfclient.SecGroup
+	for requestURL != "" {
+		var secGroupResp cfclient.SecGroupResponse
+		r := ccClient.NewRequest("GET", requestURL)
+		resp, err := ccClient.DoRequest(r)
+
+		if err != nil {
+			return nil, err
+		}
+		resBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		err = json.Unmarshal(resBody, &secGroupResp)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, secGroup := range secGroupResp.Resources {
+			secGroup.Entity.Guid = secGroup.Meta.Guid
+			secGroups = append(secGroups, secGroup.Entity)
+		}
+
+		requestURL = secGroupResp.NextUrl
+		resp.Body.Close()
+	}
+	return secGroups, nil
+}
+
+func (ccClient *ccClientImpl) GetOrgDefaultIsolationSegment(orgGuid string) (string, error) {
+	requestUrl := "/v3/organizations/" + orgGuid + "/relationships/default_isolation_segment"
+	return ccClient.getIsolationSegment(requestUrl)
+}
+
+func (ccClient *ccClientImpl) GetSpaceIsolationSegment(spaceGuid string) (string, error) {
+	requestUrl := "/v3/spaces/" + spaceGuid + "/relationships/isolation_segment"
+	return ccClient.getIsolationSegment(requestUrl)
+}
+
+func (ccClient *ccClientImpl) getIsolationSegment(requestURL string) (string, error) {
+	r := ccClient.NewRequest("GET", requestURL)
+	resp, err := ccClient.DoRequest(r)
+
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	var isr struct {
+		Data struct {
+			Guid string `json:"guid"`
+		} `json:"data"`
+	}
+
+	err = json.Unmarshal(resBody, &isr)
+	if err != nil {
+		return "", err
+	}
+	return isr.Data.Guid, nil
+}
+
+func (ccClient *ccClientImpl) GetUserRoleInfo(userGuid string) (*UserRoleInfo, error) {
+	r := ccClient.NewRequest("GET", "/v2/users/"+userGuid+"/summary")
+	resp, err := ccClient.DoRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	type EntityMeta struct {
+		Meta cfclient.Meta `json:"metadata"`
+	}
+	var userSummaryResp struct {
+		Meta   cfclient.Meta `json:"metadata"`
+		Entity struct {
+			Organizations               []EntityMeta `json:"organizations"`
+			AuditedOrganizations        []EntityMeta `json:"audited_organizations"`
+			ManagedOrganizations        []EntityMeta `json:"managed_organizations"`
+			BillingManagedOrganizations []EntityMeta `json:"billing_managed_organizations"`
+			Spaces                      []EntityMeta `json:"spaces"`
+			AuditedSpaces               []EntityMeta `json:"audited_spaces"`
+			ManagedSpaces               []EntityMeta `json:"managed_spaces"`
+		} `json:"entity"`
+	}
+	err = json.Unmarshal(resBody, &userSummaryResp)
+	if err != nil {
+		return nil, err
+	}
+	ri := NewUserRoleInfo(userSummaryResp.Meta.Guid)
+	for _, e := range userSummaryResp.Entity.Organizations {
+		ri.Organizations[e.Meta.Guid] = struct{}{}
+	}
+	for _, e := range userSummaryResp.Entity.AuditedOrganizations {
+		ri.AuditedOrganizations[e.Meta.Guid] = struct{}{}
+	}
+	for _, e := range userSummaryResp.Entity.ManagedOrganizations {
+		ri.ManagedOrganizations[e.Meta.Guid] = struct{}{}
+	}
+	for _, e := range userSummaryResp.Entity.BillingManagedOrganizations {
+		ri.BillingManagedOrganizations[e.Meta.Guid] = struct{}{}
+	}
+	for _, e := range userSummaryResp.Entity.Spaces {
+		ri.Spaces[e.Meta.Guid] = struct{}{}
+	}
+	for _, e := range userSummaryResp.Entity.AuditedSpaces {
+		ri.AuditedSpaces[e.Meta.Guid] = struct{}{}
+	}
+	for _, e := range userSummaryResp.Entity.ManagedSpaces {
+		ri.ManagedSpaces[e.Meta.Guid] = struct{}{}
+	}
+	return ri, nil
+}
+
+func (ccClient *ccClientImpl) GetAppSpace(appGuid string) (string, error) {
+	requestURL := "/v3/apps/" + appGuid
+
+	r := ccClient.NewRequest("GET", requestURL)
+	resp, err := ccClient.DoRequest(r)
+
+	if err != nil {
+		return "", err
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var appResp struct {
+		Guid  string `json:"guid"`
+		Links struct {
+			Space struct {
+				Href string `json:"href"`
+			} `json:"space"`
+		} `json:"links"`
+	}
+	err = json.Unmarshal(resBody, &appResp)
+	if err != nil {
+		return "", err
+	}
+	parts := strings.Split(appResp.Links.Space.Href, "/")
+	return parts[len(parts)-1], nil
+}

--- a/pkg/cfapi/cfapi_fakes/test_fakes.go
+++ b/pkg/cfapi/cfapi_fakes/test_fakes.go
@@ -1,0 +1,109 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// This file defines fake versions of various client that are meant to be used
+// for testing ONLY.
+//
+
+package cfapi_fakes
+
+import (
+	"github.com/stretchr/testify/mock"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+)
+
+type FakeCcClient struct {
+	mock.Mock
+}
+
+func (c *FakeCcClient) GetSpaceByGuid(spaceGUID string) (cfclient.Space, error) {
+	res := c.Called(spaceGUID)
+	return res.Get(0).(cfclient.Space), res.Error(1)
+}
+
+func (c *FakeCcClient) ListSecGroupsBySpace(spaceGuid string, staging bool) ([]cfclient.SecGroup, error) {
+	res := c.Called(spaceGuid, staging)
+	return res.Get(0).([]cfclient.SecGroup), res.Error(1)
+}
+
+func (c *FakeCcClient) GetIsolationSegmentByGUID(guid string) (*cfclient.IsolationSegment, error) {
+	res := c.Called(guid)
+	return res.Get(0).(*cfclient.IsolationSegment), res.Error(1)
+}
+
+func (c *FakeCcClient) GetOrgDefaultIsolationSegment(orgGuid string) (string, error) {
+	res := c.Called(orgGuid)
+	return res.String(0), res.Error(1)
+}
+
+func (c *FakeCcClient) GetSpaceIsolationSegment(spaceGuid string) (string, error) {
+	res := c.Called(spaceGuid)
+	return res.String(0), res.Error(1)
+}
+
+func (c *FakeCcClient) GetUserRoleInfo(userGuid string) (*cfapi.UserRoleInfo, error) {
+	res := c.Called(userGuid)
+	return res.Get(0).(*cfapi.UserRoleInfo), res.Error(1)
+}
+
+func (c *FakeCcClient) GetAppSpace(appGuid string) (string, error) {
+	res := c.Called(appGuid)
+	return res.String(0), res.Error(1)
+}
+
+func (c *FakeCcClient) ListApps() ([]cfclient.App, error) {
+	res := c.Called()
+	return res.Get(0).([]cfclient.App), res.Error(1)
+}
+
+func (c *FakeCcClient) ListOrgs() ([]cfclient.Org, error) {
+	res := c.Called()
+	return res.Get(0).([]cfclient.Org), res.Error(1)
+}
+
+func (c *FakeCcClient) ListSpaces() ([]cfclient.Space, error) {
+	res := c.Called()
+	return res.Get(0).([]cfclient.Space), res.Error(1)
+}
+
+func (c *FakeCcClient) ListSecGroups() ([]cfclient.SecGroup, error) {
+	res := c.Called()
+	return res.Get(0).([]cfclient.SecGroup), res.Error(1)
+}
+
+type FakeCfAuthClient struct {
+	mock.Mock
+}
+
+func (c *FakeCfAuthClient) FetchTokenInfo(token string) (*cfapi.TokenInfo, error) {
+	res := c.Called(token)
+	return res.Get(0).(*cfapi.TokenInfo), res.Error(1)
+}
+
+type FakePolicyClient struct {
+	mock.Mock
+}
+
+func (c *FakePolicyClient) GetPolicies(ids ...string) ([]cfapi.Policy, error) {
+	var l []interface{}
+	for _, s := range ids {
+		l = append(l, s)
+	}
+	res := c.Called(l...)
+	return res.Get(0).([]cfapi.Policy), res.Error(1)
+}

--- a/pkg/cfapi/network_policy.go
+++ b/pkg/cfapi/network_policy.go
@@ -1,0 +1,92 @@
+package cfapi
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"code.cloudfoundry.org/cfhttp"
+)
+
+// cf-networking-release doesn't provide API structs and methods in a way that can be easily
+// fetched and used in a Go project. So the necessary APIs are being defined here instead of
+// using cf-networking-release directly.
+
+type Policy struct {
+	Source      Source      `json:"source"`
+	Destination Destination `json:"destination"`
+}
+
+type Source struct {
+	ID string `json:"id"`
+}
+
+type Destination struct {
+	ID       string `json:"id"`
+	Protocol string `json:"protocol"`
+	Ports    Ports  `json:"ports"`
+}
+
+type Ports struct {
+	Start int `json:"start"`
+	End   int `json:"end"`
+}
+
+type PolicyClient interface {
+	GetPolicies(ids ...string) ([]Policy, error)
+}
+
+type policyClientImpl struct {
+	http.Client
+	Url string
+}
+
+func (c *policyClientImpl) GetPolicies(ids ...string) ([]Policy, error) {
+	var policiesResponse struct {
+		Policies []Policy `json:"policies"`
+	}
+	requestURL := c.Url + "/networking/v0/internal/policies"
+	if len(ids) > 0 {
+		requestURL += "?id=" + strings.Join(ids, ",")
+	}
+	resp, err := c.Get(requestURL)
+	if err != nil {
+		return nil, err
+	}
+	resBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(resBody, &policiesResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	resp.Body.Close()
+	return policiesResponse.Policies, nil
+}
+
+func NewNetPolClient(netPolUrl string, caCertFile string, clientCertFile string,
+	clientKeyFile string) (PolicyClient, error) {
+	tlsConfig, err := cfhttp.NewTLSConfig(clientCertFile, clientKeyFile, caCertFile)
+	if err != nil {
+		return nil, err
+	}
+	t := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			// values taken from http.DefaultTransport
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		// value taken from http.DefaultTransport
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     tlsConfig,
+	}
+	httpClient := policyClientImpl{http.Client{Transport: t, Timeout: 30 * time.Second}, netPolUrl}
+	return &httpClient, nil
+}

--- a/pkg/cfapi/user.go
+++ b/pkg/cfapi/user.go
@@ -1,0 +1,74 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cfapi
+
+type UserRoleInfo struct {
+	Guid                        string
+	Spaces                      map[string]struct{}
+	AuditedSpaces               map[string]struct{}
+	ManagedSpaces               map[string]struct{}
+	Organizations               map[string]struct{}
+	AuditedOrganizations        map[string]struct{}
+	ManagedOrganizations        map[string]struct{}
+	BillingManagedOrganizations map[string]struct{}
+}
+
+func NewUserRoleInfo(userId string) *UserRoleInfo {
+	return &UserRoleInfo{Guid: userId,
+		Spaces:                      make(map[string]struct{}),
+		AuditedSpaces:               make(map[string]struct{}),
+		ManagedSpaces:               make(map[string]struct{}),
+		Organizations:               make(map[string]struct{}),
+		AuditedOrganizations:        make(map[string]struct{}),
+		ManagedOrganizations:        make(map[string]struct{}),
+		BillingManagedOrganizations: make(map[string]struct{}),
+	}
+}
+
+func (ur *UserRoleInfo) CanReadSpace(spaceGuid string) bool {
+	if _, ok := ur.Spaces[spaceGuid]; ok {
+		return true
+	}
+	if _, ok := ur.AuditedSpaces[spaceGuid]; ok {
+		return true
+	}
+	if _, ok := ur.ManagedSpaces[spaceGuid]; ok {
+		return true
+	}
+	return false
+}
+
+func (ur *UserRoleInfo) CanWriteSpace(spaceGuid string) bool {
+	_, ok := ur.ManagedSpaces[spaceGuid]
+	return ok
+}
+
+func (ur *UserRoleInfo) CanReadOrg(orgGuid string) bool {
+	if _, ok := ur.Organizations[orgGuid]; ok {
+		return true
+	}
+	if _, ok := ur.AuditedOrganizations[orgGuid]; ok {
+		return true
+	}
+	if _, ok := ur.ManagedOrganizations[orgGuid]; ok {
+		return true
+	}
+	return false
+}
+
+func (ur *UserRoleInfo) CanWriteOrg(orgGuid string) bool {
+	_, ok := ur.ManagedOrganizations[orgGuid]
+	return ok
+}

--- a/pkg/controller/cf_annotations.go
+++ b/pkg/controller/cf_annotations.go
@@ -1,0 +1,263 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+)
+
+type EpgAnnotationDb struct {
+}
+
+const (
+	CF_OBJ_APP = iota
+	CF_OBJ_SPACE
+	CF_OBJ_ORG
+	CF_OBJ_LAST
+)
+
+func (db *EpgAnnotationDb) UpdateAnnotation(txn *sql.Tx, objId string, objKind int, ann string) error {
+	if objKind < 0 || objKind >= CF_OBJ_LAST {
+		return fmt.Errorf("Invalid object kind %d", objKind)
+	}
+	res, err := txn.Exec("UPDATE aci_epg_annotations SET value=? WHERE guid=? AND kind=?",
+		ann, objId, objKind)
+	if err != nil {
+		return err
+	}
+	nrows, _ := res.RowsAffected()
+	if nrows == 0 {
+		_, err = txn.Exec("INSERT INTO aci_epg_annotations(guid, kind, value) VALUES(?, ?, ?)",
+			objId, objKind, ann)
+	}
+	return err
+}
+
+func (db *EpgAnnotationDb) DeleteAnnotation(txn *sql.Tx, objId string, objKind int) error {
+	if objKind < 0 || objKind >= CF_OBJ_LAST {
+		return fmt.Errorf("Invalid object kind %d", objKind)
+	}
+	q := "DELETE FROM aci_epg_annotations WHERE guid=? AND kind=?"
+	_, err := txn.Exec(q, objId, objKind)
+	return err
+}
+
+func (db *EpgAnnotationDb) GetAnnotation(txn *sql.Tx, objId string, objKind int) (string, error) {
+	if objKind < 0 || objKind >= CF_OBJ_LAST {
+		return "", fmt.Errorf("Invalid object kind %d", objKind)
+	}
+	var v string
+	err := txn.QueryRow("SELECT value FROM aci_epg_annotations WHERE guid=? AND kind=?",
+		objId, objKind).Scan(&v)
+	if err == nil {
+		return v, nil
+	} else if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return "", err
+}
+
+type AnnotationObject struct {
+	Guid  string
+	Value string
+	Kind  int
+}
+
+func (db *EpgAnnotationDb) List(txn *sql.Tx, kind int) ([]AnnotationObject, error) {
+	var objs []AnnotationObject
+	var rows *sql.Rows
+	var err error
+	if kind == CF_OBJ_LAST {
+		rows, err = txn.Query("SELECT guid, value, kind FROM aci_epg_annotations ORDER BY guid ASC")
+	} else {
+		rows, err = txn.Query("SELECT guid, value, kind FROM aci_epg_annotations WHERE kind=? ORDER BY guid ASC",
+			kind)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var guid, value string
+		var knd int
+		if err := rows.Scan(&guid, &value, &knd); err == nil {
+			objs = append(objs, AnnotationObject{guid, value, knd})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return objs, nil
+}
+
+func (db *EpgAnnotationDb) ResolveAnnotation(txn *sql.Tx, appId string, spaceId string,
+	orgId string) (string, error) {
+	var v string
+	var k int
+	err := txn.QueryRow("SELECT kind, value FROM aci_epg_annotations WHERE (guid=? AND kind=?) "+
+		"OR (guid=? AND kind=?) OR (guid=? AND kind=?) "+
+		"ORDER BY kind ASC",
+		appId, CF_OBJ_APP, spaceId, CF_OBJ_SPACE, orgId, CF_OBJ_ORG).Scan(&k, &v)
+	if err == nil {
+		return v, nil
+	} else if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return "", err
+}
+
+type EpgAnnotationHttpHandler struct {
+	env *CfEnvironment
+}
+
+type EpgAnnotationPutMessageBody struct {
+	Value string `json:"value, omitempty"`
+}
+
+type EpgAnnotationGetMessageBody struct {
+	Guid  string `json:"guid, omitempty"`
+	Kind  string `json:"kind, omitempty"`
+	Value string `json:"value, omitempty"`
+}
+
+func (h *EpgAnnotationHttpHandler) Path() string {
+	return h.env.cfconfig.ApiPathPrefix + "/epg/"
+}
+
+func (h *EpgAnnotationHttpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	path := req.URL.Path
+	if !strings.HasPrefix(path, h.Path()) {
+		h.env.log.Warning("Asked to handle unknown path: ", path)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if req.Method != http.MethodGet && req.Method != http.MethodPut && req.Method != http.MethodDelete {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	// expect paths of the form <org|space|app>/<id>
+	parts := strings.Split(path[len(h.Path()):], "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	var updateFunc func(string)
+	var kind int = CF_OBJ_LAST
+	switch parts[0] {
+	case "org":
+		kind = CF_OBJ_ORG
+		updateFunc = h.env.scheduleOrgContainersUpdateLocked
+	case "space":
+		kind = CF_OBJ_SPACE
+		updateFunc = h.env.scheduleSpaceContainersUpdateLocked
+	case "app":
+		kind = CF_OBJ_APP
+		updateFunc = h.env.scheduleAppContainersUpdateLocked
+	default:
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	access := "read"
+	if req.Method != http.MethodGet {
+		access = "write"
+	}
+	ok, err := cfapi.HasAccess(h.env.ccClient, h.env.cfAuthClient, req, parts[0], parts[1], access)
+	if err != nil {
+		h.env.log.Warning("Failed to verify authorized access: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	doUpdate := false
+	defer func() {
+		if doUpdate {
+			h.env.indexLock.Lock()
+			defer h.env.indexLock.Unlock()
+			h.env.lookupOrCreate(parts[1], kind)
+			updateFunc(parts[1])
+		}
+	}()
+
+	ea_db := EpgAnnotationDb{}
+	txn, err := h.env.db.Begin()
+	if err != nil {
+		h.env.log.Warning("Failed to start DB transaction: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer txn.Commit()
+
+	status := 0
+	switch req.Method {
+	case http.MethodGet:
+		var val string
+		val, err = ea_db.GetAnnotation(txn, parts[1], kind)
+		if err == nil {
+			if val == "" {
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.Header().Set("Content-Type", "application/json")
+				m := EpgAnnotationGetMessageBody{Guid: parts[1], Kind: parts[0], Value: val}
+				json.NewEncoder(w).Encode(m)
+			}
+		}
+	case http.MethodDelete:
+		err = ea_db.DeleteAnnotation(txn, parts[1], kind)
+		if err == nil {
+			w.WriteHeader(http.StatusNoContent)
+			doUpdate = true
+		}
+	case http.MethodPut:
+		var body []byte
+		body, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			h.env.log.Warning("Failed to read request body: ", err)
+			break
+		}
+		var msg EpgAnnotationPutMessageBody
+		err = json.Unmarshal(body, &msg)
+		if err != nil || msg.Value == "" {
+			if err == nil {
+				err = fmt.Errorf("Missing data")
+			}
+			status = http.StatusBadRequest
+			break
+		}
+		err = ea_db.UpdateAnnotation(txn, parts[1], kind, msg.Value)
+		if err == nil {
+			w.WriteHeader(http.StatusNoContent)
+			doUpdate = true
+		}
+	}
+	if err != nil {
+		if status == 0 {
+			h.env.log.Warning("Failed to update DB for EPG annotation: ", err)
+			status = http.StatusInternalServerError
+		}
+		w.WriteHeader(status)
+	}
+}

--- a/pkg/controller/cf_annotations_test.go
+++ b/pkg/controller/cf_annotations_test.go
@@ -1,0 +1,434 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+)
+
+func doTestAnnoDBForKind(t *testing.T, kind int) {
+	env := testCfEnvironment(t)
+	ea_db := EpgAnnotationDb{}
+
+	// add
+	txn(env.db, func(txn *sql.Tx) {
+		err := ea_db.UpdateAnnotation(txn, "1", kind, "add")
+		assert.Nil(t, err)
+	})
+
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.GetAnnotation(txn, "1", kind)
+		assert.Nil(t, err)
+		assert.Equal(t, "add", val)
+	})
+
+	// list by kind
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.List(txn, kind)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(val))
+		assert.Equal(t, "1", val[0].Guid)
+	})
+
+	// list without kind
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.List(txn, CF_OBJ_LAST)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(val))
+		assert.Equal(t, "1", val[0].Guid)
+		assert.Equal(t, kind, val[0].Kind)
+	})
+
+	// update
+	txn(env.db, func(txn *sql.Tx) {
+		err := ea_db.UpdateAnnotation(txn, "1", kind, "update")
+		assert.Nil(t, err)
+	})
+
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.GetAnnotation(txn, "1", kind)
+		assert.Nil(t, err)
+		assert.Equal(t, "update", val)
+	})
+
+	// delete
+	txn(env.db, func(txn *sql.Tx) {
+		err := ea_db.DeleteAnnotation(txn, "1", kind)
+		assert.Nil(t, err)
+	})
+
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.GetAnnotation(txn, "1", kind)
+		assert.Nil(t, err)
+		assert.Equal(t, "", val)
+	})
+
+	// delete again
+	txn(env.db, func(txn *sql.Tx) {
+		err := ea_db.DeleteAnnotation(txn, "1", kind)
+		assert.Nil(t, err)
+	})
+}
+
+func TestCfAnnotationDbOrgLifecycle(t *testing.T) {
+	doTestAnnoDBForKind(t, CF_OBJ_ORG)
+}
+
+func TestCfAnnotationDbSpaceLifecycle(t *testing.T) {
+	doTestAnnoDBForKind(t, CF_OBJ_SPACE)
+}
+
+func TestCfAnnotationDbAppLifecycle(t *testing.T) {
+	doTestAnnoDBForKind(t, CF_OBJ_APP)
+}
+
+func TestCfAnnotationDbInvalidKind(t *testing.T) {
+	env := testCfEnvironment(t)
+	ea_db := EpgAnnotationDb{}
+	kind := CF_OBJ_LAST
+
+	txn, _ := env.db.Begin()
+	err := ea_db.UpdateAnnotation(txn, "1", kind, "add")
+	assert.NotNil(t, err)
+
+	err = ea_db.DeleteAnnotation(txn, "1", kind)
+	assert.NotNil(t, err)
+
+	_, err = ea_db.GetAnnotation(txn, "1", kind)
+	assert.NotNil(t, err)
+
+	txn.Commit()
+}
+
+func TestCfAnnotationDbResolve(t *testing.T) {
+	env := testCfEnvironment(t)
+	ea_db := EpgAnnotationDb{}
+
+	// resolve -> nothing
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.ResolveAnnotation(txn, "1", "2", "3")
+		assert.Nil(t, err)
+		assert.Equal(t, "", val)
+	})
+
+	// add org annotation
+	txn(env.db, func(txn *sql.Tx) {
+		err := ea_db.UpdateAnnotation(txn, "3", CF_OBJ_ORG, "org")
+		assert.Nil(t, err)
+	})
+
+	// resolve and verify
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.ResolveAnnotation(txn, "1", "2", "3")
+		assert.Nil(t, err)
+		assert.Equal(t, "org", val)
+	})
+
+	// add space annotation
+	txn(env.db, func(txn *sql.Tx) {
+		err := ea_db.UpdateAnnotation(txn, "2", CF_OBJ_SPACE, "space")
+		assert.Nil(t, err)
+	})
+
+	// resolve and verify
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.ResolveAnnotation(txn, "1", "2", "3")
+		assert.Nil(t, err)
+		assert.Equal(t, "space", val)
+	})
+
+	// add app annotation
+	txn(env.db, func(txn *sql.Tx) {
+		err := ea_db.UpdateAnnotation(txn, "1", CF_OBJ_APP, "app")
+		assert.Nil(t, err)
+	})
+
+	// resolve and verify
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.ResolveAnnotation(txn, "1", "2", "3")
+		assert.Nil(t, err)
+		assert.Equal(t, "app", val)
+	})
+}
+
+func TestCfAnnotationHttpPathPrefix(t *testing.T) {
+	env := testCfEnvironment(t)
+	h := EpgAnnotationHttpHandler{env: env}
+	assert.Equal(t, "/networking-aci/epg/", h.Path())
+}
+
+func doHttp(t *testing.T, handler *EpgAnnotationHttpHandler, verb, kind, id, data string) (int, string) {
+	var rdr io.Reader
+	if data != "" {
+		str, err := json.Marshal(EpgAnnotationPutMessageBody{Value: data})
+		assert.Nil(t, err)
+		rdr = strings.NewReader(string(str))
+	}
+	req := httptest.NewRequest(verb, "http://localhost/networking-aci/epg/"+kind+"/"+id, rdr)
+	req.Header.Add("Authorization", "Bearer testtoken")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	resp := w.Result()
+	var msg EpgAnnotationGetMessageBody
+	if resp.StatusCode == 200 {
+		assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+		body, _ := ioutil.ReadAll(resp.Body)
+		assert.Nil(t, json.Unmarshal(body, &msg))
+		assert.Equal(t, id, msg.Guid)
+		assert.Equal(t, kind, msg.Kind)
+	}
+	return resp.StatusCode, msg.Value
+}
+
+func doTestAnnoHttpHandlerForKind(t *testing.T, kind string) {
+	env := testCfEnvironment(t)
+	h := &EpgAnnotationHttpHandler{env: env}
+	cont_to_check := []interface{}{"c-1", "c-2"}
+	if kind == "space" {
+		cont_to_check = append(cont_to_check, "c-3")
+	}
+	if kind == "org" {
+		cont_to_check = append(cont_to_check, "c-3", "c-4")
+	}
+
+	var code int
+	var value string
+	obj := kind + "-1"
+
+	// get non-existent
+	code, value = doHttp(t, h, "GET", kind, obj, "")
+	assert.Equal(t, http.StatusNotFound, code)
+	assert.Equal(t, "", value)
+
+	// add
+	code, value = doHttp(t, h, "PUT", kind, obj, "add")
+	assert.Equal(t, http.StatusNoContent, code)
+	assert.Equal(t, "", value)
+
+	// get
+	code, value = doHttp(t, h, "GET", kind, obj, "")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "add", value)
+
+	waitForGetList(t, env.containerUpdateQ, 1000*time.Millisecond, cont_to_check)
+
+	// update
+	code, value = doHttp(t, h, "PUT", kind, obj, "update")
+	assert.Equal(t, http.StatusNoContent, code)
+	assert.Equal(t, "", value)
+
+	// get
+	code, value = doHttp(t, h, "GET", kind, obj, "")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, "update", value)
+
+	waitForGetList(t, env.containerUpdateQ, 1000*time.Millisecond, cont_to_check)
+
+	// delete
+	code, value = doHttp(t, h, "DELETE", kind, obj, "")
+	assert.Equal(t, http.StatusNoContent, code)
+	assert.Equal(t, "", value)
+
+	// get
+	code, value = doHttp(t, h, "GET", kind, obj, "")
+	assert.Equal(t, http.StatusNotFound, code)
+	assert.Equal(t, "", value)
+
+	waitForGetList(t, env.containerUpdateQ, 1000*time.Millisecond, cont_to_check)
+
+	// delete non-existent
+	code, value = doHttp(t, h, "DELETE", kind, obj, "")
+	assert.Equal(t, http.StatusNoContent, code)
+	assert.Equal(t, "", value)
+}
+
+func TestCfAnnotationHttpOrgLifecycle(t *testing.T) {
+	doTestAnnoHttpHandlerForKind(t, "org")
+}
+
+func TestCfAnnotationHttpSpaceLifecycle(t *testing.T) {
+	doTestAnnoHttpHandlerForKind(t, "space")
+}
+
+func TestCfAnnotationHttpAppLifecycle(t *testing.T) {
+	doTestAnnoHttpHandlerForKind(t, "app")
+}
+
+func TestCfAnnotationHttpInvalidKind(t *testing.T) {
+	env := testCfEnvironment(t)
+	h := &EpgAnnotationHttpHandler{env: env}
+	kind := "foo"
+
+	code, _ := doHttp(t, h, "GET", kind, "some-obj", "")
+	assert.Equal(t, http.StatusNotFound, code)
+
+	code, _ = doHttp(t, h, "PUT", kind, "some-obj", "")
+	assert.Equal(t, http.StatusNotFound, code)
+
+	code, _ = doHttp(t, h, "DELETE", kind, "some-obj", "")
+	assert.Equal(t, http.StatusNotFound, code)
+}
+
+func TestCfAnnotationHttpInvalidPath(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := EpgAnnotationHttpHandler{env: env}
+	paths := map[string]int{
+		"foo": http.StatusInternalServerError,
+		"networking-aci/epg/":            http.StatusNotFound,
+		"networking-aci/epg/app":         http.StatusNotFound,
+		"networking-aci/epg/org/foo/bar": http.StatusNotFound,
+	}
+	for p, c := range paths {
+		req := httptest.NewRequest("GET", "http://localhost/"+p, nil)
+		req.Header.Add("Authorization", "Bearer testtoken")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		assert.Equal(t, c, resp.StatusCode)
+	}
+}
+
+func TestCfAnnotationHttpInvalidMethod(t *testing.T) {
+	env := testCfEnvironment(t)
+	h := &EpgAnnotationHttpHandler{env: env}
+
+	for _, v := range []string{"POST", "HEAD", "PATCH"} {
+		code, _ := doHttp(t, h, v, "org", "some-obj", "")
+		assert.Equal(t, http.StatusMethodNotAllowed, code)
+	}
+}
+
+func TestCfAnnotationHttpInvalidPutBody(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := EpgAnnotationHttpHandler{env: env}
+
+	for _, kind := range []string{"org", "space", "app"} {
+		for _, body := range []string{"{\"value\": \"\"}", "{", "{\"foo\": 123}"} {
+			req := httptest.NewRequest(
+				"PUT", "http://localhost/networking-aci/epg/"+kind+"/"+kind+"-1",
+				strings.NewReader(body))
+			req.Header.Add("Authorization", "Bearer testtoken")
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			resp := w.Result()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		}
+	}
+}
+
+func doTestAnnoHttpHandlerAuthForKind(t *testing.T, kind string) {
+	env := testCfEnvironment(t)
+	cc := env.fakeCcClient()
+	ri := cfapi.NewUserRoleInfo("some")
+	ri.Spaces["space-one"] = struct{}{}
+	ri.AuditedSpaces["space-two"] = struct{}{}
+	ri.ManagedSpaces["space-three"] = struct{}{}
+	ri.Organizations["org-one"] = struct{}{}
+	ri.AuditedOrganizations["org-two"] = struct{}{}
+	ri.ManagedOrganizations["org-three"] = struct{}{}
+	cc.On("GetUserRoleInfo", "some").Return(ri, nil)
+
+	auth := env.fakeCfAuthClient()
+	auth.On("FetchTokenInfo", "testtoken-some").Return(
+		&cfapi.TokenInfo{Scope: []string{}, UserId: "some", UserName: "someone"},
+		nil)
+
+	h := &EpgAnnotationHttpHandler{env: env}
+	doHttpOp := func(verb, kind, id string) int {
+		var rdr io.Reader
+		if verb == "PUT" {
+			str, err := json.Marshal(EpgAnnotationPutMessageBody{Value: "epg42"})
+			assert.Nil(t, err)
+			rdr = strings.NewReader(string(str))
+		}
+		req := httptest.NewRequest(verb, "http://localhost/networking-aci/epg/"+kind+"/"+id, rdr)
+		req.Header.Add("Authorization", "Bearer testtoken-some")
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, req)
+		return w.Result().StatusCode
+	}
+
+	var code int
+
+	cc.On("GetAppSpace", "zero").Return("space-zero", nil)
+	code = doHttpOp("GET", kind, "zero")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	code = doHttpOp("PUT", kind, "zero")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	code = doHttpOp("DELETE", kind, "zero")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	cc.On("GetAppSpace", kind+"-one").Return("space-one", nil)
+	code = doHttpOp("GET", kind, kind+"-one")
+	assert.Equal(t, http.StatusNotFound, code)
+
+	code = doHttpOp("PUT", kind, kind+"-one")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	code = doHttpOp("DELETE", kind, kind+"-one")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	cc.On("GetAppSpace", kind+"-two").Return("space-two", nil)
+	code = doHttpOp("GET", kind, kind+"-two")
+	assert.Equal(t, http.StatusNotFound, code)
+
+	code = doHttpOp("PUT", kind, kind+"-two")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	code = doHttpOp("DELETE", kind, kind+"-two")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	cc.On("GetAppSpace", kind+"-three").Return("space-three", nil)
+	code = doHttpOp("PUT", kind, kind+"-three")
+	assert.Equal(t, http.StatusNoContent, code)
+
+	code = doHttpOp("GET", kind, kind+"-three")
+	assert.Equal(t, http.StatusOK, code)
+
+	code = doHttpOp("DELETE", kind, kind+"-three")
+	assert.Equal(t, http.StatusNoContent, code)
+}
+
+func TestCfAnnotationHttpAuthOrg(t *testing.T) {
+	doTestAnnoHttpHandlerAuthForKind(t, "org")
+}
+
+func TestCfAnnotationHttpAuthSpace(t *testing.T) {
+	doTestAnnoHttpHandlerAuthForKind(t, "space")
+}
+
+func TestCfAnnotationHttpAuthApp(t *testing.T) {
+	doTestAnnoHttpHandlerAuthForKind(t, "app")
+}

--- a/pkg/controller/cf_app_ext_ip.go
+++ b/pkg/controller/cf_app_ext_ip.go
@@ -1,0 +1,283 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+)
+
+type AppExtIpDb struct {
+}
+
+type ExtIpAlloc struct {
+	IP      string
+	Dynamic bool
+	Pool    string
+}
+
+type ExtIpAllocApp struct {
+	Guid string
+	ExtIpAlloc
+}
+
+func (db *AppExtIpDb) Get(txn *sql.Tx, appId string) ([]ExtIpAlloc, error) {
+	var ips []ExtIpAlloc
+	rows, err := txn.Query("SELECT ip, dynamic, pool FROM aci_app_ext_ip WHERE guid=? ORDER BY ip ASC", appId)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var ip, pool string
+		var dynamic int
+		if err := rows.Scan(&ip, &dynamic, &pool); err == nil {
+			ips = append(ips, ExtIpAlloc{ip, dynamic != 0, pool})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ips, nil
+}
+
+func (db *AppExtIpDb) List(txn *sql.Tx) ([]ExtIpAllocApp, error) {
+	var ips []ExtIpAllocApp
+	rows, err := txn.Query("SELECT guid, ip, dynamic, pool FROM aci_app_ext_ip ORDER BY guid, ip ASC")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var guid, ip, pool string
+		var dynamic int
+		if err := rows.Scan(&guid, &ip, &dynamic, &pool); err == nil {
+			ips = append(ips, ExtIpAllocApp{guid, ExtIpAlloc{ip, dynamic != 0, pool}})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ips, nil
+}
+
+func (db *AppExtIpDb) Set(txn *sql.Tx, appId string, ips []ExtIpAlloc) error {
+	err := db.Delete(txn, appId)
+	if err != nil {
+		return fmt.Errorf("Error deleting old rows - %s", err.Error())
+	}
+	for _, ip := range ips {
+		dyn := 0
+		if ip.Dynamic {
+			dyn = 1
+		}
+		_, err = txn.Exec("INSERT INTO aci_app_ext_ip(guid, ip, dynamic, pool) VALUES(?, ?, ?, ?)",
+			appId, ip.IP, dyn, ip.Pool)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *AppExtIpDb) Delete(txn *sql.Tx, appId string) error {
+	q := "DELETE FROM aci_app_ext_ip WHERE guid=?"
+	_, err := txn.Exec(q, appId)
+	return err
+}
+
+type AppExtIpHttpHandler struct {
+	env *CfEnvironment
+}
+
+type AppExtIpGetMessageBody struct {
+	Guid string   `json:"guid, omitempty"`
+	IP   []string `json:"ip, omitempty"`
+}
+
+type AppExtIpPutMessageBody struct {
+	IP []string `json:"ip, omitempty"`
+}
+
+func (h *AppExtIpHttpHandler) Path() string {
+	return h.env.cfconfig.ApiPathPrefix + "/app_ext_ip/"
+}
+
+func (h *AppExtIpHttpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	path := req.URL.Path
+	if !strings.HasPrefix(path, h.Path()) {
+		h.env.log.Warning("Asked to handle unknown path: ", path)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if req.Method != http.MethodGet && req.Method != http.MethodPut && req.Method != http.MethodDelete {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	// expect paths of the form <prefix>/<id>
+	parts := strings.Split(path[len(h.Path()):], "/")
+	if len(parts) != 1 || parts[0] == "" {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	appId := parts[0]
+	access := "read"
+	if req.Method != http.MethodGet {
+		access = "write"
+	}
+	ok, err := cfapi.HasAccess(h.env.ccClient, h.env.cfAuthClient, req, "app", appId, access)
+	if err != nil {
+		h.env.log.Warning("Failed to verify authorized access: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	doUpdate := false
+	var new_ips []ExtIpAlloc
+	defer func() {
+		if doUpdate {
+			// update the index
+			var new_ext []string
+			for _, i := range new_ips {
+				new_ext = append(new_ext, i.IP)
+			}
+			h.env.indexLock.Lock()
+			defer h.env.indexLock.Unlock()
+			appInfo := h.env.appIdx[appId]
+			if appInfo == nil {
+				appInfo = NewAppInfo(appId)
+			}
+			appInfo.ExternalIp = new_ext
+			h.env.appIdx[appId] = appInfo
+			// notify change
+			h.env.appUpdateQ.Add(appId)
+			h.env.scheduleAppContainersUpdateLocked(appId)
+		}
+	}()
+
+	aei_db := AppExtIpDb{}
+	txn, err := h.env.db.Begin()
+	if err != nil {
+		h.env.log.Warning("Failed to start DB transaction: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer func() {
+		if err == nil {
+			txn.Commit()
+		} else {
+			txn.Rollback()
+		}
+	}()
+
+	status := 0
+	switch req.Method {
+	case http.MethodGet:
+		var ips []ExtIpAlloc
+		ips, err = aei_db.Get(txn, appId)
+		if err == nil {
+			if ips == nil {
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.Header().Set("Content-Type", "application/json")
+				ips_only := make([]string, 0, len(ips))
+				for _, i := range ips {
+					ips_only = append(ips_only, i.IP)
+				}
+				m := AppExtIpGetMessageBody{Guid: appId, IP: ips_only}
+				json.NewEncoder(w).Encode(m)
+			}
+		}
+	case http.MethodDelete:
+		var ips []ExtIpAlloc
+		ips, err = aei_db.Get(txn, appId)
+		if err != nil {
+			h.env.log.Warn("Failed to read app external IPs: ", err)
+		}
+		err = aei_db.Delete(txn, appId)
+		if err == nil {
+			_, err1 := h.env.ManageAppExtIp(ips, nil, false)
+			if err1 != nil {
+				h.env.log.Warning("Failed to unmanage ext ip: ", err1)
+			}
+			w.WriteHeader(http.StatusNoContent)
+			doUpdate = true
+		}
+	case http.MethodPut:
+		var body []byte
+		body, err = ioutil.ReadAll(req.Body)
+		if err != nil {
+			h.env.log.Warning("Failed to read request body: ", err)
+			break
+		}
+		var msg AppExtIpPutMessageBody
+		dynamic := false
+		err = json.Unmarshal(body, &msg)
+		if err != nil {
+			status = http.StatusBadRequest
+			break
+		}
+		if len(msg.IP) == 0 && dynamic == false {
+			err = fmt.Errorf("Missing data")
+			status = http.StatusBadRequest
+			break
+		}
+		if len(msg.IP) > 0 && dynamic == true {
+			err = fmt.Errorf("Both static and dynamic address cannot be requested")
+			status = http.StatusBadRequest
+			break
+		}
+		ips := make([]ExtIpAlloc, 0, len(msg.IP))
+		for _, i := range msg.IP {
+			ips = append(ips, ExtIpAlloc{IP: i, Dynamic: false, Pool: ""})
+		}
+		var current_ips []ExtIpAlloc
+		current_ips, err = aei_db.Get(txn, appId)
+		if err != nil {
+			h.env.log.Warn("Failed to read app external IPs: ", err)
+			break
+		}
+		new_ips, err = h.env.ManageAppExtIp(current_ips, ips, dynamic)
+		if err == nil {
+			err = aei_db.Set(txn, appId, new_ips)
+		} else {
+			h.env.log.Error("Updating external IPs failed: ", err)
+			status = http.StatusBadRequest
+		}
+		if err == nil {
+			w.WriteHeader(http.StatusNoContent)
+			doUpdate = true
+		}
+	}
+	if err != nil {
+		if status == 0 {
+			h.env.log.Warning("Failed to update DB for app ext ip: ", err)
+			status = http.StatusInternalServerError
+		} else {
+			h.env.log.Debug("Request failed: ", err)
+		}
+		w.WriteHeader(status)
+	}
+}

--- a/pkg/controller/cf_app_ext_ip_test.go
+++ b/pkg/controller/cf_app_ext_ip_test.go
@@ -1,0 +1,319 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+	//	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func TestCfAppExtIpDbOps(t *testing.T) {
+	env := testCfEnvironment(t)
+	ipdb := AppExtIpDb{}
+
+	// set v4 & v6
+	ip1 := ExtIpAlloc{"1.2.3.4", false, "p1"}
+	ip2 := ExtIpAlloc{"2.3.4.4", true, "p2"}
+	ip3 := ExtIpAlloc{"::fe80", false, "p1"}
+
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "1", []ExtIpAlloc{ip1, ip2, ip3})
+		assert.Nil(t, err)
+	})
+
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		ips, err := ipdb.Get(txn, "1")
+		assert.Nil(t, err)
+		assert.Equal(t, []ExtIpAlloc{ip1, ip2, ip3}, ips)
+	})
+
+	// list
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ipdb.List(txn)
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(val))
+		assert.Equal(t, "1", val[0].Guid)
+		assert.Equal(t, "1", val[1].Guid)
+		assert.Equal(t, "1", val[2].Guid)
+	})
+
+	// reset
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "1", nil)
+		assert.Nil(t, err)
+	})
+
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		ips, err := ipdb.Get(txn, "1")
+		assert.Nil(t, err)
+		assert.Nil(t, ips)
+	})
+
+	// set only v4
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "1", []ExtIpAlloc{ip1, ip2})
+		assert.Nil(t, err)
+	})
+
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		ips, err := ipdb.Get(txn, "1")
+		assert.Nil(t, err)
+		assert.Equal(t, []ExtIpAlloc{ip1, ip2}, ips)
+	})
+
+	// delete
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Delete(txn, "1")
+		assert.Nil(t, err)
+	})
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		ips, err := ipdb.Get(txn, "1")
+		assert.Nil(t, err)
+		assert.Nil(t, ips)
+	})
+
+	// delete again
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Delete(txn, "1")
+		assert.Nil(t, err)
+	})
+}
+
+func TestCfAppExtIpDbList(t *testing.T) {
+	env := testCfEnvironment(t)
+	ipdb := AppExtIpDb{}
+
+	a := make([][]ExtIpAlloc, 0)
+	aa := make([]ExtIpAllocApp, 0)
+	ids := []string{"1", "2", "3", "4"}
+	for _, id := range ids {
+		ip1 := ExtIpAlloc{id + ".2.3.4", false, "p1"}
+		ip2 := ExtIpAlloc{id + ".3.3.4", true, "p2"}
+		ip3 := ExtIpAlloc{"::fe80" + id, false, "p1"}
+		a = append(a, []ExtIpAlloc{ip1, ip2, ip3})
+		aa = append(aa, ExtIpAllocApp{id, ip1}, ExtIpAllocApp{id, ip2}, ExtIpAllocApp{id, ip3})
+	}
+	txn(env.db, func(txn *sql.Tx) {
+		assert.Nil(t, ipdb.Set(txn, ids[0], a[0]))
+		assert.Nil(t, ipdb.Set(txn, ids[1], a[1]))
+		assert.Nil(t, ipdb.Set(txn, ids[2], a[2]))
+		assert.Nil(t, ipdb.Set(txn, ids[3], a[3]))
+	})
+	txn(env.db, func(txn *sql.Tx) {
+		res, err := ipdb.List(txn)
+		assert.Nil(t, err)
+		assert.Equal(t, aa, res)
+	})
+}
+
+func TestCfAppExtIpHttpHandler(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := &AppExtIpHttpHandler{env: env}
+
+	doHttpOp := func(verb, id string, ips []string) (int, []string) {
+		var rdr io.Reader
+		if ips != nil {
+			str, err := json.Marshal(AppExtIpPutMessageBody{IP: ips})
+			assert.Nil(t, err)
+			rdr = strings.NewReader(string(str))
+		}
+		req := httptest.NewRequest(verb, "http://localhost/networking-aci/app_ext_ip/"+id, rdr)
+		req.Header.Add("Authorization", "Bearer testtoken")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		var msg AppExtIpGetMessageBody
+		if resp.StatusCode == 200 {
+			assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+			body, _ := ioutil.ReadAll(resp.Body)
+			assert.Nil(t, json.Unmarshal(body, &msg))
+			assert.Equal(t, id, msg.Guid)
+		}
+		return resp.StatusCode, msg.IP
+	}
+
+	var code int
+	var ips []string
+	obj := "app-1"
+	cont_to_check := []interface{}{"c-1", "c-2"}
+
+	// get non-existent
+	code, ips = doHttpOp("GET", obj, nil)
+	assert.Equal(t, http.StatusNotFound, code)
+	assert.Nil(t, ips)
+
+	// add
+	code, ips = doHttpOp("PUT", obj, []string{"1.2.3.4", "::2fee"})
+	assert.Equal(t, http.StatusNoContent, code)
+	assert.Nil(t, ips)
+
+	// get
+	code, ips = doHttpOp("GET", obj, nil)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{"1.2.3.4", "::2fee"}, ips)
+
+	assert.Equal(t, []string{"1.2.3.4", "::2fee"}, env.appIdx[obj].ExternalIp)
+	waitForGet(t, env.appUpdateQ, 500*time.Millisecond, "app-1")
+	waitForGetList(t, env.containerUpdateQ, 1000*time.Millisecond, cont_to_check)
+
+	// update
+	code, ips = doHttpOp("PUT", obj, []string{"1.2.3.5"})
+	assert.Equal(t, http.StatusNoContent, code)
+	assert.Nil(t, ips)
+
+	// get
+	code, ips = doHttpOp("GET", obj, nil)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{"1.2.3.5"}, ips)
+
+	assert.Equal(t, []string{"1.2.3.5"}, env.appIdx[obj].ExternalIp)
+	waitForGet(t, env.appUpdateQ, 500*time.Millisecond, "app-1")
+	waitForGetList(t, env.containerUpdateQ, 1000*time.Millisecond, cont_to_check)
+
+	// delete
+	code, ips = doHttpOp("DELETE", obj, nil)
+	assert.Equal(t, http.StatusNoContent, code)
+	assert.Nil(t, ips)
+
+	// get
+	code, ips = doHttpOp("GET", obj, nil)
+	assert.Equal(t, http.StatusNotFound, code)
+	assert.Nil(t, ips)
+
+	assert.Equal(t, 0, len(env.appIdx[obj].ExternalIp))
+	waitForGet(t, env.appUpdateQ, 500*time.Millisecond, "app-1")
+	waitForGetList(t, env.containerUpdateQ, 1000*time.Millisecond, cont_to_check)
+
+	// delete non-existent
+	code, ips = doHttpOp("DELETE", obj, nil)
+	assert.Equal(t, http.StatusNoContent, code)
+	assert.Nil(t, ips)
+}
+
+func TestCfAppExtIpHttpInvalidPath(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := &AppExtIpHttpHandler{env: env}
+	paths := map[string]int{
+		"foo": http.StatusInternalServerError,
+		"networking-aci/app_ext_ip/":         http.StatusNotFound,
+		"networking-aci/app_ext_ip/foo/1234": http.StatusNotFound,
+	}
+	for p, c := range paths {
+		req := httptest.NewRequest("GET", "http://localhost/"+p, nil)
+		req.Header.Add("Authorization", "Bearer testtoken")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		assert.Equal(t, c, resp.StatusCode)
+	}
+}
+
+func TestCfAppExtIpHttpInvalidMethod(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := &AppExtIpHttpHandler{env: env}
+
+	for _, v := range []string{"POST", "HEAD", "PATCH"} {
+		req := httptest.NewRequest(v, "http://localhost/networking-aci/app_ext_ip/1234", nil)
+		req.Header.Add("Authorization", "Bearer testtoken")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Result().StatusCode)
+	}
+}
+
+func TestCfAppExtIpHttpAuth(t *testing.T) {
+	env := testCfEnvironment(t)
+	cc := env.fakeCcClient()
+	ri := cfapi.NewUserRoleInfo("some")
+	ri.Spaces["space-one"] = struct{}{}
+	ri.AuditedSpaces["space-two"] = struct{}{}
+	ri.ManagedSpaces["space-three"] = struct{}{}
+	cc.On("GetUserRoleInfo", "some").Return(ri, nil)
+
+	auth := env.fakeCfAuthClient()
+	auth.On("FetchTokenInfo", "testtoken-some").Return(
+		&cfapi.TokenInfo{Scope: []string{}, UserId: "some", UserName: "someone"},
+		nil)
+
+	handler := &AppExtIpHttpHandler{env: env}
+
+	doHttpOp := func(verb, id string) int {
+		req := httptest.NewRequest(verb, "http://localhost/networking-aci/app_ext_ip/"+id, nil)
+		req.Header.Add("Authorization", "Bearer testtoken-some")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Result().StatusCode
+	}
+
+	var code int
+
+	cc.On("GetAppSpace", "zero").Return("space-zero", nil)
+	code = doHttpOp("GET", "zero")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	code = doHttpOp("PUT", "zero")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	code = doHttpOp("DELETE", "zero")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	cc.On("GetAppSpace", "one").Return("space-one", nil)
+	code = doHttpOp("GET", "one")
+	assert.Equal(t, http.StatusNotFound, code)
+
+	code = doHttpOp("PUT", "one")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	code = doHttpOp("DELETE", "one")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	cc.On("GetAppSpace", "two").Return("space-two", nil)
+	code = doHttpOp("GET", "two")
+	assert.Equal(t, http.StatusNotFound, code)
+
+	code = doHttpOp("PUT", "two")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	code = doHttpOp("DELETE", "two")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	cc.On("GetAppSpace", "three").Return("space-three", nil)
+	code = doHttpOp("PUT", "three")
+	assert.Equal(t, http.StatusBadRequest, code)
+
+	code = doHttpOp("GET", "three")
+	assert.Equal(t, http.StatusNotFound, code)
+
+	code = doHttpOp("DELETE", "three")
+	assert.Equal(t, http.StatusNoContent, code)
+}

--- a/pkg/controller/cf_app_vip.go
+++ b/pkg/controller/cf_app_vip.go
@@ -1,0 +1,155 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+)
+
+type AppVipDb struct {
+}
+
+func (db *AppVipDb) Get(txn *sql.Tx, appId string) (string, string, error) {
+	var v4, v6 string
+	err := txn.QueryRow("SELECT ip_v4, ip_v6 FROM aci_app_vip WHERE guid=?",
+		appId).Scan(&v4, &v6)
+	if err == nil {
+		return v4, v6, nil
+	} else if err == sql.ErrNoRows {
+		return "", "", nil
+	}
+	return "", "", err
+}
+
+func (db *AppVipDb) Set(txn *sql.Tx, appId, v4, v6 string) error {
+	res, err := txn.Exec("UPDATE aci_app_vip SET ip_v4=?, ip_v6=? WHERE guid=?",
+		v4, v6, appId)
+	if err != nil {
+		return err
+	}
+	nrows, _ := res.RowsAffected()
+	if nrows == 0 {
+		_, err = txn.Exec("INSERT INTO aci_app_vip(guid, ip_v4, ip_v6) VALUES(?, ?, ?)",
+			appId, v4, v6)
+	}
+	return err
+}
+
+func (db *AppVipDb) Delete(txn *sql.Tx, appId string) error {
+	q := "DELETE FROM aci_app_vip WHERE guid=?"
+	_, err := txn.Exec(q, appId)
+	return err
+}
+
+type VipAllocApp struct {
+	Guid string
+	IPv4 string
+	IPv6 string
+}
+
+func (db *AppVipDb) List(txn *sql.Tx) ([]VipAllocApp, error) {
+	var ips []VipAllocApp
+	rows, err := txn.Query("SELECT guid, ip_v4, ip_v6 FROM aci_app_vip ORDER BY guid ASC")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var guid, ip_v4, ip_v6 string
+		if err := rows.Scan(&guid, &ip_v4, &ip_v6); err == nil {
+			ips = append(ips, VipAllocApp{guid, ip_v4, ip_v6})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ips, nil
+}
+
+type AppVipHttpHandler struct {
+	env *CfEnvironment
+}
+
+type AppVipGetMessageBody struct {
+	Guid string   `json:"guid, omitempty"`
+	IP   []string `json:"ip, omitempty"`
+}
+
+func (h *AppVipHttpHandler) Path() string {
+	return h.env.cfconfig.ApiPathPrefix + "/app_vip/"
+}
+
+func (h *AppVipHttpHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	path := req.URL.Path
+	if !strings.HasPrefix(path, h.Path()) {
+		h.env.log.Warning("Asked to handle unknown path: ", path)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if req.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	// expect paths of the form <prefix>/<id>
+	parts := strings.Split(path[len(h.Path()):], "/")
+	if len(parts) != 1 || parts[0] == "" {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	ok, err := cfapi.HasAccess(h.env.ccClient, h.env.cfAuthClient, req, "app", parts[0], "read")
+	if err != nil {
+		h.env.log.Warning("Failed to verify authorized access: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		w.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	ipdb := AppVipDb{}
+	txn, err := h.env.db.Begin()
+	if err != nil {
+		h.env.log.Warning("Failed to start DB transaction: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	defer txn.Commit()
+
+	v4, v6, err := ipdb.Get(txn, parts[0])
+	if err == nil {
+		m := AppVipGetMessageBody{Guid: parts[0]}
+		if v4 != "" {
+			m.IP = append(m.IP, v4)
+		}
+		if v6 != "" {
+			m.IP = append(m.IP, v6)
+		}
+		if len(m.IP) == 0 {
+			w.WriteHeader(http.StatusNotFound)
+		} else {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(m)
+		}
+	} else {
+		h.env.log.Warning("Failed to get app virtual ip: ", err)
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/pkg/controller/cf_app_vip_test.go
+++ b/pkg/controller/cf_app_vip_test.go
@@ -1,0 +1,233 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+)
+
+func TestCfAppVipDbOps(t *testing.T) {
+	env := testCfEnvironment(t)
+	ipdb := AppVipDb{}
+
+	// set v4 & v6
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "1", "1.2.3.4", "::fe80")
+		assert.Nil(t, err)
+	})
+
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		v4, v6, err := ipdb.Get(txn, "1")
+		assert.Nil(t, err)
+		assert.Equal(t, "1.2.3.4", v4)
+		assert.Equal(t, "::fe80", v6)
+	})
+
+	// list
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ipdb.List(txn)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(val))
+		assert.Equal(t, "1", val[0].Guid)
+	})
+
+	// reset
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "1", "", "")
+		assert.Nil(t, err)
+	})
+
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		v4, v6, err := ipdb.Get(txn, "1")
+		assert.Nil(t, err)
+		assert.Equal(t, "", v4)
+		assert.Equal(t, "", v6)
+	})
+
+	// set only v4
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "1", "1.2.3.4", "")
+		assert.Nil(t, err)
+	})
+
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		v4, v6, err := ipdb.Get(txn, "1")
+		assert.Nil(t, err)
+		assert.Equal(t, "1.2.3.4", v4)
+		assert.Equal(t, "", v6)
+	})
+
+	// delete
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Delete(txn, "1")
+		assert.Nil(t, err)
+	})
+	// verify
+	txn(env.db, func(txn *sql.Tx) {
+		v4, v6, err := ipdb.Get(txn, "1")
+		assert.Nil(t, err)
+		assert.Equal(t, "", v4)
+		assert.Equal(t, "", v6)
+	})
+
+	// delete again
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Delete(txn, "1")
+		assert.Nil(t, err)
+	})
+}
+
+func TestCfAppVipHttpHandler(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := &AppVipHttpHandler{env: env}
+
+	doHttpGet := func(id string) (int, []string) {
+		req := httptest.NewRequest("GET", "http://localhost/networking-aci/app_vip/"+id, nil)
+		req.Header.Add("Authorization", "Bearer testtoken")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		var msg AppVipGetMessageBody
+		if resp.StatusCode == 200 {
+			assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+			body, _ := ioutil.ReadAll(resp.Body)
+			assert.Nil(t, json.Unmarshal(body, &msg))
+			assert.Equal(t, id, msg.Guid)
+		}
+		return resp.StatusCode, msg.IP
+	}
+
+	var code int
+	var ips []string
+	code, ips = doHttpGet("app-1")
+	assert.Equal(t, http.StatusNotFound, code)
+	assert.Nil(t, ips)
+
+	ipdb := AppVipDb{}
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "app-1", "1.2.3.4", "")
+		assert.Nil(t, err)
+	})
+	code, ips = doHttpGet("app-1")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{"1.2.3.4"}, ips)
+
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "app-1", "1.2.3.4", "::fe80")
+		assert.Nil(t, err)
+	})
+	code, ips = doHttpGet("app-1")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, []string{"1.2.3.4", "::fe80"}, ips)
+}
+
+func TestCfAppVipHttpInvalidPath(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := &AppVipHttpHandler{env: env}
+	paths := map[string]int{
+		"foo": http.StatusInternalServerError,
+		"networking-aci/app_vip/":         http.StatusNotFound,
+		"networking-aci/app_vip/foo/1234": http.StatusNotFound,
+	}
+	for p, c := range paths {
+		req := httptest.NewRequest("GET", "http://localhost/"+p, nil)
+		req.Header.Add("Authorization", "Bearer testtoken")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		resp := w.Result()
+		assert.Equal(t, c, resp.StatusCode)
+	}
+}
+
+func TestCfAppVipHttpInvalidMethod(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := &AppVipHttpHandler{env: env}
+
+	for _, v := range []string{"PUT", "POST", "HEAD", "PATCH", "DELETE"} {
+		req := httptest.NewRequest(v, "http://localhost/networking-aci/app_vip/1234", nil)
+		req.Header.Add("Authorization", "Bearer testtoken")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Result().StatusCode)
+	}
+}
+
+func TestCfAppVipHttpAuth(t *testing.T) {
+	env := testCfEnvironment(t)
+	cc := env.fakeCcClient()
+	ri := cfapi.NewUserRoleInfo("some")
+	ri.Spaces["space-one"] = struct{}{}
+	ri.AuditedSpaces["space-two"] = struct{}{}
+	ri.ManagedSpaces["space-three"] = struct{}{}
+	cc.On("GetUserRoleInfo", "some").Return(ri, nil)
+
+	auth := env.fakeCfAuthClient()
+	auth.On("FetchTokenInfo", "testtoken-some").Return(
+		&cfapi.TokenInfo{Scope: []string{}, UserId: "some", UserName: "someone"},
+		nil)
+
+	handler := &AppVipHttpHandler{env: env}
+	ipdb := AppVipDb{}
+
+	doHttpGet := func(id string) int {
+		req := httptest.NewRequest("GET", "http://localhost/networking-aci/app_vip/"+id, nil)
+		req.Header.Add("Authorization", "Bearer testtoken-some")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		return w.Result().StatusCode
+	}
+
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "zero", "1.2.3.3", "::fe7f")
+		assert.Nil(t, err)
+		err = ipdb.Set(txn, "one", "1.2.3.4", "::fe80")
+		assert.Nil(t, err)
+		err = ipdb.Set(txn, "two", "1.2.3.5", "::fe81")
+		assert.Nil(t, err)
+		err = ipdb.Set(txn, "three", "1.2.3.6", "::fe82")
+		assert.Nil(t, err)
+	})
+	var code int
+
+	cc.On("GetAppSpace", "zero").Return("space-zero", nil)
+	code = doHttpGet("zero")
+	assert.Equal(t, http.StatusForbidden, code)
+
+	cc.On("GetAppSpace", "one").Return("space-one", nil)
+	code = doHttpGet("one")
+	assert.Equal(t, http.StatusOK, code)
+
+	cc.On("GetAppSpace", "two").Return("space-one", nil)
+	code = doHttpGet("two")
+	assert.Equal(t, http.StatusOK, code)
+
+	cc.On("GetAppSpace", "three").Return("space-three", nil)
+	code = doHttpGet("three")
+	assert.Equal(t, http.StatusOK, code)
+}

--- a/pkg/controller/cf_apps.go
+++ b/pkg/controller/cf_apps.go
@@ -1,0 +1,762 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"net"
+	"reflect"
+	"strings"
+	"time"
+
+	"code.cloudfoundry.org/bbs/models"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	etcdclient "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+
+	"github.com/noironetworks/aci-containers/pkg/apicapi"
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+)
+
+type ContainerInfo struct {
+	ContainerId   string
+	CellId        string
+	InstanceIndex int32
+	IpAddress     string
+	Ports         []*models.PortMapping
+	AppId         string
+	TaskName      string
+}
+
+func (a *ContainerInfo) IsStaging() bool {
+	return a.InstanceIndex == etcd.INST_IDX_STAGING
+}
+
+func (a *ContainerInfo) IsApp() bool {
+	return a.InstanceIndex >= 0
+}
+
+type AppInfo struct {
+	AppId        string
+	SpaceId      string
+	AppName      string
+	ContainerIps map[string]string
+	VipV4        string
+	VipV6        string
+	ExternalIp   []string
+}
+
+func NewAppInfo(appId string) *AppInfo {
+	return &AppInfo{AppId: appId, ContainerIps: make(map[string]string)}
+}
+
+type SpaceInfo struct {
+	SpaceId               string
+	OrgId                 string
+	RunningSecurityGroups []string
+	StagingSecurityGroups []string
+	IsolationSegment      string
+}
+
+type OrgInfo struct {
+	OrgId   string
+	OrgName string
+}
+
+type IsoSegInfo struct {
+	Id   string
+	Name string
+}
+
+func (env *CfEnvironment) constructAppInfo(app *AppAndSpace) *AppInfo {
+	appInfo := NewAppInfo(app.AppId)
+	appInfo.AppName = app.AppName
+	appInfo.SpaceId = app.SpaceId
+
+	aei_db := AppExtIpDb{}
+	txn, _ := env.db.Begin()
+	ext_ip_alloc, err := aei_db.Get(txn, app.AppId)
+	if err != nil {
+		env.log.Error("Failed to get app external IPs: ", err)
+	} else {
+		for _, i := range ext_ip_alloc {
+			appInfo.ExternalIp = append(appInfo.ExternalIp, i.IP)
+		}
+	}
+	txn.Commit()
+
+	appInfo.VipV4, appInfo.VipV6 = env.getOrAllocateAppVip(app.AppId)
+	return appInfo
+}
+
+func (env *CfEnvironment) mergeAppInfo(nw *AppInfo) bool {
+	old := env.appIdx[nw.AppId]
+	if old == nil {
+		env.appIdx[nw.AppId] = nw
+		return true
+	}
+	if nw.AppName == "" {
+		nw.AppName = old.AppName
+	}
+	if nw.SpaceId == "" {
+		nw.SpaceId = old.SpaceId
+	}
+	for k, v := range old.ContainerIps {
+		_, ok := nw.ContainerIps[k]
+		if !ok {
+			nw.ContainerIps[k] = v
+		}
+	}
+	if !reflect.DeepEqual(old, nw) {
+		env.appIdx[nw.AppId] = nw
+		return true
+	}
+	return false
+}
+
+func (env *CfEnvironment) mergeContainerInfo(nw *ContainerInfo) bool {
+	old := env.contIdx[nw.ContainerId]
+	if old == nil {
+		env.contIdx[nw.ContainerId] = nw
+		return true
+	}
+	if nw.AppId == "" {
+		nw.AppId = old.AppId
+	}
+	if nw.CellId == "" {
+		nw.CellId = old.CellId
+	}
+	if nw.IpAddress == "" {
+		nw.IpAddress = old.IpAddress
+	}
+	if !reflect.DeepEqual(old, nw) {
+		env.contIdx[nw.ContainerId] = nw
+		return true
+	}
+	return false
+}
+
+func (env *CfEnvironment) scheduleAppAndSpaceUpdate(appInfo *AppInfo) {
+	if appInfo.SpaceId != "" {
+		env.spaceFetchQ.Add(appInfo.SpaceId)
+	}
+	env.appUpdateQ.Add(appInfo.AppId)
+}
+
+func hashJsonSerializable(obj interface{}) (uint64, error) {
+	js, err := json.Marshal(obj)
+	if err != nil {
+		return 0, err
+	}
+	hasher := fnv.New64()
+	hasher.Reset()
+	_, err = hasher.Write(js)
+	if err != nil {
+		return 0, err
+	}
+	return hasher.Sum64(), nil
+}
+
+func (env *CfEnvironment) GetAdditionalPorts(cinfo *ContainerInfo) []uint32 {
+	var res []uint32
+	for _, pm := range cinfo.Ports {
+		if pm.ContainerPort != env.cfconfig.AppPort && pm.ContainerPort != env.cfconfig.SshPort {
+			res = append(res, pm.ContainerPort)
+		}
+	}
+	return res
+}
+
+func (env *CfEnvironment) fetchSpaceInfo(spaceId *string) (*SpaceInfo, []*cfclient.SecGroup, error) {
+	sp, err := env.ccClient.GetSpaceByGuid(*spaceId)
+	if err != nil {
+		env.log.Error("Error fetching info for space "+*spaceId+": ", err)
+		return nil, nil, err
+	}
+	spi := SpaceInfo{SpaceId: sp.Guid, OrgId: sp.OrganizationGuid}
+
+	// fetch isolation segment info
+	isoseg, err := env.ccClient.GetSpaceIsolationSegment(sp.Guid)
+	if err != nil {
+		env.log.Error("Error fetching isolation segment for space "+*spaceId+": ", err)
+		return &spi, nil, err
+	}
+	if isoseg == "" {
+		isoseg, err = env.ccClient.GetOrgDefaultIsolationSegment(sp.OrganizationGuid)
+		if err != nil {
+			env.log.Error("Error fetching default segment for org "+sp.OrganizationGuid+": ", err)
+			return &spi, nil, err
+		}
+	}
+	spi.IsolationSegment = isoseg
+
+	// fetch ASG info
+	runsg, err := env.ccClient.ListSecGroupsBySpace(*spaceId, false)
+	if err != nil {
+		env.log.Error("Error fetching running ASGs for space "+*spaceId+": ", err)
+		return &spi, nil, err
+	}
+	stagesg, err := env.ccClient.ListSecGroupsBySpace(*spaceId, true)
+	if err != nil {
+		env.log.Error("Error fetching staging ASGs for space "+*spaceId+": ", err)
+		return &spi, nil, err
+	}
+	var allsgs []*cfclient.SecGroup
+	for i, _ := range runsg {
+		spi.RunningSecurityGroups = append(spi.RunningSecurityGroups, runsg[i].Guid)
+		allsgs = append(allsgs, &runsg[i])
+	}
+	for i, _ := range stagesg {
+		spi.StagingSecurityGroups = append(spi.StagingSecurityGroups, stagesg[i].Guid)
+		allsgs = append(allsgs, &stagesg[i])
+	}
+	return &spi, allsgs, nil
+}
+
+func (env *CfEnvironment) spaceFetchQueueHandler(spaceId interface{}) bool {
+	var err error
+	id := spaceId.(string)
+	spi, allsgs, err := env.fetchSpaceInfo(&id)
+	if err != nil {
+		return true
+	}
+	var iseg *cfclient.IsolationSegment
+	if spi.IsolationSegment != "" {
+		iseg, err = env.ccClient.GetIsolationSegmentByGUID(spi.IsolationSegment)
+		if err != nil {
+			env.log.Error("Error fetching info for isolation segment "+spi.IsolationSegment+": ", err)
+			return true
+		}
+	}
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	// update space
+	oldspace := env.spaceIdx[spi.SpaceId]
+	if oldspace == nil || !reflect.DeepEqual(oldspace, spi) {
+		env.spaceIdx[spi.SpaceId] = spi
+		env.log.Debug("Updating containers in space ", spi.SpaceId)
+		env.scheduleSpaceContainersUpdateLocked(spi.SpaceId)
+	}
+	// update ASGs
+	for _, sg := range allsgs {
+		oldsg := env.asgIdx[sg.Guid]
+		newsg := sg
+		if oldsg == nil || !reflect.DeepEqual(oldsg, newsg) {
+			env.asgIdx[sg.Guid] = newsg
+			env.log.Debug("Updating ASG ", newsg.Guid)
+			env.asgUpdateQ.Add(newsg.Guid)
+		}
+	}
+	// update isolation-segment
+	if iseg != nil {
+		env.isoSegIdx[iseg.GUID] = &IsoSegInfo{Id: iseg.GUID, Name: iseg.Name}
+		// TODO: Check if name has changed, and if so update all containers in the isolation segment
+	}
+	return false
+}
+
+func (env *CfEnvironment) cleanupEtcdContainers() error {
+	kapi := env.etcdKeysApi
+	cellKey := etcd.ACI_KEY_BASE
+	resp, err := kapi.Get(context.Background(), cellKey, &etcdclient.GetOptions{Recursive: true})
+	if err != nil {
+		env.log.Error("Unable to fetch etcd container nodes: ", err)
+		return err
+	}
+	var nodes etcdclient.Nodes
+	etcd.FlattenNodes(resp.Node, &nodes)
+
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	for _, n := range nodes {
+		key_parts := strings.Split(n.Key, "/")
+		if len(key_parts) == 6 && key_parts[4] == "containers" {
+			// process keys of the form /aci/cells/<cell-id>/containers/<container-id>
+			cell_id := key_parts[3]
+			cont_id := key_parts[5]
+			c := env.contIdx[cont_id]
+			if c == nil || c.CellId != cell_id {
+				env.log.Info(fmt.Sprintf("Deleting stale container %s on cell %s", cont_id, cell_id))
+				_, err := kapi.Delete(context.Background(), n.Key, &etcdclient.DeleteOptions{Recursive: true})
+				if err != nil {
+					env.log.Error("Error deleting container node: ", err)
+				}
+			}
+		} else if len(key_parts) == 4 && key_parts[2] == "apps" {
+			// process keys of the form /aci/apps/<app-id>
+			appId := key_parts[3]
+			app := env.appIdx[appId]
+			if app == nil {
+				env.log.Info(fmt.Sprintf("Deleting stale app %s", appId))
+				_, err := kapi.Delete(context.Background(), n.Key, &etcdclient.DeleteOptions{Recursive: true})
+				if err != nil {
+					env.log.Error("Error deleting app node: ", err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func NewNetworkPolicyPoller(env *CfEnvironment) *CfPoller {
+
+	pollFunc := func() (map[string]interface{}, interface{}, error) {
+		allNetPol, err := env.netpolClient.GetPolicies()
+		if err != nil {
+			return nil, nil, err
+		}
+		var newRespHashIf interface{}
+		newRespHash, err := hashJsonSerializable(allNetPol)
+		if err != nil {
+			env.log.Warning("Failed to hash network policies response: ", err)
+			newRespHashIf = nil
+		} else {
+			newRespHashIf = &newRespHash
+		}
+		npRead := make(map[string]interface{})
+		for _, npol := range allNetPol {
+			dst := npol.Destination.ID
+			npol.Destination.ID = npol.Source.ID
+
+			npDstIf, ok := npRead[dst]
+			var npDst map[string][]cfapi.Destination
+			if !ok {
+				npDst = make(map[string][]cfapi.Destination)
+			} else {
+				npDst = npDstIf.(map[string][]cfapi.Destination)
+			}
+			npDst[npol.Source.ID] = append(npDst[npol.Source.ID], npol.Destination)
+			npRead[dst] = npDst
+		}
+		return npRead, newRespHashIf, nil
+	}
+
+	handleFunc := func(updates map[string]interface{}, deletes map[string]interface{}) {
+		env.indexLock.Lock()
+		defer env.indexLock.Unlock()
+
+		for k, v := range updates {
+			env.log.Debug(fmt.Sprintf("Add/update net pol %s: %+v", k, v))
+			env.netpolIdx[k] = v.(map[string][]cfapi.Destination)
+
+			hpp := env.createHppForNetPol(&k)
+			env.cont.apicConn.WriteApicObjects("np:"+k, hpp)
+			env.scheduleAppContainersUpdateLocked(k)
+		}
+		for k, _ := range deletes {
+			env.log.Debug("Delete net pol ", k)
+			delete(env.netpolIdx, k)
+			env.cont.apicConn.ClearApicObjects("np:" + k)
+			env.scheduleAppContainersUpdateLocked(k)
+		}
+	}
+	pollInterval := time.Duration(env.cfconfig.NetPolPollingInterval) * time.Second
+	errDelay := 10 * time.Second
+	return NewCfPoller("Network-policy", pollInterval, errDelay, pollFunc, handleFunc, env.log)
+}
+
+func (env *CfEnvironment) createHppForNetPol(polId *string) apicapi.ApicSlice {
+	// must be called with index lock
+
+	npApicName := env.cont.aciNameForKey("np", *polId)
+	hpp := apicapi.NewHostprotPol(env.cont.config.AciPolicyTenant, npApicName)
+	for srcId, info := range env.netpolIdx[*polId] {
+		ingressSubj := apicapi.NewHostprotSubj(hpp.GetDn(), "in-"+srcId)
+		subjDn := ingressSubj.GetDn()
+		for i, rule := range info {
+			hpr := apicapi.NewHostprotRule(subjDn, fmt.Sprintf("rule_%d", i))
+			hpr.SetAttr("direction", "ingress")
+			hpr.SetAttr("ethertype", "ipv4") // TODO fix for v6
+			hpr.SetAttr("protocol", rule.Protocol)
+			hpr.SetAttr("fromPort", fmt.Sprintf("%d", rule.Ports.Start))
+			hpr.SetAttr("toPort", fmt.Sprintf("%d", rule.Ports.End))
+
+			app := env.appIdx[srcId]
+			if app != nil {
+				for _, ip := range app.ContainerIps {
+					hpremote := apicapi.NewHostprotRemoteIp(hpr.GetDn(), ip)
+					hpr.AddChild(hpremote)
+				}
+			}
+			ingressSubj.AddChild(hpr)
+		}
+		hpp.AddChild(ingressSubj)
+	}
+	return apicapi.ApicSlice{hpp}
+}
+
+func (env *CfEnvironment) getOrAllocateAppVip(appId string) (string, string) {
+	txn, _ := env.db.Begin()
+	defer txn.Commit()
+	ipdb := AppVipDb{}
+
+	db_v4, db_v6, err := ipdb.Get(txn, appId)
+	if err != nil {
+		env.log.Error("Failed to get app virtual IP: ", err)
+		return "", ""
+	}
+
+	var v4, v6 net.IP
+	var new_v4, new_v6 string
+	if db_v4 != "" {
+		v4 = net.ParseIP(db_v4)
+	}
+	if v4 == nil {
+		v4, _ = env.appVips.V4.GetIp()
+		if v4 != nil {
+			env.log.Debug(fmt.Sprintf("Allocated v4 VIP %s to app %s", v4.String(), appId))
+		}
+	}
+	if v4 != nil {
+		new_v4 = v4.String()
+	}
+
+	if db_v6 != "" {
+		v6 = net.ParseIP(db_v6)
+	}
+	if v6 == nil {
+		v6, _ = env.appVips.V6.GetIp()
+		if v6 != nil {
+			env.log.Debug(fmt.Sprintf("Allocated v6 VIP %s to app %s", v6.String(), appId))
+		}
+	}
+	if v6 != nil {
+		new_v6 = v6.String()
+	}
+
+	if db_v4 != new_v4 || db_v6 != new_v6 {
+		err = ipdb.Set(txn, appId, new_v4, new_v6)
+		if err != nil {
+			env.log.Error("Failed to set app virtual IP: ", err)
+			if v4 != nil {
+				env.appVips.V4.AddIp(v4)
+			}
+			if v6 != nil {
+				env.appVips.V6.AddIp(v6)
+			}
+			return "", ""
+		}
+	}
+	return new_v4, new_v6
+}
+
+func (env *CfEnvironment) LoadEpgAnnotations() {
+	txn, _ := env.db.Begin()
+	defer txn.Commit()
+	epgdb := EpgAnnotationDb{}
+
+	objs, err := epgdb.List(txn, CF_OBJ_LAST)
+	if err != nil {
+		env.log.Warn("Unable to load EPG annotations from DB: ", err)
+		return
+	}
+
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	for _, obj := range objs {
+		env.lookupOrCreate(obj.Guid, obj.Kind)
+	}
+}
+
+// must be called with index lock
+func (env *CfEnvironment) lookupOrCreate(objId string, kind int) interface{} {
+	var res interface{}
+	switch kind {
+	case CF_OBJ_APP:
+		ainfo := env.appIdx[objId]
+		if ainfo == nil {
+			ainfo = NewAppInfo(objId)
+		}
+		env.appIdx[objId] = ainfo
+		res = ainfo
+	case CF_OBJ_SPACE:
+		sinfo := env.spaceIdx[objId]
+		if sinfo == nil {
+			sinfo = &SpaceInfo{SpaceId: objId}
+		}
+		env.spaceIdx[objId] = sinfo
+		res = sinfo
+	case CF_OBJ_ORG:
+		oinfo := env.orgIdx[objId]
+		if oinfo == nil {
+			oinfo = &OrgInfo{OrgId: objId}
+		}
+		env.orgIdx[objId] = oinfo
+		res = oinfo
+	}
+	return res
+}
+
+func (env *CfEnvironment) cleanupEpgAnnotation(objId string, kind int) {
+	ea_db := EpgAnnotationDb{}
+	txn, _ := env.db.Begin()
+
+	err := ea_db.DeleteAnnotation(txn, objId, kind)
+	if err == nil {
+		txn.Commit()
+	} else {
+		env.log.Error("Failed to delete epg annotation: ", err)
+		txn.Rollback()
+	}
+}
+
+func (env *CfEnvironment) releaseAppVip(appId string) {
+	txn, _ := env.db.Begin()
+	ipdb := AppVipDb{}
+
+	db_v4, db_v6, err := ipdb.Get(txn, appId)
+	if err != nil {
+		env.log.Error("Failed to get app virtual IP: ", err)
+		return
+	}
+	err = ipdb.Delete(txn, appId)
+	if err != nil {
+		env.log.Error("Failed to delete app virtual IP: ", err)
+		txn.Rollback()
+		return
+	}
+	if db_v4 != "" {
+		v4 := net.ParseIP(db_v4)
+		if v4 != nil {
+			env.appVips.V4.AddIp(v4)
+		}
+	}
+	if db_v6 != "" {
+		v6 := net.ParseIP(db_v6)
+		if v6 != nil {
+			env.appVips.V6.AddIp(v6)
+		}
+	}
+	txn.Commit()
+}
+
+func (env *CfEnvironment) LoadAppVips() {
+	txn, _ := env.db.Begin()
+	defer txn.Commit()
+	ipdb := AppVipDb{}
+
+	ips, err := ipdb.List(txn)
+	if err != nil {
+		env.log.Warn("Unable to load app virtual IPs from DB: ", err)
+		return
+	}
+
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	for _, ipa := range ips {
+		ainfo := env.appIdx[ipa.Guid]
+		if ainfo == nil {
+			ainfo = NewAppInfo(ipa.Guid)
+		}
+		ainfo.VipV4 = ipa.IPv4
+		ainfo.VipV6 = ipa.IPv6
+		env.appIdx[ipa.Guid] = ainfo
+		v4 := net.ParseIP(ipa.IPv4)
+		if v4 != nil && v4.To4() != nil {
+			env.appVips.V4.RemoveIp(v4) // TODO reset IP if this fails
+		}
+		v6 := net.ParseIP(ipa.IPv6)
+		if v6 != nil && v6.To16() != nil {
+			env.appVips.V6.RemoveIp(v6) // TODO reset IP if this fails
+		}
+	}
+}
+
+func (env *CfEnvironment) releaseAppExtIp(appId string) {
+	aei_db := AppExtIpDb{}
+	txn, _ := env.db.Begin()
+
+	ips, err := aei_db.Get(txn, appId)
+	if err != nil {
+		env.log.Warn("Failed to read app external IP: ", err)
+		return
+	}
+	err = aei_db.Delete(txn, appId)
+	if err != nil {
+		env.log.Error("Failed to delete app external IP: ", err)
+		txn.Rollback()
+		return
+	}
+	env.ManageAppExtIp(ips, nil, false)
+	txn.Commit()
+}
+
+func (env *CfEnvironment) LoadAppExtIps() {
+	txn, _ := env.db.Begin()
+	defer txn.Commit()
+	ipdb := AppExtIpDb{}
+
+	ips, err := ipdb.List(txn)
+	if err != nil {
+		env.log.Warn("Unable to load app external IPs from DB: ", err)
+		return
+	}
+
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	env.cont.indexMutex.Lock()
+	defer env.cont.indexMutex.Unlock()
+
+	for _, ipa := range ips {
+		ainfo := env.appIdx[ipa.Guid]
+		if ainfo == nil {
+			ainfo = NewAppInfo(ipa.Guid)
+		}
+		ainfo.ExternalIp = append(ainfo.ExternalIp, ipa.IP)
+		env.appIdx[ipa.Guid] = ainfo
+		ip := net.ParseIP(ipa.IP)
+		if ip == nil {
+			continue
+		}
+		if ipa.Dynamic {
+			env.cont.serviceIps.RemoveIp(ip)
+		} else {
+			if ip.To4() != nil {
+				env.cont.staticServiceIps.V4.RemoveIp(ip)
+			} else if ip != nil && ip.To16() != nil {
+				env.cont.staticServiceIps.V6.RemoveIp(ip)
+			}
+		}
+	}
+}
+
+func (env *CfEnvironment) ManageAppExtIp(current []ExtIpAlloc, requestedStatic []ExtIpAlloc,
+	requestedDynamic bool) ([]ExtIpAlloc, error) {
+
+	currentDynamic := make([]*ExtIpAlloc, 0)
+	currentStatic := make(map[string]*ExtIpAlloc, 0)
+	for i, _ := range current {
+		if current[i].Dynamic {
+			currentDynamic = append(currentDynamic, &current[i])
+		} else {
+			currentStatic[current[i].IP] = &current[i]
+		}
+	}
+
+	env.cont.indexMutex.Lock()
+	defer env.cont.indexMutex.Unlock()
+
+	// cleanup function on errors
+	staticAllocatedV4 := make([]net.IP, 0)
+	staticAllocatedV6 := make([]net.IP, 0)
+	var err error
+	defer func() {
+		if err != nil {
+			for _, i := range staticAllocatedV4 {
+				env.log.Debug("Error, returned static external IP: ", i.String())
+				env.cont.staticServiceIps.V4.AddIp(i)
+			}
+			for _, i := range staticAllocatedV6 {
+				env.log.Debug("Error, returned static external IP: ", i.String())
+				env.cont.staticServiceIps.V6.AddIp(i)
+			}
+		}
+	}()
+
+	// Allocate requested new static IPs
+	for i, _ := range requestedStatic {
+		ipa := &requestedStatic[i]
+		if _, ok := currentStatic[ipa.IP]; ok {
+			continue
+		}
+		ip := net.ParseIP(ipa.IP)
+		if ip == nil {
+			err = fmt.Errorf("Invalid IP requested %s", ipa.IP)
+			return nil, err
+		}
+		if ip.To4() != nil {
+			if !env.cont.staticServiceIps.V4.RemoveIp(ip) {
+				err = fmt.Errorf("Requested IP %s unavailable", ipa.IP)
+				env.log.Debug("Requested static IP unavailable: ", ipa.IP)
+				return nil, err
+			}
+			env.log.Debug("Allocated static external IP ", ipa.IP)
+			staticAllocatedV4 = append(staticAllocatedV4, ip)
+		} else if ip.To16() != nil {
+			if !env.cont.staticServiceIps.V6.RemoveIp(ip) {
+				err = fmt.Errorf("Requested IP %s unavailable", ipa.IP)
+				env.log.Debug("Requested static IP unavailable: ", ipa.IP)
+				return nil, err
+			}
+			env.log.Debug("Allocated static external IP ", ipa.IP)
+			staticAllocatedV6 = append(staticAllocatedV6, ip)
+		} else {
+			err = fmt.Errorf("Invalid IP requested %s", ipa.IP)
+			return nil, err
+		}
+	}
+	// remove processed IPs from currentStatic
+	for i, _ := range requestedStatic {
+		delete(currentStatic, requestedStatic[i].IP)
+	}
+
+	if requestedDynamic {
+		// Allocate dynamic IPs and append them to requestedStatic
+		if len(currentDynamic) == 0 {
+			ipv4, _ := env.cont.serviceIps.AllocateIp(true)
+			if ipv4 != nil {
+				requestedStatic = append(requestedStatic, ExtIpAlloc{IP: ipv4.String(), Dynamic: true, Pool: ""})
+				env.log.Debug("Allocated dynamic external IP ", ipv4.String())
+			}
+			ipv6, _ := env.cont.serviceIps.AllocateIp(false)
+			if ipv6 != nil {
+				requestedStatic = append(requestedStatic, ExtIpAlloc{IP: ipv6.String(), Dynamic: true, Pool: ""})
+				env.log.Debug("Allocated dynamic external IP ", ipv6.String())
+			}
+			if ipv4 == nil && ipv6 == nil {
+				err = fmt.Errorf("Unable to assign dynamic address")
+				env.log.Debug("Dynamic external IP unavailable")
+				return nil, err
+			}
+		}
+		// Add current dynamic IPs if any
+		for _, ipa := range currentDynamic {
+			requestedStatic = append(requestedStatic, *ipa)
+		}
+	}
+	// At this point new allocations are done, and we don't expect any more errors
+
+	// Return unused static IPs
+	for _, ipa := range currentStatic {
+		ip := net.ParseIP(ipa.IP)
+		if ip != nil && ip.To4() != nil {
+			env.log.Debug("Unused, returned static external IP: ", ip.String())
+			env.cont.staticServiceIps.V4.AddIp(ip)
+		} else if ip != nil && ip.To16() != nil {
+			env.log.Debug("Unused, returned static external IP: ", ip.String())
+			env.cont.staticServiceIps.V6.AddIp(ip)
+		}
+	}
+	// Return unused dynamic IPs
+	if !requestedDynamic && len(currentDynamic) > 0 {
+		for _, ipa := range currentDynamic {
+			ip := net.ParseIP(ipa.IP)
+			if ip != nil {
+				env.log.Debug("Unused, returned dynamic external IP: ", ip.String())
+				env.cont.serviceIps.DeallocateIp(ip)
+			}
+		}
+	}
+	return requestedStatic, nil
+}

--- a/pkg/controller/cf_apps_test.go
+++ b/pkg/controller/cf_apps_test.go
@@ -1,0 +1,322 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"net"
+	"testing"
+	"time"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+)
+
+func TestCfSpaceFetchQueueHandler(t *testing.T) {
+	env := testCfEnvironment(t)
+	cc := env.fakeCcClient()
+
+	sp := cfclient.Space{Guid: "space-2", Name: "SPACE2", OrganizationGuid: "org-1"}
+	cc.On("GetSpaceByGuid", "space-2").Return(sp, nil)
+	cc.On("GetSpaceIsolationSegment", "space-2").Return("", nil).Once()
+	cc.On("GetOrgDefaultIsolationSegment", "org-1").Return("iso-org-1", nil)
+
+	is_space_2 := &cfclient.IsolationSegment{GUID: "iso-space-2", Name: "space-private"}
+	is_org_1 := &cfclient.IsolationSegment{GUID: "iso-org-1", Name: "org-private"}
+	cc.On("GetIsolationSegmentByGUID", "iso-space-2").Return(is_space_2, nil)
+	cc.On("GetIsolationSegmentByGUID", "iso-org-1").Return(is_org_1, nil)
+
+	asg_stage := cfclient.SecGroup{Guid: "stagesg"}
+	asg_run := cfclient.SecGroup{Guid: "runsg"}
+	asg_s1 := cfclient.SecGroup{Guid: "ASG_S1"}
+	asg_r1 := cfclient.SecGroup{Guid: "ASG_R1"}
+	cc.On("ListSecGroupsBySpace", "space-2", true).Return(
+		[]cfclient.SecGroup{asg_stage, asg_s1}, nil)
+	cc.On("ListSecGroupsBySpace", "space-2", false).Return(
+		[]cfclient.SecGroup{asg_run, asg_r1}, nil)
+
+	delete(env.spaceIdx, "space-2")
+	env.spaceFetchQueueHandler("space-2")
+	exp_sp2 := &SpaceInfo{SpaceId: "space-2", OrgId: "org-1",
+		RunningSecurityGroups: []string{"runsg", "ASG_R1"},
+		StagingSecurityGroups: []string{"stagesg", "ASG_S1"},
+		IsolationSegment:      "iso-org-1"}
+	assert.Equal(t, exp_sp2, env.spaceIdx["space-2"])
+	assert.Equal(t,
+		&IsoSegInfo{Id: "iso-org-1", Name: "org-private"}, env.isoSegIdx["iso-org-1"])
+	assert.Equal(t, &asg_stage, env.asgIdx["stagesg"])
+	assert.Equal(t, &asg_run, env.asgIdx["runsg"])
+	assert.Equal(t, &asg_s1, env.asgIdx["ASG_S1"])
+	assert.Equal(t, &asg_r1, env.asgIdx["ASG_R1"])
+	waitForGet(t, env.containerUpdateQ, 500*time.Millisecond, "c-4")
+	waitForGet(t, env.asgUpdateQ, 500*time.Millisecond, "runsg")
+	waitForGet(t, env.asgUpdateQ, 500*time.Millisecond, "ASG_R1")
+	waitForGet(t, env.asgUpdateQ, 500*time.Millisecond, "stagesg")
+	waitForGet(t, env.asgUpdateQ, 500*time.Millisecond, "ASG_S1")
+
+	cc.On("GetSpaceIsolationSegment", "space-2").Return("iso-space-2", nil)
+	exp_sp2.IsolationSegment = "iso-space-2"
+	env.spaceFetchQueueHandler("space-2")
+	assert.Equal(t, exp_sp2, env.spaceIdx["space-2"])
+	assert.Equal(t,
+		&IsoSegInfo{Id: "iso-space-2", Name: "space-private"}, env.isoSegIdx["iso-space-2"])
+}
+
+func TestCfManageAppExtIp(t *testing.T) {
+	env := testCfEnvironment(t)
+	env.cont.staticServiceIps.V4.RemoveIp(net.ParseIP("1.2.3.2"))
+	env.cont.staticServiceIps.V4.RemoveIp(net.ParseIP("1.2.3.3"))
+	env.cont.staticServiceIps.V6.RemoveIp(net.ParseIP("::2f01"))
+	env.cont.staticServiceIps.V6.RemoveIp(net.ParseIP("::2f02"))
+
+	curr := []ExtIpAlloc{ExtIpAlloc{"1.2.3.2", false, ""},
+		ExtIpAlloc{"1.2.3.3", false, ""},
+		ExtIpAlloc{"::2f01", false, ""},
+		ExtIpAlloc{"::2f02", false, ""},
+	}
+
+	// allocate static
+	req := []ExtIpAlloc{ExtIpAlloc{"1.2.3.3", false, ""},
+		ExtIpAlloc{"1.2.3.4", false, ""},
+		ExtIpAlloc{"::2f02", false, ""},
+		ExtIpAlloc{"::2f03", false, ""},
+	}
+	res, err := env.ManageAppExtIp(curr, req, false)
+	assert.Nil(t, err)
+	assert.Equal(t, req, res)
+	assert.True(t, env.cont.staticServiceIps.V4.RemoveIp(net.ParseIP("1.2.3.2")))
+	assert.True(t, env.cont.staticServiceIps.V6.RemoveIp(net.ParseIP("::2f01")))
+
+	// allocate unavailable IP
+	env.cont.staticServiceIps.V4.RemoveIp(net.ParseIP("1.2.3.6"))
+	env.cont.staticServiceIps.V6.RemoveIp(net.ParseIP("::2f05"))
+	v4copy := ipam.NewFromRanges(env.cont.staticServiceIps.V4.FreeList)
+	v6copy := ipam.NewFromRanges(env.cont.staticServiceIps.V6.FreeList)
+	req = []ExtIpAlloc{ExtIpAlloc{"1.2.3.5", false, ""}, ExtIpAlloc{"1.2.3.6", false, ""}}
+	res1, err := env.ManageAppExtIp(res, req, false)
+	assert.NotNil(t, err)
+	assert.Nil(t, res1)
+	assert.Equal(t, v4copy, env.cont.staticServiceIps.V4)
+	assert.Equal(t, v6copy, env.cont.staticServiceIps.V6)
+
+	req = []ExtIpAlloc{ExtIpAlloc{"::2f04", false, ""}, ExtIpAlloc{"::2f05", false, ""}}
+	res1, err = env.ManageAppExtIp(res, req, false)
+	assert.NotNil(t, err)
+	assert.Nil(t, res1)
+	assert.Equal(t, v4copy, env.cont.staticServiceIps.V4)
+	assert.Equal(t, v6copy, env.cont.staticServiceIps.V6)
+
+	// deallocate static
+	req = []ExtIpAlloc{ExtIpAlloc{"1.2.3.3", false, ""}, ExtIpAlloc{"::2f02", false, ""}}
+	res1, err = env.ManageAppExtIp(res, req, false)
+	assert.Nil(t, err)
+	assert.Equal(t, req, res1)
+	v4copy.AddIp(net.ParseIP("1.2.3.4"))
+	v6copy.AddIp(net.ParseIP("::2f03"))
+	assert.Equal(t, v4copy, env.cont.staticServiceIps.V4)
+	assert.Equal(t, v6copy, env.cont.staticServiceIps.V6)
+
+	// allocate dynamic
+	res, err = env.ManageAppExtIp(res, nil, true)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(res))
+	assert.Equal(t, "1.2.4", res[0].IP[0:5])
+	assert.Equal(t, "::2e0", res[1].IP[0:5])
+	assert.False(t, ipam.HasIp(env.cont.serviceIps.GetV4IpCache()[0], net.ParseIP(res[0].IP)))
+	assert.False(t, ipam.HasIp(env.cont.serviceIps.GetV4IpCache()[1], net.ParseIP(res[0].IP)))
+	assert.False(t, ipam.HasIp(env.cont.serviceIps.GetV6IpCache()[0], net.ParseIP(res[1].IP)))
+	assert.False(t, ipam.HasIp(env.cont.serviceIps.GetV6IpCache()[1], net.ParseIP(res[1].IP)))
+
+	// allocate once again -> no-op
+	ipc := ipam.NewIpCache()
+	ipc.LoadRanges(env.cont.serviceIps.GetV4IpCache()[0].FreeList)
+	ipc.LoadRanges(env.cont.serviceIps.GetV6IpCache()[0].FreeList)
+	res1, err = env.ManageAppExtIp(res, nil, true)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(res1))
+	assert.Equal(t, res, res1)
+	assert.Equal(t, ipc, env.cont.serviceIps)
+
+	// deallocate dynamic
+	ipc.DeallocateIp(net.ParseIP(res1[0].IP))
+	ipc.DeallocateIp(net.ParseIP(res1[1].IP))
+	res1, err = env.ManageAppExtIp(res1, nil, false)
+	assert.Nil(t, err)
+	assert.Nil(t, res1)
+	assert.Equal(t, ipc, env.cont.serviceIps)
+}
+
+func TestCfLoadAppExtIp(t *testing.T) {
+	env := testCfEnvironment(t)
+	ipdb := AppExtIpDb{}
+
+	ip1 := ExtIpAlloc{"1.2.3.4", false, "p1"}
+	ip2 := ExtIpAlloc{"1.2.4.4", true, "p2"}
+	ip3 := ExtIpAlloc{"::2f02", false, "p1"}
+	ip4 := ExtIpAlloc{"::2e01", true, "p1"}
+
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "1", []ExtIpAlloc{ip1, ip3})
+		assert.Nil(t, err)
+		err = ipdb.Set(txn, "2", []ExtIpAlloc{ip2, ip4})
+		assert.Nil(t, err)
+	})
+	env.LoadAppExtIps()
+
+	ainfo_1 := env.appIdx["1"]
+	assert.NotNil(t, ainfo_1)
+	assert.Equal(t, ainfo_1.ExternalIp, []string{"1.2.3.4", "::2f02"})
+
+	ainfo_2 := env.appIdx["2"]
+	assert.Equal(t, ainfo_2.ExternalIp, []string{"1.2.4.4", "::2e01"})
+
+	v4 := env.cont.serviceIps.GetV4IpCache()
+	v6 := env.cont.serviceIps.GetV4IpCache()
+
+	assert.False(t, ipam.HasIp(v4[0], net.ParseIP("1.2.3.4")))
+	assert.False(t, ipam.HasIp(v4[1], net.ParseIP("1.2.3.4")))
+	assert.False(t, ipam.HasIp(v6[0], net.ParseIP("::2f02")))
+	assert.False(t, ipam.HasIp(v6[1], net.ParseIP("::2f02")))
+
+	assert.False(t, ipam.HasIp(v4[0], net.ParseIP("1.2.4.4")))
+	assert.False(t, ipam.HasIp(v4[1], net.ParseIP("1.2.4.4")))
+	assert.False(t, ipam.HasIp(v6[0], net.ParseIP("::2e01")))
+	assert.False(t, ipam.HasIp(v6[1], net.ParseIP("::2e01")))
+}
+
+func TestCfLoadAppVip(t *testing.T) {
+	env := testCfEnvironment(t)
+	ipdb := AppVipDb{}
+
+	txn(env.db, func(txn *sql.Tx) {
+		err := ipdb.Set(txn, "app-1", "10.250.4.3", "aa::2e02")
+		assert.Nil(t, err)
+		err = ipdb.Set(txn, "2", "10.250.4.4", "aa::2e03")
+		assert.Nil(t, err)
+	})
+	env.LoadAppVips()
+
+	ainfo_1 := env.appIdx["app-1"]
+	assert.NotNil(t, ainfo_1)
+	assert.Equal(t, ainfo_1.VipV4, "10.250.4.3")
+	assert.Equal(t, ainfo_1.VipV6, "aa::2e02")
+
+	ainfo_2 := env.appIdx["2"]
+	assert.Equal(t, ainfo_2.VipV4, "10.250.4.4")
+	assert.Equal(t, ainfo_2.VipV6, "aa::2e03")
+
+	assert.False(t, env.appVips.V4.RemoveIp(net.ParseIP("10.250.4.3")))
+	assert.False(t, env.appVips.V6.RemoveIp(net.ParseIP("aa::2e02")))
+
+	assert.False(t, env.appVips.V4.RemoveIp(net.ParseIP("10.250.4.4")))
+	assert.False(t, env.appVips.V6.RemoveIp(net.ParseIP("aa::2e03")))
+}
+
+func TestCfLoadEpgAnnotations(t *testing.T) {
+	env := testCfEnvironment(t)
+	epgdb := EpgAnnotationDb{}
+
+	txn(env.db, func(txn *sql.Tx) {
+		err := epgdb.UpdateAnnotation(txn, "app-1", CF_OBJ_APP, "app-1")
+		assert.Nil(t, err)
+		err = epgdb.UpdateAnnotation(txn, "a2", CF_OBJ_APP, "app-2")
+		assert.Nil(t, err)
+		err = epgdb.UpdateAnnotation(txn, "space-1", CF_OBJ_SPACE, "space-1")
+		assert.Nil(t, err)
+		err = epgdb.UpdateAnnotation(txn, "s2", CF_OBJ_SPACE, "space-2")
+		assert.Nil(t, err)
+		err = epgdb.UpdateAnnotation(txn, "org-1", CF_OBJ_ORG, "org-1")
+		assert.Nil(t, err)
+		err = epgdb.UpdateAnnotation(txn, "o2", CF_OBJ_ORG, "org-2")
+		assert.Nil(t, err)
+	})
+	env.LoadEpgAnnotations()
+
+	assert.NotNil(t, env.appIdx["app-1"])
+	assert.NotNil(t, env.appIdx["a2"])
+	assert.NotNil(t, env.spaceIdx["space-1"])
+	assert.NotNil(t, env.spaceIdx["s2"])
+	assert.NotNil(t, env.orgIdx["org-1"])
+	assert.NotNil(t, env.orgIdx["o2"])
+}
+
+func TestCfNetworkPolicyPoller(t *testing.T) {
+	env := testCfEnvironment(t)
+	npc := env.fakePolicyClient()
+	npp_func := NewNetworkPolicyPoller(env).Poller()
+	nph_func := NewNetworkPolicyPoller(env).Handler()
+
+	pol_0 := cfapi.Policy{Source: cfapi.Source{ID: "app-1"},
+		Destination: cfapi.Destination{ID: "app-100", Protocol: "tcp",
+			Ports: cfapi.Ports{Start: 100, End: 200}}}
+	pol_1 := cfapi.Policy{Source: cfapi.Source{ID: "app-1"},
+		Destination: cfapi.Destination{ID: "app-100", Protocol: "tcp",
+			Ports: cfapi.Ports{Start: 10, End: 20}}}
+	pol_2 := cfapi.Policy{Source: cfapi.Source{ID: "app-2"},
+		Destination: cfapi.Destination{ID: "app-200", Protocol: "udp",
+			Ports: cfapi.Ports{Start: 30, End: 40}}}
+	pol_3 := cfapi.Policy{Source: cfapi.Source{ID: "app-3"},
+		Destination: cfapi.Destination{ID: "app-100", Protocol: "tcp",
+			Ports: cfapi.Ports{Start: 30, End: 40}}}
+	npc.On("GetPolicies").Return([]cfapi.Policy{pol_0, pol_1, pol_2, pol_3}, nil).Twice()
+
+	store1, hash1, _ := npp_func()
+	exp_app_100 := map[string][]cfapi.Destination{
+		"app-1": []cfapi.Destination{
+			cfapi.Destination{ID: "app-1", Protocol: "tcp", Ports: cfapi.Ports{Start: 100, End: 200}},
+			cfapi.Destination{ID: "app-1", Protocol: "tcp", Ports: cfapi.Ports{Start: 10, End: 20}},
+		},
+		"app-3": []cfapi.Destination{
+			cfapi.Destination{ID: "app-3", Protocol: "tcp", Ports: cfapi.Ports{Start: 30, End: 40}},
+		},
+	}
+	exp_app_200 := map[string][]cfapi.Destination{
+		"app-2": []cfapi.Destination{
+			cfapi.Destination{ID: "app-2", Protocol: "udp", Ports: cfapi.Ports{Start: 30, End: 40}},
+		}}
+	assert.Equal(t, exp_app_100, store1["app-100"])
+	assert.Equal(t, exp_app_200, store1["app-200"])
+
+	store2, hash2, _ := npp_func()
+	assert.Equal(t, store1, store2)
+	assert.Equal(t, hash1, hash2)
+
+	npc.On("GetPolicies").Return([]cfapi.Policy{pol_1, pol_2}, nil)
+	store3, _, _ := npp_func()
+	exp_app_100["app-1"] = exp_app_100["app-1"][1:]
+	delete(exp_app_100, "app-3")
+	assert.Equal(t, exp_app_100, store3["app-100"])
+	assert.Equal(t, exp_app_200, store3["app-200"])
+
+	env.contIdx["c-5"] = &ContainerInfo{ContainerId: "c-5", CellId: "cell-2", AppId: "app-100"}
+	env.contIdx["c-6"] = &ContainerInfo{ContainerId: "c-6", CellId: "cell-3", AppId: "app-100"}
+	env.appIdx["app-100"] = &AppInfo{AppId: "app-100", SpaceId: "space-1", AppName: "app-100-name",
+		ContainerIps: map[string]string{"c-5": "", "c-6": ""}}
+
+	nph_func(map[string]interface{}{"app-100": exp_app_100, "app-200": exp_app_200}, nil)
+	assert.Equal(t, exp_app_100, env.netpolIdx["app-100"])
+	assert.Equal(t, exp_app_200, env.netpolIdx["app-200"])
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("np:app-100"))
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("np:app-200"))
+	waitForGetList(t, env.containerUpdateQ, 500*time.Millisecond, []interface{}{"c-5", "c-6"})
+
+	nph_func(nil, map[string]interface{}{"app-100": exp_app_100})
+	assert.Nil(t, env.netpolIdx["app-100"])
+	assert.Nil(t, env.cont.apicConn.GetDesiredState("np:app-100"))
+	waitForGetList(t, env.containerUpdateQ, 500*time.Millisecond, []interface{}{"c-5", "c-6"})
+}

--- a/pkg/controller/cf_bbs_listener.go
+++ b/pkg/controller/cf_bbs_listener.go
@@ -1,0 +1,400 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"code.cloudfoundry.org/bbs"
+	"code.cloudfoundry.org/bbs/events"
+	"code.cloudfoundry.org/bbs/models"
+	"github.com/Sirupsen/logrus"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+)
+
+type AppAndSpace struct {
+	AppId    string `json:"application_id",omitempty"`
+	SpaceId  string `json:"space_id",omitempty"`
+	AppName  string `json:"application_name",omitempty"`
+	TaskName string
+}
+
+func findRunAction(act *models.Action) *models.RunAction {
+	if act == nil {
+		return nil
+	}
+	if act.RunAction != nil {
+		return act.RunAction
+	}
+	var newacts []*models.Action
+	if act.TimeoutAction != nil {
+		newacts = append(newacts, act.TimeoutAction.Action)
+	} else if act.EmitProgressAction != nil {
+		newacts = append(newacts, act.EmitProgressAction.Action)
+	} else if act.TryAction != nil {
+		newacts = append(newacts, act.TryAction.Action)
+	} else if act.ParallelAction != nil && len(act.ParallelAction.Actions) > 0 {
+		newacts = act.ParallelAction.Actions
+	} else if act.SerialAction != nil && len(act.SerialAction.Actions) > 0 {
+		newacts = act.SerialAction.Actions
+	} else if act.CodependentAction != nil && len(act.CodependentAction.Actions) > 0 {
+		newacts = act.CodependentAction.Actions
+	}
+	for _, a := range newacts {
+		ra := findRunAction(a)
+		if ra != nil {
+			return ra
+		}
+	}
+	return nil
+}
+
+func (env *CfEnvironment) getAppAndSpaceFromAction(action *models.Action) *AppAndSpace {
+	act := findRunAction(action)
+	if act != nil {
+		for _, envVar := range act.Env {
+			if envVar.Name == "VCAP_APPLICATION" {
+				var as AppAndSpace
+				err := json.Unmarshal([]byte(envVar.Value), &as)
+				if err != nil {
+					env.log.Error("JSON deserialize failed for VCAP_APPLICATION env var: ", err)
+					return nil
+				} else {
+					if strings.HasPrefix(act.LogSource, "APP/TASK/") {
+						as.TaskName = act.LogSource[9:]
+					}
+					return &as
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type DesiredLrp2App map[string]string
+type PendingActualLrp map[string]map[string]*models.ActualLRPGroup
+
+func (env *CfEnvironment) fetchLrps(dlrp2app DesiredLrp2App, pending PendingActualLrp) error {
+	// Get all actual LRPs
+	existActualGroup, err := env.bbsClient.ActualLRPGroups(env.cfLogger, models.ActualLRPFilter{})
+	if err != nil {
+		env.log.Error("Initial fetch of all actual LRPs failed: ", err)
+		return err
+	}
+	env.log.Debug(fmt.Sprintf("Got %d initial BBS actual LRPs", len(existActualGroup)))
+
+	// Get all desired LRPs
+	existDesired, err := env.bbsClient.DesiredLRPs(env.cfLogger, models.DesiredLRPFilter{})
+	if err != nil {
+		env.log.Error("Initial fetch of all desired LRPs failed: ", err)
+		return err
+	}
+	env.log.Debug(fmt.Sprintf("Got %d initial BBS desired LRPs", len(existDesired)))
+
+	for _, alrpg := range existActualGroup {
+		env.processBbsActualLrp(alrpg, dlrp2app, pending)
+	}
+	for _, dlrp := range existDesired {
+		env.processBbsDesiredLrp(dlrp, dlrp2app, pending)
+	}
+	return nil
+}
+
+func (env *CfEnvironment) fetchTasks() error {
+	tasks, err := env.bbsClient.Tasks(env.cfLogger)
+	if err != nil {
+		env.log.Error("Initial fetch of all tasks failed: ", err)
+		return err
+	}
+	env.log.Debug(fmt.Sprintf("Got %d initial BBS tasks", len(tasks)))
+	for _, task := range tasks {
+		env.processBbsTask(task)
+	}
+	return nil
+}
+
+func (env *CfEnvironment) processBbsTask(task *models.Task) {
+	as := env.getAppAndSpaceFromAction(task.GetAction())
+	if as == nil {
+		return
+	}
+	instIdx := etcd.INST_IDX_STAGING
+	if task.Domain == "cf-tasks" {
+		instIdx = etcd.INST_IDX_TASK
+	}
+	appInfo := env.constructAppInfo(as)
+	cinfo := &ContainerInfo{ContainerId: task.TaskGuid,
+		AppId:         appInfo.AppId,
+		CellId:        task.CellId,
+		InstanceIndex: instIdx,
+		TaskName:      as.TaskName}
+	appInfo.ContainerIps[cinfo.ContainerId] = cinfo.IpAddress
+
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	if env.mergeAppInfo(appInfo) {
+		env.log.Debug("BBS Task - Queuing update for app ", appInfo.AppId)
+		env.scheduleAppAndSpaceUpdate(appInfo)
+	}
+	if env.mergeContainerInfo(cinfo) {
+		env.log.Debug("BBS Task - Queuing update for container ", cinfo.ContainerId)
+		env.containerUpdateQ.Add(cinfo.ContainerId)
+	}
+}
+
+func (env *CfEnvironment) processBbsDesiredLrp(dlrp *models.DesiredLRP,
+	dlrp2app DesiredLrp2App, pending PendingActualLrp) {
+
+	as := env.getAppAndSpaceFromAction(dlrp.GetAction())
+	if as == nil {
+		return
+	}
+	dlrp2app[dlrp.GetProcessGuid()] = as.AppId
+	appInfo := env.constructAppInfo(as)
+
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	ct_upd := make([]string, 0)
+	for contId, lrp := range pending[dlrp.GetProcessGuid()] {
+		inst := lrp.Instance
+		if inst == nil {
+			continue
+		}
+		cinfo := &ContainerInfo{ContainerId: contId,
+			AppId:         appInfo.AppId,
+			CellId:        inst.GetCellId(),
+			IpAddress:     inst.GetInstanceAddress(),
+			InstanceIndex: inst.GetIndex(),
+			Ports:         inst.GetPorts()}
+		if env.mergeContainerInfo(cinfo) {
+			ct_upd = append(ct_upd, contId)
+		}
+		appInfo.ContainerIps[cinfo.ContainerId] = cinfo.IpAddress
+	}
+	delete(pending, dlrp.GetProcessGuid())
+
+	if env.mergeAppInfo(appInfo) {
+		env.log.Debug("BBS DesiredLRP - Queuing update for app ", appInfo.AppId)
+		env.scheduleAppAndSpaceUpdate(appInfo)
+	}
+	for _, ct := range ct_upd {
+		env.log.Debug("BBS DesiredLRP - Queuing update for container ", ct)
+		env.containerUpdateQ.Add(ct)
+	}
+}
+
+func (env *CfEnvironment) processBbsActualLrp(alrp *models.ActualLRPGroup,
+	dlrp2app DesiredLrp2App, pending PendingActualLrp) {
+
+	inst := alrp.Instance
+	if inst == nil {
+		return
+	}
+	appId := dlrp2app[inst.GetProcessGuid()]
+	if appId == "" {
+		env.log.Debug(
+			fmt.Sprintf("Marked container %s as pending for Desired LRP %s",
+				inst.GetInstanceGuid(), inst.GetProcessGuid()))
+		alrps := pending[inst.GetProcessGuid()]
+		if alrps == nil {
+			alrps = make(map[string]*models.ActualLRPGroup)
+		}
+		alrps[inst.GetInstanceGuid()] = alrp
+		pending[inst.GetProcessGuid()] = alrps
+		return
+	}
+
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	cinfo := &ContainerInfo{ContainerId: inst.GetInstanceGuid(),
+		AppId:         appId,
+		CellId:        inst.GetCellId(),
+		IpAddress:     inst.GetInstanceAddress(),
+		InstanceIndex: inst.GetIndex(),
+		Ports:         inst.GetPorts()}
+	cu := env.mergeContainerInfo(cinfo)
+
+	appInfo := env.appIdx[appId]
+	au := false
+	if appInfo != nil && appInfo.ContainerIps[cinfo.ContainerId] != cinfo.IpAddress {
+		appInfo.ContainerIps[cinfo.ContainerId] = cinfo.IpAddress
+		au = true
+	}
+
+	if au {
+		env.log.Debug("BBS ActualLRP - Queuing update for app ", appInfo.AppId)
+		env.scheduleAppAndSpaceUpdate(appInfo)
+	}
+	if cu {
+		env.log.Debug("BBS ActualLRP - Queuing update for container ", cinfo.ContainerId)
+		env.containerUpdateQ.Add(cinfo.ContainerId)
+	}
+}
+
+func (env *CfEnvironment) processContainerDelete(ctId string) {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	cinfo := env.contIdx[ctId]
+	delete(env.contIdx, ctId)
+	var appInfo *AppInfo
+	if cinfo != nil && cinfo.AppId != "" {
+		appInfo = env.appIdx[cinfo.AppId]
+		if appInfo != nil {
+			delete(appInfo.ContainerIps, cinfo.ContainerId)
+			env.appIdx[cinfo.AppId] = appInfo
+		}
+	}
+
+	if cinfo != nil {
+		env.containerDeleteQ.Add(cinfo)
+	}
+	if appInfo != nil {
+		env.appUpdateQ.Add(appInfo.AppId)
+	}
+}
+
+type CfBbsEventListener struct {
+	name         string
+	bbsClient    bbs.Client
+	synced       bool
+	log          *logrus.Logger
+	delayOnErr   time.Duration
+	fetchHandler func(bbs.Client) (events.EventSource, error)
+	eventHandler func(models.Event) error
+}
+
+func (l *CfBbsEventListener) Run(stopCh <-chan struct{}) {
+	cancelled := false
+	var es events.EventSource
+	go func() {
+		for !cancelled {
+			var err error
+			es, err = l.fetchHandler(l.bbsClient)
+			if err != nil {
+				l.log.Error(
+					fmt.Sprintf("BBS listener %s - Error in fetch handler: ", l.name), err)
+				time.Sleep(l.delayOnErr) // TODO exponential backoff
+				continue
+			}
+			l.log.Debug(fmt.Sprintf("BBS listener %s - fetch complete", l.name))
+			l.synced = true
+
+			l.log.Debug(fmt.Sprintf("BBS listener %s - listening for events", l.name))
+			for !cancelled {
+				event, err := es.Next()
+				if err != nil {
+					if err == events.ErrUnrecognizedEventType {
+						l.log.Debug(
+							fmt.Sprintf("BBS listener %s - Ignoring ErrUnrecognizedEventType", l.name),
+							err)
+						continue
+					}
+					l.log.Error(fmt.Sprintf("BBS listener %s - error: ", l.name), err)
+					break
+				}
+				if event != nil {
+					l.eventHandler(event)
+				}
+			}
+		}
+		l.log.Debug(fmt.Sprintf("BBS listener %s - terminated", l.name))
+	}()
+	<-stopCh
+	cancelled = true
+	if es != nil {
+		es.Close()
+	}
+}
+
+func (l *CfBbsEventListener) Synced() bool {
+	return l.synced
+}
+
+func NewCfBbsTaskListener(env *CfEnvironment) *CfBbsEventListener {
+	fetchHandler := func(client bbs.Client) (events.EventSource, error) {
+		es, err := env.bbsClient.SubscribeToTaskEvents(env.cfLogger)
+		if err != nil {
+			env.log.Error("Unable to subscribe to BBS Tasks: ", err)
+			return nil, err
+		}
+		err = env.fetchTasks()
+		return es, err
+	}
+
+	eventHandler := func(event models.Event) error {
+		switch ev := event.(type) {
+		case *models.TaskCreatedEvent:
+			env.processBbsTask(ev.Task)
+		case *models.TaskChangedEvent:
+			env.processBbsTask(ev.After)
+		case *models.TaskRemovedEvent:
+			env.processContainerDelete(ev.Task.TaskGuid)
+		}
+		return nil
+	}
+	return &CfBbsEventListener{name: "Task",
+		bbsClient:    env.bbsClient,
+		log:          env.log,
+		delayOnErr:   10 * time.Second,
+		fetchHandler: fetchHandler, eventHandler: eventHandler}
+}
+
+func NewCfBbsLrpListener(env *CfEnvironment) *CfBbsEventListener {
+	dlrp2app := make(DesiredLrp2App)
+	pending := make(PendingActualLrp)
+
+	fetchHandler := func(client bbs.Client) (events.EventSource, error) {
+		es, err := env.bbsClient.SubscribeToEvents(env.cfLogger)
+		if err != nil {
+			env.log.Error("Unable to subscribe to BBS LRP events: ", err)
+			return nil, err
+		}
+		err = env.fetchLrps(dlrp2app, pending)
+		return es, err
+	}
+
+	eventHandler := func(event models.Event) error {
+		switch ev := event.(type) {
+		case *models.DesiredLRPCreatedEvent:
+			env.processBbsDesiredLrp(ev.DesiredLrp, dlrp2app, pending)
+		case *models.DesiredLRPChangedEvent:
+			env.processBbsDesiredLrp(ev.After, dlrp2app, pending)
+		case *models.DesiredLRPRemovedEvent:
+			delete(dlrp2app, ev.DesiredLrp.GetProcessGuid())
+			delete(pending, ev.DesiredLrp.GetProcessGuid())
+
+		case *models.ActualLRPCreatedEvent:
+			env.processBbsActualLrp(ev.ActualLrpGroup, dlrp2app, pending)
+		case *models.ActualLRPChangedEvent:
+			env.processBbsActualLrp(ev.After, dlrp2app, pending)
+		case *models.ActualLRPRemovedEvent:
+			if ev.ActualLrpGroup.Instance != nil {
+				env.processContainerDelete(ev.ActualLrpGroup.Instance.GetInstanceGuid())
+			}
+		}
+		return nil
+	}
+	return &CfBbsEventListener{name: "LRP",
+		bbsClient:    env.bbsClient,
+		log:          env.log,
+		delayOnErr:   10 * time.Second,
+		fetchHandler: fetchHandler, eventHandler: eventHandler}
+}

--- a/pkg/controller/cf_bbs_listener_test.go
+++ b/pkg/controller/cf_bbs_listener_test.go
@@ -1,0 +1,332 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/bbs/models"
+	"github.com/stretchr/testify/assert"
+
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+var TO500 time.Duration = 500 * time.Millisecond
+
+func testCfEnvironmentWithBbsChannel(t *testing.T) (*CfEnvironment, chan models.Event) {
+	env := testCfEnvironment(t)
+	ch := make(chan models.Event)
+	env.setBbsFakeEventSource(ch)
+	return env, ch
+}
+
+func actionForApp(appId, spaceId, appName, taskName string) *models.Action {
+	js := "{\"application_id\": \"%s\", \"space_id\": \"%s\", \"application_name\": \"%s\"}"
+	e := models.EnvironmentVariable{Name: "VCAP_APPLICATION",
+		Value: fmt.Sprintf(js, appId, spaceId, appName)}
+	ra := &models.RunAction{}
+	ra.Env = append(ra.Env, &e)
+	if taskName != "" {
+		ra.LogSource = "APP/TASK/" + taskName
+	}
+	raw := &models.Action{RunAction: ra}
+	toa := &models.Action{TimeoutAction: &models.TimeoutAction{Action: raw}}
+	epa := &models.Action{EmitProgressAction: &models.EmitProgressAction{Action: toa}}
+	ta := &models.Action{TryAction: &models.TryAction{Action: epa}}
+	pa := &models.Action{ParallelAction: &models.ParallelAction{Actions: []*models.Action{ta}}}
+	sa := &models.Action{SerialAction: &models.SerialAction{Actions: []*models.Action{pa}}}
+	ca := &models.Action{CodependentAction: &models.CodependentAction{Actions: []*models.Action{sa}}}
+	return ca
+}
+
+func TestCfBbsTaskListener(t *testing.T) {
+	env, ch := testCfEnvironmentWithBbsChannel(t)
+	f_bbs := env.fakeBbsClient()
+	tl := NewCfBbsTaskListener(env)
+
+	t1 := &models.Task{TaskGuid: "c-tsk-1", Domain: "cf-staging", CellId: "cell1"}
+	t1.TaskDefinition = &models.TaskDefinition{Action: actionForApp("a1", "sp1", "a-app", "")}
+	t2 := &models.Task{TaskGuid: "c-tsk-2", Domain: "cf-tasks", CellId: "cell2"}
+	t2.TaskDefinition = &models.TaskDefinition{Action: actionForApp("a2", "sp2", "b-app", "errand")}
+	f_bbs.TasksReturns([]*models.Task{t1, t2}, nil)
+
+	stopCh := make(chan struct{})
+	runEnded := false
+	go func() {
+		tl.Run(stopCh)
+		runEnded = true
+	}()
+
+	// Test initial fetch
+	tu.WaitFor(t, "BBS task listener synced", TO500,
+		func(bool) (bool, error) { return tl.Synced(), nil })
+
+	exp_a1 := &AppInfo{AppId: "a1", AppName: "a-app", SpaceId: "sp1",
+		ContainerIps: make(map[string]string), VipV4: "10.250.4.1", VipV6: "aa::2e00"}
+	exp_a1.ContainerIps["c-tsk-1"] = ""
+	exp_tsk_1 := &ContainerInfo{ContainerId: "c-tsk-1", CellId: "cell1", InstanceIndex: -1, AppId: "a1"}
+	assert.Equal(t, exp_a1, env.appIdx["a1"])
+	assert.Equal(t, exp_tsk_1, env.contIdx["c-tsk-1"])
+
+	exp_a2 := &AppInfo{AppId: "a2", AppName: "b-app", SpaceId: "sp2",
+		ContainerIps: make(map[string]string), VipV4: "10.250.4.2", VipV6: "aa::2e01"}
+	exp_a2.ContainerIps["c-tsk-2"] = ""
+	exp_tsk_2 := &ContainerInfo{ContainerId: "c-tsk-2", CellId: "cell2", InstanceIndex: -2, AppId: "a2",
+		TaskName: "errand"}
+	assert.Equal(t, exp_a2, env.appIdx["a2"])
+	assert.Equal(t, exp_tsk_2, env.contIdx["c-tsk-2"])
+
+	waitForGet(t, env.appUpdateQ, TO500, "a1")
+	waitForGet(t, env.appUpdateQ, TO500, "a2")
+	waitForGet(t, env.spaceFetchQ, TO500, "sp1")
+	waitForGet(t, env.spaceFetchQ, TO500, "sp2")
+	waitForGet(t, env.containerUpdateQ, TO500, "c-tsk-1")
+	waitForGet(t, env.containerUpdateQ, TO500, "c-tsk-2")
+
+	// Test task create
+	t3 := &models.Task{TaskGuid: "c-tsk-3", Domain: "cf-tasks", CellId: "cell3"}
+	t3.TaskDefinition = &models.TaskDefinition{Action: actionForApp("a3", "sp3", "c-app", "another")}
+	t3_create := &models.TaskCreatedEvent{Task: t3}
+	ch <- t3_create
+
+	exp_a3 := &AppInfo{AppId: "a3", AppName: "c-app", SpaceId: "sp3",
+		ContainerIps: make(map[string]string), VipV4: "10.250.4.3", VipV6: "aa::2e02"}
+	exp_a3.ContainerIps["c-tsk-3"] = ""
+	exp_tsk_3 := &ContainerInfo{ContainerId: "c-tsk-3", CellId: "cell3", InstanceIndex: -2, AppId: "a3",
+		TaskName: "another"}
+	tu.WaitFor(t, "BBS task create - app", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a3, env.appIdx["a3"]), nil
+		})
+	tu.WaitFor(t, "BBS task create - container", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_tsk_3, env.contIdx["c-tsk-3"]), nil
+		})
+
+	waitForGet(t, env.appUpdateQ, TO500, "a3")
+	waitForGet(t, env.spaceFetchQ, TO500, "sp3")
+	waitForGet(t, env.containerUpdateQ, TO500, "c-tsk-3")
+
+	// Test task update
+	t1.CellId = "cell2"
+	t1_update := &models.TaskChangedEvent{After: t1}
+	ch <- t1_update
+
+	exp_tsk_1.CellId = "cell2"
+	tu.WaitFor(t, "BBS task update - container", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_tsk_1, env.contIdx["c-tsk-1"]), nil
+		})
+	waitForGet(t, env.containerUpdateQ, TO500, "c-tsk-1")
+
+	// Test task delete
+	t2_delete := &models.TaskRemovedEvent{Task: t2}
+	ch <- t2_delete
+
+	delete(exp_a2.ContainerIps, "c-tsk-2")
+	tu.WaitFor(t, "BBS task delete - app", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a2, env.appIdx["a2"]), nil
+		})
+	tu.WaitFor(t, "BBS task delete - container", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitNil(t, last, env.contIdx["c-tsk-2"]), nil
+		})
+	waitForGet(t, env.appUpdateQ, TO500, "a2")
+	waitForGet(t, env.containerDeleteQ, TO500, exp_tsk_2)
+
+	close(stopCh)
+	tu.WaitFor(t, "BBS task loop ended", TO500,
+		func(last bool) (bool, error) { return runEnded, nil })
+}
+
+func desiredLrp(pguid, appId, spaceId, appName string) *models.DesiredLRP {
+	return &models.DesiredLRP{ProcessGuid: pguid,
+		Action: actionForApp(appId, spaceId, appName, "")}
+}
+
+func actualLrp(pguid, contId, cellId, ip string) *models.ActualLRPGroup {
+	alrp := &models.ActualLRP{
+		ActualLRPKey: models.ActualLRPKey{ProcessGuid: pguid},
+		ActualLRPInstanceKey: models.ActualLRPInstanceKey{
+			InstanceGuid: contId, CellId: cellId},
+		ActualLRPNetInfo: models.ActualLRPNetInfo{
+			InstanceAddress: ip,
+			Ports: []*models.PortMapping{
+				&models.PortMapping{ContainerPort: 1001, HostPort: 22},
+				&models.PortMapping{ContainerPort: 1002, HostPort: 23}}}}
+	return &models.ActualLRPGroup{Instance: alrp}
+}
+
+func TestCfBbsLrpListener(t *testing.T) {
+	env, ch := testCfEnvironmentWithBbsChannel(t)
+	f_bbs := env.fakeBbsClient()
+	ll := NewCfBbsLrpListener(env)
+
+	// Test intial fetch
+	a1_dlrp := desiredLrp("a1-v1", "a1", "sp1", "a-app")
+	a1_alrp1 := actualLrp("a1-v1", "c-a-1", "cell1", "10.255.0.42")
+	a2_dlrp := desiredLrp("a2-v1", "a2", "sp2", "b-app")
+	a2_alrp1 := actualLrp("a2-v1", "c-a-2", "cell2", "10.255.0.43")
+
+	f_bbs.ActualLRPGroupsReturns(
+		[]*models.ActualLRPGroup{a1_alrp1, a2_alrp1}, nil)
+	f_bbs.DesiredLRPsReturns(
+		[]*models.DesiredLRP{a1_dlrp, a2_dlrp}, nil)
+
+	stopCh := make(chan struct{})
+	runEnded := false
+	go func() {
+		ll.Run(stopCh)
+		runEnded = true
+	}()
+
+	tu.WaitFor(t, "BBS LRP listener synced", TO500,
+		func(bool) (bool, error) { return ll.Synced(), nil })
+
+	exp_a1 := &AppInfo{AppId: "a1", AppName: "a-app", SpaceId: "sp1",
+		ContainerIps: make(map[string]string), VipV4: "10.250.4.1", VipV6: "aa::2e00"}
+	exp_a1.ContainerIps["c-a-1"] = "10.255.0.42"
+	exp_a1_lrp1 := &ContainerInfo{ContainerId: "c-a-1", CellId: "cell1", InstanceIndex: 0,
+		AppId: "a1", IpAddress: "10.255.0.42", Ports: a1_alrp1.Instance.Ports}
+	assert.Equal(t, exp_a1, env.appIdx["a1"])
+	assert.Equal(t, exp_a1_lrp1, env.contIdx["c-a-1"])
+
+	exp_a2 := &AppInfo{AppId: "a2", AppName: "b-app", SpaceId: "sp2",
+		ContainerIps: make(map[string]string), VipV4: "10.250.4.2", VipV6: "aa::2e01"}
+	exp_a2.ContainerIps["c-a-2"] = "10.255.0.43"
+	exp_a2_lrp1 := &ContainerInfo{ContainerId: "c-a-2", CellId: "cell2", InstanceIndex: 0,
+		AppId: "a2", IpAddress: "10.255.0.43", Ports: a2_alrp1.Instance.Ports}
+	assert.Equal(t, exp_a2, env.appIdx["a2"])
+	assert.Equal(t, exp_a2_lrp1, env.contIdx["c-a-2"])
+
+	waitForGet(t, env.appUpdateQ, TO500, "a1")
+	waitForGet(t, env.appUpdateQ, TO500, "a2")
+	waitForGet(t, env.spaceFetchQ, TO500, "sp1")
+	waitForGet(t, env.spaceFetchQ, TO500, "sp2")
+	waitForGet(t, env.containerUpdateQ, TO500, "c-a-1")
+	waitForGet(t, env.containerUpdateQ, TO500, "c-a-2")
+
+	// Test Actual LRP create (no desired LRP), then create desired LRP
+	a3_alrp1 := actualLrp("a3-v1", "c-a-3", "cell3", "10.255.0.44")
+	a3_alrp1_create := &models.ActualLRPCreatedEvent{ActualLrpGroup: a3_alrp1}
+	ch <- a3_alrp1_create
+	time.Sleep(TO500)
+	assert.Nil(t, env.contIdx["c-a-3"])
+
+	a3_dlrp := desiredLrp("a3-v1", "a3", "sp3", "c-app")
+	a3_dlrp_create := &models.DesiredLRPCreatedEvent{DesiredLrp: a3_dlrp}
+	ch <- a3_dlrp_create
+
+	exp_a3 := &AppInfo{AppId: "a3", AppName: "c-app", SpaceId: "sp3",
+		ContainerIps: make(map[string]string), VipV4: "10.250.4.3", VipV6: "aa::2e02"}
+	exp_a3.ContainerIps["c-a-3"] = "10.255.0.44"
+	exp_a3_lrp1 := &ContainerInfo{ContainerId: "c-a-3", CellId: "cell3", InstanceIndex: 0,
+		AppId: "a3", IpAddress: "10.255.0.44", Ports: a3_alrp1.Instance.Ports}
+	tu.WaitFor(t, "BBS LRP create - app", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a3, env.appIdx["a3"]), nil
+		})
+	tu.WaitFor(t, "BBS LRP create - container", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a3_lrp1, env.contIdx["c-a-3"]), nil
+		})
+	waitForGet(t, env.appUpdateQ, TO500, "a3")
+	waitForGet(t, env.spaceFetchQ, TO500, "sp3")
+	waitForGet(t, env.containerUpdateQ, TO500, "c-a-3")
+
+	// Test Actual LRP create (desired LRP present)
+	a3_alrp2 := actualLrp("a3-v1", "c-a-4", "cell1", "10.255.0.45")
+	a3_alrp2.Instance.Index = 1
+	a3_alrp2_create := &models.ActualLRPCreatedEvent{ActualLrpGroup: a3_alrp2}
+	ch <- a3_alrp2_create
+
+	exp_a3.ContainerIps["c-a-4"] = "10.255.0.45"
+	exp_a3_lrp2 := &ContainerInfo{ContainerId: "c-a-4", CellId: "cell1", InstanceIndex: 1,
+		AppId: "a3", IpAddress: "10.255.0.45", Ports: a3_alrp1.Instance.Ports}
+	tu.WaitFor(t, "BBS LRP create another - app", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a3, env.appIdx["a3"]), nil
+		})
+	tu.WaitFor(t, "BBS LRP create another - container", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a3_lrp2, env.contIdx["c-a-4"]), nil
+		})
+	waitForGet(t, env.appUpdateQ, TO500, "a3")
+	waitForGet(t, env.spaceFetchQ, TO500, "sp3")
+	waitForGet(t, env.containerUpdateQ, TO500, "c-a-4")
+
+	// Test Actual LRP change
+	a1_alrp1.Instance.CellId = "cell3"
+	a1_alrp1.Instance.InstanceAddress = "10.255.0.10"
+	a1_alrp1_update := &models.ActualLRPChangedEvent{After: a1_alrp1}
+	ch <- a1_alrp1_update
+
+	exp_a1.ContainerIps["c-a-1"] = "10.255.0.10"
+	exp_a1_lrp1.CellId = "cell3"
+	exp_a1_lrp1.IpAddress = "10.255.0.10"
+	tu.WaitFor(t, "BBS LRP update - app", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a1, env.appIdx["a1"]), nil
+		})
+	tu.WaitFor(t, "BBS LRP update - container", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a1_lrp1, env.contIdx["c-a-1"]), nil
+		})
+	waitForGet(t, env.appUpdateQ, TO500, "a1")
+	waitForGet(t, env.spaceFetchQ, TO500, "sp1")
+	waitForGet(t, env.containerUpdateQ, TO500, "c-a-1")
+
+	// Test Actual LRP delete
+	a1_alrp1_delete := &models.ActualLRPRemovedEvent{ActualLrpGroup: a1_alrp1}
+	ch <- a1_alrp1_delete
+
+	delete(exp_a1.ContainerIps, "c-a-1")
+	tu.WaitFor(t, "BBS LRP delete - app", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a1, env.appIdx["a1"]), nil
+		})
+	tu.WaitFor(t, "BBS LRP delete - container", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitNil(t, last, env.contIdx["c-a-1"]), nil
+		})
+	waitForGet(t, env.appUpdateQ, TO500, "a1")
+	waitForGet(t, env.containerDeleteQ, TO500, exp_a1_lrp1)
+
+	// Test Desired LRP change
+	a1_dlrp = desiredLrp("a1-v1", "a1", "sp1", "a-new-app")
+	a1_dlrp_update := &models.DesiredLRPChangedEvent{After: a1_dlrp}
+	ch <- a1_dlrp_update
+
+	exp_a1.AppName = "a-new-app"
+	tu.WaitFor(t, "BBS LRP desired update - app", TO500,
+		func(last bool) (bool, error) {
+			return tu.WaitEqual(t, last, exp_a1, env.appIdx["a1"]), nil
+		})
+	waitForGet(t, env.appUpdateQ, TO500, "a1")
+	waitForGet(t, env.spaceFetchQ, TO500, "sp1")
+
+	// Test Desired LRP delete
+	a1_dlrp_delete := &models.DesiredLRPRemovedEvent{DesiredLrp: a1_dlrp}
+	ch <- a1_dlrp_delete
+	time.Sleep(TO500)
+	assert.Equal(t, exp_a1, env.appIdx["a1"])
+
+	close(stopCh)
+	tu.WaitFor(t, "BBS LRP loop ended", TO500,
+		func(last bool) (bool, error) { return runEnded, nil })
+}

--- a/pkg/controller/cf_cleanup_poller.go
+++ b/pkg/controller/cf_cleanup_poller.go
@@ -1,0 +1,151 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"time"
+)
+
+func NewAppCleanupPoller(env *CfEnvironment) *CfPoller {
+
+	pollFunc := func() (map[string]interface{}, interface{}, error) {
+		allApps, err := env.ccClient.ListApps()
+		if err != nil {
+			return nil, nil, err
+		}
+		existApps := make(map[string]struct{})
+		for i := 0; i < len(allApps); i++ {
+			existApps[allApps[i].Guid] = struct{}{}
+		}
+		toDelete := make(map[string]struct{})
+		env.indexLock.Lock()
+		defer env.indexLock.Unlock()
+		for k, _ := range env.appIdx {
+			if _, ok := existApps[k]; !ok {
+				toDelete[k] = struct{}{}
+			}
+		}
+		for k, _ := range toDelete {
+			env.log.Debug("Delete app on cleanup ", k)
+			ainfo := env.appIdx[k]
+			delete(env.appIdx, k)
+			env.appDeleteQ.Add(ainfo)
+		}
+		return nil, "0", nil
+	}
+
+	handleFunc := func(updates map[string]interface{}, deletes map[string]interface{}) {}
+	pollInterval := time.Duration(env.cfconfig.CleanupPollingInterval) * time.Second
+	return NewCfPoller("App-cleanup", pollInterval, 0, pollFunc, handleFunc, env.log)
+}
+
+func NewSpaceCleanupPoller(env *CfEnvironment) *CfPoller {
+
+	pollFunc := func() (map[string]interface{}, interface{}, error) {
+		allSpaces, err := env.ccClient.ListSpaces()
+		if err != nil {
+			return nil, nil, err
+		}
+		existSpaces := make(map[string]struct{})
+		for i := 0; i < len(allSpaces); i++ {
+			existSpaces[allSpaces[i].Guid] = struct{}{}
+		}
+		toDelete := make(map[string]struct{})
+		env.indexLock.Lock()
+		defer env.indexLock.Unlock()
+		for k, _ := range env.spaceIdx {
+			if _, ok := existSpaces[k]; !ok {
+				toDelete[k] = struct{}{}
+			}
+		}
+		for k, _ := range toDelete {
+			env.log.Debug("Delete space on cleanup ", k)
+			sinfo := env.spaceIdx[k]
+			delete(env.spaceIdx, k)
+			env.spaceDeleteQ.Add(sinfo)
+		}
+		return nil, "0", nil
+	}
+
+	handleFunc := func(updates map[string]interface{}, deletes map[string]interface{}) {}
+	pollInterval := time.Duration(env.cfconfig.CleanupPollingInterval) * time.Second
+	return NewCfPoller("Space-cleanup", pollInterval, 0, pollFunc, handleFunc, env.log)
+}
+
+func NewOrgCleanupPoller(env *CfEnvironment) *CfPoller {
+
+	pollFunc := func() (map[string]interface{}, interface{}, error) {
+		allOrgs, err := env.ccClient.ListOrgs()
+		if err != nil {
+			return nil, nil, err
+		}
+		existOrgs := make(map[string]struct{})
+		for i := 0; i < len(allOrgs); i++ {
+			existOrgs[allOrgs[i].Guid] = struct{}{}
+		}
+		toDelete := make(map[string]struct{})
+		env.indexLock.Lock()
+		defer env.indexLock.Unlock()
+		for k, _ := range env.orgIdx {
+			if _, ok := existOrgs[k]; !ok {
+				toDelete[k] = struct{}{}
+			}
+		}
+		for k, _ := range toDelete {
+			env.log.Debug("Delete org on cleanup ", k)
+			oinfo := env.orgIdx[k]
+			delete(env.orgIdx, k)
+			env.orgDeleteQ.Add(oinfo)
+		}
+		return nil, "0", nil
+	}
+
+	handleFunc := func(updates map[string]interface{}, deletes map[string]interface{}) {}
+	pollInterval := time.Duration(env.cfconfig.CleanupPollingInterval) * time.Second
+	return NewCfPoller("Org-cleanup", pollInterval, 0, pollFunc, handleFunc, env.log)
+}
+
+func NewAsgCleanupPoller(env *CfEnvironment) *CfPoller {
+
+	pollFunc := func() (map[string]interface{}, interface{}, error) {
+		allAsgs, err := env.ccClient.ListSecGroups()
+		if err != nil {
+			return nil, nil, err
+		}
+		existAsgs := make(map[string]struct{})
+		for i := 0; i < len(allAsgs); i++ {
+			existAsgs[allAsgs[i].Guid] = struct{}{}
+		}
+		toDelete := make(map[string]struct{})
+		env.indexLock.Lock()
+		defer env.indexLock.Unlock()
+		for k, _ := range env.asgIdx {
+			if _, ok := existAsgs[k]; !ok {
+				toDelete[k] = struct{}{}
+			}
+		}
+		for k, _ := range toDelete {
+			env.log.Debug("Delete ASG on cleanup ", k)
+			asgInfo := env.asgIdx[k]
+			delete(env.asgIdx, k)
+			env.asgDeleteQ.Add(asgInfo)
+		}
+		return nil, "0", nil
+	}
+
+	handleFunc := func(updates map[string]interface{}, deletes map[string]interface{}) {}
+	pollInterval := time.Duration(env.cfconfig.CleanupPollingInterval) * time.Second
+	return NewCfPoller("ASG-cleanup", pollInterval, 0, pollFunc, handleFunc, env.log)
+}

--- a/pkg/controller/cf_cleanup_poller_test.go
+++ b/pkg/controller/cf_cleanup_poller_test.go
@@ -1,0 +1,85 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+	"time"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCfAppCleanupPoller(t *testing.T) {
+	env := testCfEnvironment(t)
+	cp := NewAppCleanupPoller(env)
+
+	cc := env.fakeCcClient()
+	apps := []cfclient.App{cfclient.App{Guid: "app-1"}}
+	cc.On("ListApps").Return(apps, nil)
+	to_del := []interface{}{env.appIdx["app-2"], env.appIdx["app-3"]}
+
+	cp.Poller()()
+	assert.Nil(t, env.appIdx["app-2"])
+	assert.Nil(t, env.appIdx["app-3"])
+	waitForGetList(t, env.appDeleteQ, 500*time.Millisecond, to_del)
+}
+
+func TestCfSpaceCleanupPoller(t *testing.T) {
+	env := testCfEnvironment(t)
+	cp := NewSpaceCleanupPoller(env)
+
+	cc := env.fakeCcClient()
+	spaces := []cfclient.Space{cfclient.Space{Guid: "space-1"}}
+	cc.On("ListSpaces").Return(spaces, nil)
+	to_del := []interface{}{env.spaceIdx["space-2"]}
+
+	cp.Poller()()
+	assert.Nil(t, env.spaceIdx["space-2"])
+	waitForGetList(t, env.spaceDeleteQ, 500*time.Millisecond, to_del)
+}
+
+func TestCfOrgCleanupPoller(t *testing.T) {
+	env := testCfEnvironment(t)
+	cp := NewOrgCleanupPoller(env)
+
+	cc := env.fakeCcClient()
+	orgs := []cfclient.Org{cfclient.Org{Guid: "org-1"}}
+	cc.On("ListOrgs").Return(orgs, nil)
+
+	env.orgIdx["org-2"] = &OrgInfo{OrgId: "org-2"}
+	env.orgIdx["org-3"] = &OrgInfo{OrgId: "org-3"}
+	to_del := []interface{}{env.orgIdx["org-2"], env.orgIdx["org-3"]}
+
+	cp.Poller()()
+	assert.Nil(t, env.orgIdx["org-2"])
+	assert.Nil(t, env.orgIdx["org-3"])
+	waitForGetList(t, env.orgDeleteQ, 500*time.Millisecond, to_del)
+}
+
+func TestCfAsgCleanupPoller(t *testing.T) {
+	env := testCfEnvironment(t)
+	cp := NewAsgCleanupPoller(env)
+
+	cc := env.fakeCcClient()
+	asgs := []cfclient.SecGroup{cfclient.SecGroup{Guid: "ASG_PUB"}}
+	cc.On("ListSecGroups").Return(asgs, nil)
+	to_del := []interface{}{env.asgIdx["ASG_S1"], env.asgIdx["ASG_S1"]}
+
+	cp.Poller()()
+	assert.Nil(t, env.asgIdx["ASG_S1"])
+	assert.Nil(t, env.asgIdx["ASG_R1"])
+	waitForGetList(t, env.asgDeleteQ, 500*time.Millisecond, to_del)
+}

--- a/pkg/controller/cf_common_test.go
+++ b/pkg/controller/cf_common_test.go
@@ -1,0 +1,323 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/bbs/events/eventfakes"
+	"code.cloudfoundry.org/bbs/fake_bbs"
+	"code.cloudfoundry.org/bbs/models"
+	"github.com/Sirupsen/logrus"
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+	wq "k8s.io/client-go/util/workqueue"
+
+	apic "github.com/noironetworks/aci-containers/pkg/apicapi"
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	etcd_f "github.com/noironetworks/aci-containers/pkg/cf_etcd_fakes"
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+	"github.com/noironetworks/aci-containers/pkg/cfapi/cfapi_fakes"
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func fakeApicConnection(t *testing.T, log *logrus.Logger) *apic.ApicConnection {
+	conn, _ := apic.New(log, []string{}, "admin", "", nil, nil, "test")
+	assert.NotNil(t, conn)
+	return conn
+}
+
+func testCfEnvironmentNoMigration(t *testing.T) *CfEnvironment {
+	env := CfEnvironment{indexLock: &sync.Mutex{}, appVips: newNetIps()}
+	log := logrus.New()
+	log.Level = logrus.DebugLevel
+	log.Formatter = &logrus.TextFormatter{
+		DisableColors: true,
+	}
+	cont := NewController(NewConfig(), &env, log)
+	cont.config.DefaultEg.Name = "default|cf-app-default"
+	cont.config.DefaultEg.PolicySpace = "cf"
+	cont.config.AciPolicyTenant = "cf"
+	cont.config.AciPrefix = "cf"
+	cont.configuredPodNetworkIps.V4.AddRange(net.ParseIP("10.10.0.0"), net.ParseIP("10.10.255.255"))
+	cont.configuredPodNetworkIps.V6.AddRange(net.ParseIP("::fe00"), net.ParseIP("::feff"))
+	cont.nodeServiceIps.V4.AddRange(net.ParseIP("1.0.0.1"), net.ParseIP("1.0.0.24"))
+	cont.nodeServiceIps.V6.AddRange(net.ParseIP("a1::"), net.ParseIP("a1::ff"))
+	cont.staticServiceIps.V4.AddRange(net.ParseIP("1.2.3.1"), net.ParseIP("1.2.3.20"))
+	cont.staticServiceIps.V6.AddRange(net.ParseIP("::2f00"), net.ParseIP("::2fff"))
+	cont.serviceIps.LoadRanges([]ipam.IpRange{
+		ipam.IpRange{Start: net.ParseIP("1.2.4.1"), End: net.ParseIP("1.2.4.20")},
+		ipam.IpRange{Start: net.ParseIP("::2e00"), End: net.ParseIP("::2eff")}})
+	env.appVips.V4.AddRange(net.ParseIP("10.250.4.1"), net.ParseIP("10.250.4.20"))
+	env.appVips.V6.AddRange(net.ParseIP("aa::2e00"), net.ParseIP("aa::2eff"))
+	cont.apicConn = fakeApicConnection(t, log)
+	env.cont = cont
+	env.log = log
+	db, err := sql.Open("sqlite3", ":memory:")
+	db.SetMaxOpenConns(1) // workaround for sqlite3 memory-only DB
+	assert.Nil(t, err)
+	env.db = db
+	env.cfconfig = &CfConfig{}
+	env.cfconfig.ApiPathPrefix = "/networking-aci"
+	env.cfconfig.DefaultAppProfile = "auto"
+	env.cfconfig.AppPort = 8080
+	env.cfconfig.SshPort = 2222
+	env.cfconfig.CfNetIntfAddress = "169.254.169.254"
+	env.ccClient = &cfapi_fakes.FakeCcClient{}
+	env.cfAuthClient = &cfapi_fakes.FakeCfAuthClient{}
+	env.bbsClient = new(fake_bbs.FakeClient)
+	env.netpolClient = &cfapi_fakes.FakePolicyClient{}
+
+	env.etcdKeysApi = etcd_f.NewFakeEtcdKeysApi(log)
+	env.initIndexes()
+	env.setupIndexes()
+	env.setupCcClientFakes()
+	return &env
+}
+
+func testCfEnvironment(t *testing.T) *CfEnvironment {
+	env := testCfEnvironmentNoMigration(t)
+	err := env.RunDbMigration()
+	assert.Nil(t, err)
+	return env
+}
+
+func (e *CfEnvironment) fakeCcClient() *cfapi_fakes.FakeCcClient {
+	return e.ccClient.(*cfapi_fakes.FakeCcClient)
+}
+
+func (e *CfEnvironment) fakeCfAuthClient() *cfapi_fakes.FakeCfAuthClient {
+	return e.cfAuthClient.(*cfapi_fakes.FakeCfAuthClient)
+}
+
+func (e *CfEnvironment) fakePolicyClient() *cfapi_fakes.FakePolicyClient {
+	return e.netpolClient.(*cfapi_fakes.FakePolicyClient)
+}
+
+func (e *CfEnvironment) fakeEtcdKeysApi() *etcd_f.FakeEtcdKeysApi {
+	return e.etcdKeysApi.(*etcd_f.FakeEtcdKeysApi)
+}
+
+func (e *CfEnvironment) fakeBbsClient() *fake_bbs.FakeClient {
+	return e.bbsClient.(*fake_bbs.FakeClient)
+}
+
+func (e *CfEnvironment) setBbsFakeEventSource(ch chan models.Event) {
+	fake_bbs_client := e.fakeBbsClient()
+	fake_bbs_es := new(eventfakes.FakeEventSource)
+	fake_bbs_es.NextStub = func() (models.Event, error) {
+		ev, ok := <-ch
+		if !ok {
+			return nil, fmt.Errorf("BBS event channel closed")
+		}
+		return ev, nil
+	}
+	fake_bbs_es.CloseStub = func() error {
+		close(ch)
+		return nil
+	}
+	fake_bbs_client.SubscribeToEventsReturns(fake_bbs_es, nil)
+	fake_bbs_client.SubscribeToTaskEventsReturns(fake_bbs_es, nil)
+}
+
+func (e *CfEnvironment) setupIndexes() {
+	e.contIdx["c-1"] = &ContainerInfo{ContainerId: "c-1", CellId: "cell-1", IpAddress: "1.2.3.4", AppId: "app-1"}
+	e.contIdx["c-1"].Ports = []*models.PortMapping{
+		&models.PortMapping{ContainerPort: 8080, HostPort: 22},
+		&models.PortMapping{ContainerPort: 2222, HostPort: 23}}
+	e.contIdx["c-2"] = &ContainerInfo{ContainerId: "c-2", CellId: "cell-1", IpAddress: "1.2.3.5", AppId: "app-1"}
+	e.contIdx["c-3"] = &ContainerInfo{ContainerId: "c-3", CellId: "cell-1", IpAddress: "1.2.3.6", AppId: "app-2"}
+	e.contIdx["c-4"] = &ContainerInfo{ContainerId: "c-4", CellId: "cell-1", IpAddress: "1.2.3.7", AppId: "app-3"}
+
+	e.appIdx["app-1"] = &AppInfo{AppId: "app-1", SpaceId: "space-1", AppName: "app-1-name",
+		ContainerIps: map[string]string{
+			"c-1": "1.2.3.4",
+			"c-2": "1.2.3.5",
+		},
+		VipV4: "10.250.4.1", VipV6: "aa::2e00",
+		ExternalIp: []string{"150.150.0.3", "aaaa::bbbb"},
+	}
+	e.appIdx["app-2"] = &AppInfo{AppId: "app-2", SpaceId: "space-1", AppName: "app-2-name",
+		ContainerIps: map[string]string{"c-3": "1.2.3.6"},
+	}
+	e.appIdx["app-3"] = &AppInfo{AppId: "app-3", SpaceId: "space-2", AppName: "app-3-name",
+		ContainerIps: map[string]string{"c-4": "1.2.3.7"},
+	}
+	e.spaceIdx["space-1"] = &SpaceInfo{SpaceId: "space-1", OrgId: "org-1",
+		RunningSecurityGroups: []string{"ASG_R1", "ASG_PUB"},
+		StagingSecurityGroups: []string{"ASG_S1", "ASG_PUB"}}
+	e.spaceIdx["space-2"] = &SpaceInfo{SpaceId: "space-2", OrgId: "org-1"}
+
+	e.orgIdx["org-1"] = &OrgInfo{OrgId: "org-1", OrgName: "ORG1"}
+
+	e.netpolIdx["app-1"] = nil
+	e.netpolIdx["app-101"] = map[string][]cfapi.Destination{
+		"app-1": []cfapi.Destination{
+			cfapi.Destination{Protocol: "tcp", Ports: cfapi.Ports{Start: 10, End: 20}}},
+		"app-2": nil}
+	e.netpolIdx["app-102"] = map[string][]cfapi.Destination{
+		"app-1": []cfapi.Destination{
+			cfapi.Destination{Protocol: "udp", Ports: cfapi.Ports{Start: 20, End: 30}}},
+		"app-2": nil}
+
+	e.isoSegIdx["is1"] = &IsoSegInfo{Id: "is1", Name: "isolate1"}
+
+	e.asgIdx["ASG_PUB"] = &cfclient.SecGroup{Guid: "ASG_PUB",
+		Rules: []cfclient.SecGroupRule{
+			cfclient.SecGroupRule{Protocol: "tcp",
+				Ports:       "50,100-200",
+				Destination: "100.100.100.1-100.100.100.8, 100.100.200.0/24"},
+			cfclient.SecGroupRule{Protocol: "tcp", Ports: "1000, 1200, 5000"}}}
+	e.asgIdx["ASG_R1"] = &cfclient.SecGroup{Guid: "ASG_R1",
+		Rules: []cfclient.SecGroupRule{
+			cfclient.SecGroupRule{Protocol: "udp", Destination: "101.101.101.101", Log: true}}}
+	e.asgIdx["ASG_S1"] = &cfclient.SecGroup{Guid: "ASG_S1",
+		Rules: []cfclient.SecGroupRule{
+			cfclient.SecGroupRule{Protocol: "icmp", Destination: "201.201.202.202",
+				Code: 10, Type: 12}}}
+
+	cont := e.cont
+	for i := 0; i < 4; i++ {
+		num := fmt.Sprintf("%d", i)
+		cell := "diego-cell-cell-" + num
+		cont.nodeServiceMetaCache[cell] = &nodeServiceMeta{
+			serviceEp: md.ServiceEndpoint{Mac: "99:99:99:88:88:8" + num, Ipv4: net.ParseIP("1.0.0." + num)}}
+		odev := apic.EmptyApicObject("opflexDev", "odev-"+num)
+		odev.SetAttr("fabricPathDn", "topo/node-101/port-[eth1/33]_"+num)
+		cont.nodeOpflexDevice["diego-cell-cell-1"] = apic.ApicSlice{odev}
+	}
+}
+
+func (e *CfEnvironment) setupCcClientFakes() {
+	admin_token := cfapi.TokenInfo{Scope: []string{"network.admin"},
+		UserId:   "admin",
+		UserName: "admin"}
+	auth := e.fakeCfAuthClient()
+	auth.On("FetchTokenInfo", "testtoken").Return(&admin_token, nil)
+
+	cc := e.fakeCcClient()
+	cc.On("GetAppSpace", "app-1").Return("space-1", nil)
+	cc.On("GetAppSpace", "app-2").Return("space-1", nil)
+	cc.On("GetAppSpace", "app-3").Return("space-2", nil)
+}
+
+func (e *CfEnvironment) GetEpInfo(cell, cont string) *etcd.EpInfo {
+	key := etcd.CELL_KEY_BASE + "/" + cell + "/containers/" + cont + "/ep"
+	resp, err := e.etcdKeysApi.Get(context.Background(), key, nil)
+	if err == nil {
+		var ep etcd.EpInfo
+		er := json.Unmarshal([]byte(resp.Node.Value), &ep)
+		if er != nil {
+			panic(er.Error())
+		}
+		return &ep
+	}
+	return nil
+}
+
+func (e *CfEnvironment) GetAppInfo(appId string) *etcd.AppInfo {
+	key := etcd.APP_KEY_BASE + "/" + appId
+	resp, err := e.etcdKeysApi.Get(context.Background(), key, nil)
+	if err == nil {
+		var app etcd.AppInfo
+		er := json.Unmarshal([]byte(resp.Node.Value), &app)
+		if er != nil {
+			panic(er.Error())
+		}
+		return &app
+	}
+	return nil
+}
+
+func txn(db *sql.DB, f func(txn *sql.Tx)) {
+	txn, _ := db.Begin()
+	defer txn.Commit()
+	f(txn)
+}
+
+func waitForGetList(t *testing.T, q wq.RateLimitingInterface, timeout time.Duration, items []interface{}) {
+	ch := make(chan struct{})
+	var objs []interface{}
+	go func() {
+		for {
+			obj, quit := q.Get()
+			if quit {
+				assert.False(t, quit, "WaitForGet - Unexpected queue shutdown")
+				return
+			}
+			objs = append(objs, obj)
+			q.Forget(obj)
+			q.Done(obj)
+			if len(objs) == len(items) {
+				close(ch)
+				return
+			}
+		}
+	}()
+	select {
+	case <-time.After(timeout):
+		assert.False(t, true, fmt.Sprintf("WaitForGet timed-out for items: %+v", items))
+	case <-ch:
+		for i, _ := range items {
+			assert.Contains(t, objs, items[i])
+		}
+	}
+}
+
+func waitForGet(t *testing.T, q wq.RateLimitingInterface, timeout time.Duration, item interface{}) {
+	waitForGetList(t, q, timeout, []interface{}{item})
+}
+
+func getExpectedEpInfo() *etcd.EpInfo {
+	ep := &etcd.EpInfo{
+		AppId:         "app-1",
+		AppName:       "app-1-name",
+		SpaceId:       "space-1",
+		OrgId:         "org-1",
+		IpAddress:     "1.2.3.4",
+		InstanceIndex: 0,
+		PortMapping: []etcd.PortMap{
+			etcd.PortMap{ContainerPort: 8080, HostPort: 22},
+			etcd.PortMap{ContainerPort: 2222, HostPort: 23}},
+		EpgTenant: "cf",
+		Epg:       "default|cf-app-default",
+		SecurityGroups: []etcd.GroupInfo{
+			etcd.GroupInfo{Tenant: "cf", Group: "cf_hpp_static"},
+			etcd.GroupInfo{Tenant: "cf", Group: "cf_hpp_cf-components"},
+			etcd.GroupInfo{Tenant: "cf", Group: "cf_asg_ASG_R1"},
+			etcd.GroupInfo{Tenant: "cf", Group: "cf_asg_ASG_PUB"},
+			etcd.GroupInfo{Tenant: "cf", Group: "cf_np_app-1"},
+			etcd.GroupInfo{Tenant: "cf", Group: "cf_hpp_app-ext-ip"}},
+	}
+	return ep
+}
+
+func getExpectedAppInfo() *etcd.AppInfo {
+	app := &etcd.AppInfo{
+		ContainerIps: []string{"1.2.3.4", "1.2.3.5"},
+		VirtualIp:    []string{"10.250.4.1", "aa::2e00"},
+		ExternalIp:   []string{"150.150.0.3", "aaaa::bbbb"},
+	}
+	return app
+}

--- a/pkg/controller/cf_db.go
+++ b/pkg/controller/cf_db.go
@@ -1,0 +1,75 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	_ "github.com/go-sql-driver/mysql"
+)
+
+type migration struct {
+	version    string
+	statements []string
+}
+
+func getV0Migration(db *sql.DB, txn *sql.Tx) *migration {
+	m := migration{version: "0",
+		statements: []string{
+			`CREATE TABLE IF NOT EXISTS aci_epg_annotations (
+					guid VARCHAR(255) NOT NULL,
+					kind INTEGER,
+					value VARCHAR(255),
+					PRIMARY KEY (guid, kind)
+					);`,
+			`CREATE TABLE IF NOT EXISTS aci_app_vip (
+					guid VARCHAR(255) NOT NULL,
+					ip_v4 VARCHAR(16),
+					ip_v6 VARCHAR(64),
+					PRIMARY KEY (guid)
+					);`,
+			`CREATE TABLE IF NOT EXISTS aci_app_ext_ip (
+					guid VARCHAR(255) NOT NULL,
+					ip VARCHAR(64),
+					dynamic INTEGER,
+					pool VARCHAR(255),
+					PRIMARY KEY (guid, ip)
+					);`,
+		},
+	}
+	return &m
+}
+
+func (env *CfEnvironment) RunDbMigration() error {
+	txn, err := env.db.Begin()
+	if err != nil {
+		return err
+	}
+
+	var stmts []migration
+	stmts = append(stmts, *getV0Migration(env.db, txn))
+
+	// TODO inspect the current version in the DB
+	for _, m := range stmts {
+		for _, s := range m.statements {
+			_, err = txn.Exec(s)
+			if err != nil {
+				txn.Rollback()
+				return err
+			}
+		}
+	}
+	err = txn.Commit()
+	return err
+}

--- a/pkg/controller/cf_db_test.go
+++ b/pkg/controller/cf_db_test.go
@@ -1,0 +1,87 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCfDbMigration(t *testing.T) {
+	env := testCfEnvironmentNoMigration(t)
+	err := env.RunDbMigration()
+	assert.Nil(t, err)
+
+	{
+		rows, err := env.db.Query("SELECT guid, kind, value from aci_epg_annotations")
+		cts, err := rows.ColumnTypes()
+		rows.Close()
+		assert.Nil(t, err)
+
+		assert.Equal(t, 3, len(cts))
+		assert.Equal(t, "guid", cts[0].Name())
+		assert.Equal(t, "VARCHAR(255)", cts[0].DatabaseTypeName())
+
+		assert.Equal(t, "kind", cts[1].Name())
+		assert.Equal(t, "INTEGER", cts[1].DatabaseTypeName())
+
+		assert.Equal(t, "value", cts[2].Name())
+		assert.Equal(t, "VARCHAR(255)", cts[2].DatabaseTypeName())
+	}
+
+	{
+		rows, err := env.db.Query("SELECT guid, ip_v4, ip_v6 from aci_app_vip")
+		cts, err := rows.ColumnTypes()
+		rows.Close()
+		assert.Nil(t, err)
+
+		assert.Equal(t, 3, len(cts))
+		assert.Equal(t, "guid", cts[0].Name())
+		assert.Equal(t, "VARCHAR(255)", cts[0].DatabaseTypeName())
+
+		assert.Equal(t, "ip_v4", cts[1].Name())
+		assert.Equal(t, "VARCHAR(16)", cts[1].DatabaseTypeName())
+
+		assert.Equal(t, "ip_v6", cts[2].Name())
+		assert.Equal(t, "VARCHAR(64)", cts[2].DatabaseTypeName())
+	}
+
+	{
+		rows, err := env.db.Query("SELECT guid, ip, dynamic, pool from aci_app_ext_ip")
+		cts, err := rows.ColumnTypes()
+		rows.Close()
+		assert.Nil(t, err)
+
+		assert.Equal(t, 4, len(cts))
+		assert.Equal(t, "guid", cts[0].Name())
+		assert.Equal(t, "VARCHAR(255)", cts[0].DatabaseTypeName())
+
+		assert.Equal(t, "ip", cts[1].Name())
+		assert.Equal(t, "VARCHAR(64)", cts[1].DatabaseTypeName())
+
+		assert.Equal(t, "dynamic", cts[2].Name())
+		assert.Equal(t, "INTEGER", cts[2].DatabaseTypeName())
+
+		assert.Equal(t, "pool", cts[3].Name())
+		assert.Equal(t, "VARCHAR(255)", cts[3].DatabaseTypeName())
+	}
+}
+
+func TestCfDbMigrationIdempotent(t *testing.T) {
+	env := testCfEnvironment(t)
+	err := env.RunDbMigration()
+	assert.Nil(t, err)
+}

--- a/pkg/controller/cf_environment.go
+++ b/pkg/controller/cf_environment.go
@@ -15,18 +15,171 @@
 package controller
 
 import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"code.cloudfoundry.org/bbs"
+	"code.cloudfoundry.org/lager"
+
 	"github.com/Sirupsen/logrus"
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	etcdclient "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/noironetworks/aci-containers/pkg/apicapi"
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	"github.com/noironetworks/aci-containers/pkg/cfapi"
+	"github.com/noironetworks/aci-containers/pkg/ipam"
 )
 
 type CfEnvironment struct {
+	cont     *AciController
+	cfconfig *CfConfig
+
+	bbsClient    bbs.Client
+	ccClient     cfapi.CcClient
+	etcdKeysApi  etcdclient.KeysAPI
+	netpolClient cfapi.PolicyClient
+	cfAuthClient cfapi.CfAuthClient
+	cfLogger     lager.Logger
+	db           *sql.DB
+
+	indexLock sync.Locker
+	contIdx   map[string]*ContainerInfo
+	appIdx    map[string]*AppInfo
+	spaceIdx  map[string]*SpaceInfo
+	orgIdx    map[string]*OrgInfo
+	asgIdx    map[string]*cfclient.SecGroup
+	netpolIdx map[string]map[string][]cfapi.Destination
+	isoSegIdx map[string]*IsoSegInfo
+
+	spaceFetchQ      workqueue.RateLimitingInterface
+	spaceDeleteQ     workqueue.RateLimitingInterface
+	appUpdateQ       workqueue.RateLimitingInterface
+	appDeleteQ       workqueue.RateLimitingInterface
+	containerUpdateQ workqueue.RateLimitingInterface
+	containerDeleteQ workqueue.RateLimitingInterface
+	orgDeleteQ       workqueue.RateLimitingInterface
+	asgUpdateQ       workqueue.RateLimitingInterface
+	asgDeleteQ       workqueue.RateLimitingInterface
+
+	appVips *netIps
+
+	goRouterIps []string
+	sshProxyIps []string
+
+	log *logrus.Logger
+}
+
+type CfConfig struct {
+	VmmPolicy                 string `json:"vmm_policy"`
+	BBSAddress                string `json:"bbs_address"`
+	BBSCACertFile             string `json:"bbs_ca_cert_file"`
+	BBSClientCertFile         string `json:"bbs_client_cert_file"`
+	BBSClientKeyFile          string `json:"bbs_client_key_file"`
+	BBSClientSessionCacheSize int    `json:"bbs_client_session_cache_size,omitempty"`
+	BBSMaxIdleConnsPerHost    int    `json:"bbs_max_idle_conns_per_host,omitempty"`
+
+	CCApiUrl      string `json:"cc_api_url,omitempty"`
+	CCApiUsername string `json:"cc_api_username,omitempty"`
+	CCApiPassword string `json:"cc_api_password,omitempty"`
+
+	EtcdUrl            string `json:"etcd_url,omitempty"`
+	EtcdCACertFile     string `json:"etcd_ca_cert_file"`
+	EtcdClientCertFile string `json:"etcd_client_cert_file"`
+	EtcdClientKeyFile  string `json:"etcd_client_key_file"`
+
+	UaaUrl          string `json:"uaa_url,omitempty"`
+	UaaCACertFile   string `json:"uaa_ca_cert_file"`
+	UaaClientName   string `json:"uaa_client_name"`
+	UaaClientSecret string `json:"uaa_client_secret"`
+
+	NetPolApiUrl          string `json:"network_policy_api_url"`
+	NetPolCACertFile      string `json:"network_policy_ca_cert_file"`
+	NetPolClientCertFile  string `json:"network_policy_client_cert_file"`
+	NetPolClientKeyFile   string `json:"network_policy_client_key_file"`
+	NetPolPollingInterval int    `json:"network_policy_polling_interval_sec"`
+
+	DbType string `json:"db_type"`
+	DbDsn  string `json:"db_dsn"`
+
+	ApiPathPrefix string `json:"api_path_prefix"`
+
+	GoRouterAddress string
+	SshProxyAddress string
+	AppPort         uint32 `json:"app_port"`
+	SshPort         uint32 `json:"ssh_port"`
+
+	DefaultAppProfile string `json:"default_app_profile"`
+
+	// Virtual IP address pool for apps
+	AppVipPool   []ipam.IpRange `json:"app_vip_pool,omitempty"`
+	AppVipSubnet []string       `json:"app_vip_subnet,omitempty"`
+
+	// Source address used on cells for legacy CF networking
+	CfNetIntfAddress string `json:"cf_net_interface_address"`
+
+	CleanupPollingInterval int `json:"cleanup_polling_interval_sec"`
 }
 
 func NewCfEnvironment(config *ControllerConfig, log *logrus.Logger) (*CfEnvironment, error) {
-	return &CfEnvironment{}, nil
+	if config.CfConfig == "" {
+		err := errors.New("Path to CloudFoundry config file is empty")
+		log.Error(err.Error())
+		return nil, err
+	}
+
+	cfconfig := &CfConfig{}
+	log.Info("Loading CF configuration from ", config.CfConfig)
+	raw, err := ioutil.ReadFile(config.CfConfig)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(raw, cfconfig)
+	if err != nil {
+		return nil, err
+	}
+	cfconfig.GoRouterAddress = "gorouter.service.cf.internal"
+	cfconfig.SshProxyAddress = "ssh-proxy.service.cf.internal"
+	if cfconfig.VmmPolicy == "" {
+		cfconfig.VmmPolicy = "CloudFoundry"
+	}
+	if cfconfig.AppPort == 0 {
+		cfconfig.AppPort = 8080
+	}
+	if cfconfig.SshPort == 0 {
+		cfconfig.SshPort = 2222
+	}
+	if cfconfig.NetPolPollingInterval <= 0 {
+		cfconfig.NetPolPollingInterval = 1
+	}
+	if cfconfig.ApiPathPrefix == "" {
+		cfconfig.ApiPathPrefix = "/networking-aci"
+	}
+	if cfconfig.CleanupPollingInterval <= 0 {
+		cfconfig.CleanupPollingInterval = 30
+	}
+
+	return &CfEnvironment{cfconfig: cfconfig, indexLock: &sync.Mutex{}, appVips: newNetIps(), log: log},
+		nil
 }
 
 func (env *CfEnvironment) VmmPolicy() string {
-	return "CloudFoundry"
+	return env.cfconfig.VmmPolicy
 }
 
 func (env *CfEnvironment) OpFlexDeviceType() string {
@@ -38,18 +191,533 @@ func (env *CfEnvironment) ServiceBd() string {
 }
 
 func (env *CfEnvironment) Init(cont *AciController) error {
+	env.cont = cont
+
+	env.cfLogger = lager.NewLogger("CfEnv")
+	lagerLevel := lager.INFO
+	switch env.log.Level {
+	case logrus.DebugLevel:
+		lagerLevel = lager.DEBUG
+	case logrus.InfoLevel:
+		lagerLevel = lager.INFO
+	case logrus.WarnLevel:
+		lagerLevel = lager.INFO
+	case logrus.ErrorLevel:
+		lagerLevel = lager.ERROR
+	case logrus.FatalLevel:
+		lagerLevel = lager.FATAL
+	case logrus.PanicLevel:
+		lagerLevel = lager.FATAL
+	default:
+	}
+	env.cfLogger.RegisterSink(lager.NewWriterSink(env.log.Out, lagerLevel))
+
+	env.initIndexes()
+	cont.loadIpRanges(env.appVips.V4, env.appVips.V6, env.cfconfig.AppVipPool)
+
+	var err error
+	env.db, err = sql.Open(env.cfconfig.DbType, env.cfconfig.DbDsn)
+	if err != nil {
+		env.log.Error("Unable to open SQL DB: ", err)
+		return err
+	}
+
+	env.log.WithFields(logrus.Fields{
+		"cfconfig": cont.config.CfConfig,
+	}).Info("Setting up CloudFoundry environment")
+
+	bbsURL, err := url.Parse(env.cfconfig.BBSAddress)
+	if err != nil {
+		env.log.Error("Invalid BBS URL: ", err)
+		return err
+	}
+	if bbsURL.Scheme != "https" {
+		env.bbsClient = bbs.NewClient(env.cfconfig.BBSAddress)
+	} else {
+		env.bbsClient, err = bbs.NewSecureClient(
+			env.cfconfig.BBSAddress,
+			env.cfconfig.BBSCACertFile,
+			env.cfconfig.BBSClientCertFile,
+			env.cfconfig.BBSClientKeyFile,
+			env.cfconfig.BBSClientSessionCacheSize,
+			env.cfconfig.BBSMaxIdleConnsPerHost,
+		)
+		if err != nil {
+			env.log.Error("Failed to configure secure BBS client: ", err)
+			return err
+		}
+	}
+
+	etcdClient, err := etcd.NewEtcdClient(env.cfconfig.EtcdUrl, env.cfconfig.EtcdCACertFile,
+		env.cfconfig.EtcdClientCertFile, env.cfconfig.EtcdClientKeyFile)
+	if err != nil {
+		env.log.Error("Failed to create Etcd client: ", err)
+		return err
+	}
+	env.etcdKeysApi = etcdclient.NewKeysAPI(etcdClient)
+
+	env.netpolClient, err = cfapi.NewNetPolClient(env.cfconfig.NetPolApiUrl,
+		env.cfconfig.NetPolCACertFile,
+		env.cfconfig.NetPolClientCertFile,
+		env.cfconfig.NetPolClientKeyFile)
+	if err != nil {
+		env.log.Error("Failed to create network policy client: ", err)
+		return err
+	}
+
+	env.cfAuthClient, err = cfapi.NewCfAuthClient(env.cfconfig.UaaUrl, env.cfconfig.UaaCACertFile,
+		env.cfconfig.UaaClientName, env.cfconfig.UaaClientSecret)
+	if err != nil {
+		env.log.Error("Failed to create UAA client: ", err)
+		return err
+	}
+
+	return nil
+}
+
+func (env *CfEnvironment) initIndexes() {
+	env.contIdx = make(map[string]*ContainerInfo)
+	env.appIdx = make(map[string]*AppInfo)
+	env.spaceIdx = make(map[string]*SpaceInfo)
+	env.orgIdx = make(map[string]*OrgInfo)
+	env.asgIdx = make(map[string]*cfclient.SecGroup)
+	env.netpolIdx = make(map[string]map[string][]cfapi.Destination)
+	env.isoSegIdx = make(map[string]*IsoSegInfo)
+
+	env.spaceFetchQ = createQueue("fetch-space")
+	env.spaceDeleteQ = createQueue("delete-space")
+	env.appUpdateQ = createQueue("update-app")
+	env.appDeleteQ = createQueue("delete-app")
+	env.containerUpdateQ = createQueue("update-container")
+	env.containerDeleteQ = createQueue("delete-container")
+	env.orgDeleteQ = createQueue("delete-org")
+	env.asgUpdateQ = createQueue("update-asg")
+	env.asgDeleteQ = createQueue("delete-asg")
+}
+
+func (env *CfEnvironment) PrepareRun(stopCh <-chan struct{}) error {
+	var err error
+
+	// test DB connectivity
+	if err = env.db.Ping(); err != nil {
+		env.log.Error("Unable to connect to SQL DB: ", err)
+		return err
+	}
+	if err = env.RunDbMigration(); err != nil {
+		env.log.Error("Failed to run DB migration: ", err)
+		return err
+	}
+
+	epg_anno_handler := EpgAnnotationHttpHandler{env: env}
+	app_vip_handler := AppVipHttpHandler{env: env}
+	app_ext_ip_handler := AppExtIpHttpHandler{env: env}
+	http.Handle(epg_anno_handler.Path(), &epg_anno_handler)
+	http.Handle(app_vip_handler.Path(), &app_vip_handler)
+	http.Handle(app_ext_ip_handler.Path(), &app_ext_ip_handler)
+
+	maxattempts := 240 // TODO move the connect loop to app-index builder
+	for env.ccClient == nil && maxattempts > 0 {
+		maxattempts--
+		ccClient, err := cfapi.NewCcClient(env.cfconfig.CCApiUrl, env.cfconfig.CCApiUsername,
+			env.cfconfig.CCApiPassword)
+		if err != nil {
+			env.log.Error("Failed to create CC API client: ", err)
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		env.log.Debug("CC API client created")
+		env.ccClient = ccClient
+	}
+	if env.ccClient == nil {
+		env.log.Error("Couldn't create CC API client, aborting: ", err)
+		return err
+	}
+
+	env.LoadAppExtIps()
+	env.LoadAppVips()
+	env.LoadEpgAnnotations()
+
+	bbsLrp := NewCfBbsLrpListener(env)
+	bbsTasks := NewCfBbsTaskListener(env)
+	go bbsLrp.Run(stopCh)
+	go bbsTasks.Run(stopCh)
+
+	go env.processQueue(env.spaceFetchQ, env.spaceFetchQueueHandler, stopCh)
+	go env.processQueue(env.spaceDeleteQ,
+		func(id interface{}) bool { return env.handleSpaceDelete(id.(*SpaceInfo)) },
+		stopCh)
+	go env.processQueue(env.appUpdateQ,
+		func(id interface{}) bool { return env.handleAppUpdate(id.(string)) },
+		stopCh)
+	go env.processQueue(env.appDeleteQ,
+		func(id interface{}) bool { return env.handleAppDelete(id.(*AppInfo)) },
+		stopCh)
+	go env.processQueue(env.containerUpdateQ,
+		func(id interface{}) bool { return env.handleContainerUpdate(id.(string)) },
+		stopCh)
+	go env.processQueue(env.containerDeleteQ,
+		func(id interface{}) bool {
+			return env.handleContainerDelete(id.(*ContainerInfo))
+		},
+		stopCh)
+	go env.processQueue(env.orgDeleteQ,
+		func(id interface{}) bool { return env.handleOrgDelete(id.(*OrgInfo)) },
+		stopCh)
+	go env.processQueue(env.asgUpdateQ,
+		func(id interface{}) bool { return env.handleAsgUpdate(id.(string)) },
+		stopCh)
+	go env.processQueue(env.asgDeleteQ,
+		func(id interface{}) bool { return env.handleAsgDelete(id.(*cfclient.SecGroup)) },
+		stopCh)
+
+	go wait.Until(env.UpdateHppForCfComponents, 30*time.Second, stopCh)
+
+	cache.WaitForCacheSync(stopCh, bbsLrp.Synced, bbsTasks.Synced)
+	env.log.Info("BBS sync complete")
+
+	netPolPoller := NewNetworkPolicyPoller(env)
+	go netPolPoller.Run(true, stopCh)
+	cache.WaitForCacheSync(stopCh, netPolPoller.Synced)
+
+	// Start the etcd watcher after intial-sync of containers
+	etcd_cont_w := NewCfEtcdContainersWatcher(env)
+	go etcd_cont_w.Run(stopCh)
+	cache.WaitForCacheSync(stopCh, etcd_cont_w.Synced)
+
+	// start cleanup pollers
+	go NewAppCleanupPoller(env).Run(false, stopCh)
+	go NewSpaceCleanupPoller(env).Run(false, stopCh)
+	go NewOrgCleanupPoller(env).Run(false, stopCh)
+	go NewAsgCleanupPoller(env).Run(false, stopCh)
+
+	env.log.Debug("Cleaning up stale etcd entries")
+	err = env.cleanupEtcdContainers()
+	if err != nil {
+		env.log.Warning("Error cleaning up stale etcd container nodes: ", err)
+	}
 	return nil
 }
 
 func (env *CfEnvironment) InitStaticAciObjects() {
+	env.initStaticHpp()
+	env.cont.initStaticServiceObjs()
 }
 
+func (env *CfEnvironment) initStaticHpp() {
+	cont := env.cont
+
+	staticName := cont.aciNameForKey("hpp", "static")
+	hpp := apicapi.NewHostprotPol(cont.config.AciPolicyTenant, staticName)
+
+	{
+		// ARP ingress/egress and ICMP ingress (+ reply)
+		discSubj := apicapi.NewHostprotSubj(hpp.GetDn(), "discovery")
+		discDn := discSubj.GetDn()
+		{
+			arpin := apicapi.NewHostprotRule(discDn, "arp-ingress")
+			arpin.SetAttr("direction", "ingress")
+			arpin.SetAttr("ethertype", "arp")
+			arpin.SetAttr("connTrack", "normal")
+			discSubj.AddChild(arpin)
+		}
+		{
+			arpout := apicapi.NewHostprotRule(discDn, "arp-egress")
+			arpout.SetAttr("direction", "egress")
+			arpout.SetAttr("ethertype", "arp")
+			arpout.SetAttr("connTrack", "normal")
+			discSubj.AddChild(arpout)
+		}
+		{
+			icmpin := apicapi.NewHostprotRule(discDn, "icmp-ingress")
+			icmpin.SetAttr("direction", "ingress")
+			icmpin.SetAttr("ethertype", "ipv4")
+			icmpin.SetAttr("protocol", "icmp")
+			discSubj.AddChild(icmpin)
+		}
+		hpp.AddChild(discSubj)
+	}
+
+	{
+		// Allow TCP/UDP egress (+ reply) to CNI network and app-VIP network
+		subnets := make([]string, 0)
+		for _, s := range env.cont.config.PodSubnets {
+			subnets = append(subnets, s)
+		}
+		if len(subnets) == 0 {
+			env.log.Warning("Pod subnets not defined")
+		}
+		for _, vip_sn := range env.cfconfig.AppVipSubnet {
+			subnets = append(subnets, vip_sn)
+		}
+		for idx, subnet_str := range subnets {
+			_, subnet, err := net.ParseCIDR(subnet_str)
+			if err != nil {
+				env.log.Warning(fmt.Sprintf("Invalid subnet %s: ", subnet_str), err)
+			} else {
+				af := "ipv4"
+				if subnet.IP.To4() == nil && subnet.IP.To16() != nil {
+					af = "ipv6"
+				}
+				c2cSubj := apicapi.NewHostprotSubj(hpp.GetDn(), fmt.Sprintf("c2c-%d", idx))
+				c2cDn := c2cSubj.GetDn()
+				tcp := apicapi.NewHostprotRule(c2cDn, "c2c-tcp")
+				tcp.SetAttr("direction", "egress")
+				tcp.SetAttr("ethertype", af)
+				tcp.SetAttr("protocol", "tcp")
+				tcp_remote := apicapi.NewHostprotRemoteIp(tcp.GetDn(), subnet.String())
+				tcp.AddChild(tcp_remote)
+				c2cSubj.AddChild(tcp)
+
+				udp := apicapi.NewHostprotRule(c2cDn, "c2c-udp")
+				udp.SetAttr("direction", "egress")
+				udp.SetAttr("ethertype", af)
+				udp.SetAttr("protocol", "udp")
+				udp_remote := apicapi.NewHostprotRemoteIp(udp.GetDn(), subnet.String())
+				udp.AddChild(udp_remote)
+				c2cSubj.AddChild(udp)
+
+				hpp.AddChild(c2cSubj)
+			}
+		}
+	}
+
+	hppExtName := cont.aciNameForKey("hpp", "app-ext-ip")
+	hppExt := apicapi.NewHostprotPol(cont.config.AciPolicyTenant, hppExtName)
+	{
+		// Allow all incoming traffic to app port. To be used if app has external-IP
+		appSubj := apicapi.NewHostprotSubj(hppExt.GetDn(), "app-ext-ingress")
+		appDn := appSubj.GetDn()
+		appPortv4 := apicapi.NewHostprotRule(appDn, "app-port-v4")
+		appPortv4.SetAttr("direction", "ingress")
+		appPortv4.SetAttr("ethertype", "ipv4")
+		appPortv4.SetAttr("toPort", fmt.Sprintf("%d", env.cfconfig.AppPort))
+		appPortv4.SetAttr("protocol", "tcp")
+		appSubj.AddChild(appPortv4)
+
+		appPortv6 := apicapi.NewHostprotRule(appDn, "app-port-v6")
+		appPortv6.SetAttr("direction", "ingress")
+		appPortv6.SetAttr("ethertype", "ipv6")
+		appPortv6.SetAttr("toPort", fmt.Sprintf("%d", env.cfconfig.AppPort))
+		appPortv6.SetAttr("protocol", "tcp")
+		appSubj.AddChild(appPortv6)
+
+		hppExt.AddChild(appSubj)
+	}
+	cont.apicConn.WriteApicObjects(cont.config.AciPrefix+"_asg_static", apicapi.ApicSlice{hpp, hppExt})
+}
+
+func (env *CfEnvironment) CheckCfComponentsIps() bool {
+	// fetch go-router IPs
+	gorouter := env.cfconfig.GoRouterAddress
+	sshproxy := env.cfconfig.SshProxyAddress
+	resolv := net.Resolver{PreferGo: true}
+	rtrIps, err_rtr := resolv.LookupHost(context.Background(), gorouter)
+	if err_rtr != nil {
+		env.log.Warn(
+			"Failed to resolve gorouter DNS name "+gorouter+": ", err_rtr)
+	} else {
+		sort.Strings(rtrIps)
+	}
+	sshPxyIps, err_pxy := resolv.LookupHost(context.Background(), sshproxy)
+	if err_pxy != nil {
+		env.log.Warn(
+			"Failed to resolve SSH-proxy DNS name "+sshproxy+": ", err_pxy)
+	} else {
+		sort.Strings(sshPxyIps)
+	}
+	updated := false
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	if err_rtr == nil && !reflect.DeepEqual(env.goRouterIps, rtrIps) {
+		env.goRouterIps = rtrIps
+		updated = true
+		env.log.Info("Updated gorouters: ", env.goRouterIps)
+	}
+	if err_pxy == nil && !reflect.DeepEqual(env.sshProxyIps, sshPxyIps) {
+		env.sshProxyIps = sshPxyIps
+		updated = true
+		env.log.Info("Updated SSH-proxys: ", env.sshProxyIps)
+	}
+	return updated
+}
+
+func (env *CfEnvironment) UpdateHppForCfComponents() {
+	if !env.CheckCfComponentsIps() {
+		return
+	}
+
+	cont := env.cont
+	cfcompName := cont.aciNameForKey("hpp", "cf-components")
+	hpp := apicapi.NewHostprotPol(cont.config.AciPolicyTenant, cfcompName)
+
+	// Default app port and SSH port - ingress (+reply) allowed from GoRouter & SSH-proxy
+	appSubj := apicapi.NewHostprotSubj(hpp.GetDn(), "app-ingress")
+	appDn := appSubj.GetDn()
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	if len(env.goRouterIps) > 0 {
+		appPort := apicapi.NewHostprotRule(appDn, "app-port")
+		appPort.SetAttr("direction", "ingress")
+		appPort.SetAttr("ethertype", "ipv4") // TODO separate out v6
+		appPort.SetAttr("toPort", fmt.Sprintf("%d", env.cfconfig.AppPort))
+		appPort.SetAttr("protocol", "tcp")
+		for _, ip := range env.goRouterIps {
+			remote := apicapi.NewHostprotRemoteIp(appPort.GetDn(), ip)
+			appPort.AddChild(remote)
+		}
+		appSubj.AddChild(appPort)
+	}
+	if len(env.sshProxyIps) > 0 && env.cfconfig.CfNetIntfAddress != "" {
+		appSsh := apicapi.NewHostprotRule(appDn, "app-ssh")
+		appSsh.SetAttr("direction", "ingress")
+		appSsh.SetAttr("ethertype", "ipv4") // TODO separate out v6
+		appSsh.SetAttr("toPort", fmt.Sprintf("%d", env.cfconfig.SshPort))
+		appSsh.SetAttr("protocol", "tcp")
+		remote := apicapi.NewHostprotRemoteIp(appSsh.GetDn(), env.cfconfig.CfNetIntfAddress)
+		appSsh.AddChild(remote)
+		appSubj.AddChild(appSsh)
+	}
+	// update apps that support multiple ports
+	apps := make(map[string]struct{})
+	for _, cinfo := range env.contIdx {
+		if cinfo != nil && cinfo.AppId != "" && len(env.GetAdditionalPorts(cinfo)) > 0 {
+			apps[cinfo.AppId] = struct{}{}
+		}
+	}
+
+	for a, _ := range apps {
+		env.appUpdateQ.Add(a)
+	}
+	hpp.AddChild(appSubj)
+	cont.apicConn.WriteApicObjects(cont.config.AciPrefix+"_hpp_cf_comp", apicapi.ApicSlice{hpp})
+}
+
+// must be called with cont.indexMutex locked
+func (env *CfEnvironment) LoadCellNetworkInfo(cellId string) {
+	if _, ok := env.cont.nodePodNetCache[cellId]; ok {
+		return
+	}
+	kapi := env.etcdKeysApi
+	cellKey := etcd.CELL_KEY_BASE + "/" + cellId + "/network"
+	resp, err := kapi.Get(context.Background(), cellKey, nil)
+	if err != nil {
+		keyerr, ok := err.(etcdclient.Error)
+		if ok && keyerr.Code == etcdclient.ErrorCodeKeyNotFound {
+			env.log.Info(fmt.Sprintf("Etcd subtree %s doesn't exist yet", cellKey))
+		} else {
+			env.log.Error("Unable to fetch etcd cell network info: ", err)
+		}
+		return
+	}
+	nodePodNet := newNodePodNetMeta()
+	env.cont.nodePodNetCache[cellId] = nodePodNet
+	env.cont.mergePodNet(nodePodNet, resp.Node.Value, logrus.NewEntry(env.log))
+}
+
+// must be called with cont.indexMutex locked
+func (env *CfEnvironment) LoadCellServiceInfo(cellId string) bool {
+	nodeName := "diego-cell-" + cellId
+	if _, ok := env.cont.nodeServiceMetaCache[nodeName]; ok {
+		return false
+	}
+	nodeMeta := &nodeServiceMeta{}
+	kapi := env.etcdKeysApi
+	cellKey := etcd.CELL_KEY_BASE + "/" + cellId + "/service"
+	resp, err := kapi.Get(context.Background(), cellKey, nil)
+	if err != nil {
+		keyerr, ok := err.(etcdclient.Error)
+		if ok && keyerr.Code == etcdclient.ErrorCodeKeyNotFound {
+			env.log.Info(fmt.Sprintf("Etcd subtree %s doesn't exist yet", cellKey))
+		} else {
+			env.log.Error("Unable to fetch etcd cell service info: ", err)
+			return false
+		}
+	} else {
+		err = json.Unmarshal([]byte(resp.Node.Value), &nodeMeta.serviceEp)
+		if err != nil {
+			env.log.Warn("Could not parse cell service info: ", err)
+		}
+	}
+	err = env.cont.createServiceEndpoint(&nodeMeta.serviceEp)
+	if err != nil {
+		env.log.Error("Couldn't create service EP info for cell: ", err)
+		return false
+	}
+	raw, err := json.Marshal(&nodeMeta.serviceEp)
+	if err != nil {
+		env.log.Error("Could not marshal cell service info: ", err)
+	} else {
+		_, err = kapi.Set(context.Background(), cellKey, string(raw), nil)
+		if err != nil {
+			env.log.Error("Error setting etcd service info for cell: ", err)
+		} else {
+			env.log.Debug(fmt.Sprintf("Wrote to etcd %s = %s", cellKey, string(raw)))
+		}
+	}
+	if err == nil {
+		env.cont.nodeServiceMetaCache[nodeName] = nodeMeta
+		return true
+	} else {
+		if nodeMeta.serviceEp.Ipv4 != nil {
+			env.cont.nodeServiceIps.V4.AddIp(nodeMeta.serviceEp.Ipv4)
+		}
+		if nodeMeta.serviceEp.Ipv6 != nil {
+			env.cont.nodeServiceIps.V6.AddIp(nodeMeta.serviceEp.Ipv6)
+		}
+	}
+	return false
+}
+
+// must be called with cont.indexMutex locked
 func (env *CfEnvironment) NodePodNetworkChanged(nodename string) {
+	env.cont.indexMutex.Lock()
+	podnet, ok := env.cont.nodePodNetCache[nodename]
+	env.cont.indexMutex.Unlock()
+	if ok {
+		cellKey := etcd.CELL_KEY_BASE + "/" + nodename
+		kapi := env.etcdKeysApi
+		_, err := kapi.Set(context.Background(), cellKey+"/network", podnet.podNetIpsAnnotation, nil)
+		if err != nil {
+			env.log.Error("Error setting etcd net info for cell: ", err)
+		}
+	}
 }
 
 func (env *CfEnvironment) NodeServiceChanged(nodeName string) {
+	cellId := strings.TrimPrefix(nodeName, "diego-cell-")
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	apps := make(map[string]struct{})
+	for _, cinfo := range env.contIdx {
+		if cinfo != nil && cinfo.CellId == cellId {
+			apps[cinfo.AppId] = struct{}{}
+		}
+	}
+
+	for id, _ := range apps {
+		env.appUpdateQ.Add(id)
+	}
 }
 
-func (env *CfEnvironment) PrepareRun(stopCh <-chan struct{}) error {
-	return nil
+func (env *CfEnvironment) processQueue(queue workqueue.RateLimitingInterface,
+	handler func(interface{}) bool, stopCh <-chan struct{}) {
+	go wait.Until(func() {
+		for {
+			key, quit := queue.Get()
+			if quit {
+				break
+			}
+
+			requeue := handler(key)
+			if requeue {
+				queue.AddRateLimited(key)
+			} else {
+				queue.Forget(key)
+			}
+			queue.Done(key)
+		}
+	}, time.Second, stopCh)
+	<-stopCh
+	queue.ShutDown()
 }

--- a/pkg/controller/cf_environment_test.go
+++ b/pkg/controller/cf_environment_test.go
@@ -1,0 +1,171 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"code.cloudfoundry.org/bbs/models"
+	etcdclient "github.com/coreos/etcd/client"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/net/context"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+	"github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func TestCfLoadCellNetworkInfo(t *testing.T) {
+	env := testCfEnvironment(t)
+	k := env.fakeEtcdKeysApi()
+	cellId := "cell-1"
+	key := etcd.CELL_KEY_BASE + "/" + cellId + "/network"
+	ctx := context.Background()
+
+	env.LoadCellNetworkInfo(cellId)
+	_, ok := env.cont.nodePodNetCache[cellId]
+	assert.False(t, ok)
+
+	nodeMeta := newNodePodNetMeta()
+	nodeMeta.podNetIps.V4 = append(nodeMeta.podNetIps.V4,
+		ipam.IpRange{Start: net.ParseIP("10.10.0.1"), End: net.ParseIP("10.10.0.24")})
+	nodeMeta.podNetIps.V6 = append(nodeMeta.podNetIps.V6,
+		ipam.IpRange{Start: net.ParseIP("::fe80"), End: net.ParseIP("::fe90")})
+	env.cont.recomputePodNetAnnotation(nodeMeta)
+
+	k.Set(ctx, key, nodeMeta.podNetIpsAnnotation, nil)
+	env.LoadCellNetworkInfo(cellId)
+	r, ok := env.cont.nodePodNetCache[cellId]
+	assert.True(t, ok)
+	assert.Equal(t, nodeMeta.podNetIpsAnnotation, r.podNetIpsAnnotation)
+
+	k.Delete(ctx, key, nil)
+	env.LoadCellNetworkInfo(cellId)
+	r, ok = env.cont.nodePodNetCache[cellId]
+	assert.True(t, ok)
+	assert.Equal(t, nodeMeta.podNetIpsAnnotation, r.podNetIpsAnnotation)
+}
+
+func TestCfLoadCellServiceInfo(t *testing.T) {
+	env := testCfEnvironment(t)
+	k := env.fakeEtcdKeysApi()
+	cellId := "cell-1"
+	nodename := "diego-cell-" + cellId
+	key := etcd.CELL_KEY_BASE + "/" + cellId + "/service"
+	ctx := context.Background()
+
+	// cleanup initial state
+	delete(env.cont.nodeServiceMetaCache, nodename)
+
+	env.LoadCellServiceInfo(cellId)
+	r, ok := env.cont.nodeServiceMetaCache[nodename]
+	assert.True(t, ok)
+	assert.NotEqual(t, "", r.serviceEp.Mac)
+	assert.NotNil(t, r.serviceEp.Ipv4)
+	assert.NotNil(t, r.serviceEp.Ipv6)
+
+	svcEpStr, _ := json.Marshal(r.serviceEp)
+	v, _ := k.Get(ctx, key, nil)
+	assert.Equal(t, string(svcEpStr), v.Node.Value)
+
+	delete(env.cont.nodeServiceMetaCache, nodename)
+	svcEP := metadata.ServiceEndpoint{Mac: "aa:bb:cc:dd:ee:ff",
+		Ipv4: net.ParseIP("1.0.0.10"),
+		Ipv6: net.ParseIP("a1::1a"),
+	}
+	svcEpStr, _ = json.Marshal(&svcEP)
+	k.Set(ctx, key, string(svcEpStr), nil)
+	env.LoadCellServiceInfo(cellId)
+	r, ok = env.cont.nodeServiceMetaCache[nodename]
+	assert.True(t, ok)
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", r.serviceEp.Mac)
+	assert.Equal(t, net.ParseIP("1.0.0.10"), r.serviceEp.Ipv4)
+	assert.Equal(t, net.ParseIP("a1::1a"), r.serviceEp.Ipv6)
+	v, _ = k.Get(ctx, key, nil)
+	assert.Equal(t, string(svcEpStr), v.Node.Value)
+
+	k.Delete(ctx, key, nil)
+	env.LoadCellServiceInfo(cellId)
+	r, ok = env.cont.nodeServiceMetaCache[nodename]
+	assert.True(t, ok)
+	assert.Equal(t, "aa:bb:cc:dd:ee:ff", r.serviceEp.Mac)
+	assert.Equal(t, net.ParseIP("1.0.0.10"), r.serviceEp.Ipv4)
+	assert.Equal(t, net.ParseIP("a1::1a"), r.serviceEp.Ipv6)
+}
+
+func TestCfEtcdStaleCleanup(t *testing.T) {
+	env := testCfEnvironment(t)
+	k := env.fakeEtcdKeysApi()
+	ctx := context.Background()
+
+	k.Set(ctx, "/aci", "", nil)
+	keys := []string{"/aci/cells/cell-1/containers/c-stale",
+		"/aci/cells/cell-10/containers/c-1",
+		"/aci/apps/app-stale"}
+	for _, ky := range keys {
+		k.Set(ctx, ky, "", nil)
+	}
+
+	env.cleanupEtcdContainers()
+	err := etcdclient.Error{Code: etcdclient.ErrorCodeKeyNotFound}
+	for _, ky := range keys {
+		resp, e := k.Get(ctx, ky, nil)
+		assert.Nil(t, resp)
+		assert.Equal(t, err, e)
+	}
+}
+
+func TestCfInitStaticAciObjects(t *testing.T) {
+	env := testCfEnvironment(t)
+	env.cont.config.PodSubnets = []string{"10.10.0.1/16"}
+	env.cfconfig.AppVipSubnet = []string{"10.250.4.1/24", "aa::2e00/120"}
+	env.InitStaticAciObjects()
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("cf_asg_static"))
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("cf_service_static"))
+}
+
+func TestCfUpdateHppForCfComponents(t *testing.T) {
+	env := testCfEnvironment(t)
+	env.cfconfig.GoRouterAddress = "96.97.98.99"
+	env.cfconfig.SshProxyAddress = "86.87.88.89"
+	env.contIdx["c-1"].Ports = append(env.contIdx["c-1"].Ports,
+		&models.PortMapping{ContainerPort: 7777, HostPort: 32},
+		&models.PortMapping{ContainerPort: 8888, HostPort: 33})
+	env.contIdx["c-3"].Ports = append(env.contIdx["c-3"].Ports,
+		&models.PortMapping{ContainerPort: 7777, HostPort: 32},
+		&models.PortMapping{ContainerPort: 8888, HostPort: 33})
+
+	env.UpdateHppForCfComponents()
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("cf_hpp_cf_comp"))
+	waitForGetList(t, env.appUpdateQ, 500*time.Millisecond, []interface{}{"app-1", "app-2"})
+}
+
+func TestCfNodePodNetworkChanged(t *testing.T) {
+	env := testCfEnvironment(t)
+	env.cont.nodePodNetCache["cell-10"] = &nodePodNetMeta{podNetIpsAnnotation: "some-annotation"}
+
+	env.NodePodNetworkChanged("cell-10")
+	v, _ := env.fakeEtcdKeysApi().Get(context.Background(), "/aci/cells/cell-10/network", nil)
+	assert.Equal(t, "some-annotation", v.Node.Value)
+}
+
+func TestCfNodeServiceChanged(t *testing.T) {
+	env := testCfEnvironment(t)
+	env.NodeServiceChanged("diego-cell-cell-1")
+	waitForGetList(t, env.appUpdateQ, 500*time.Millisecond, []interface{}{"app-1", "app-2", "app-3"})
+}

--- a/pkg/controller/cf_etcd_watcher.go
+++ b/pkg/controller/cf_etcd_watcher.go
@@ -1,0 +1,84 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	etcdclient "github.com/coreos/etcd/client"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func NewCfEtcdContainersWatcher(env *CfEnvironment) *etcd.CfEtcdWatcher {
+	key := etcd.CONTROLLER_KEY_BASE + "/containers"
+	handleEtcdNode := func(action *string, node *etcdclient.Node) error {
+		if strings.HasPrefix(node.Key, key) {
+			return env.handleEtcdContainerNode(action, node)
+		}
+		return nil
+	}
+
+	return etcd.NewEtcdWatcher(env.etcdKeysApi, key, handleEtcdNode, env.log)
+}
+
+func (env *CfEnvironment) handleEtcdContainerNode(action *string, node *etcdclient.Node) error {
+	if etcd.IsDeleteAction(action) {
+		return nil
+	}
+	isMdNode := strings.HasSuffix(node.Key, "/metadata")
+	if !isMdNode {
+		return nil
+	}
+	key_parts := strings.Split(node.Key, "/")
+	ctId := key_parts[len(key_parts)-2]
+
+	md := md.ContainerMetadata{Id: md.ContainerId{ContId: ctId}}
+	err := json.Unmarshal([]byte(node.Value), &md.Ifaces)
+	if err != nil {
+		env.log.Error("Error deserializing container metadata: ", err)
+		return nil
+	}
+	if len(md.Ifaces) == 0 || len(md.Ifaces[0].IPs) == 0 {
+		return nil
+	}
+
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	ct := env.contIdx[ctId]
+	if ct == nil || ct.IsApp() {
+		return nil
+	}
+	ct.IpAddress = md.Ifaces[0].IPs[0].Address.IP.String()
+	env.contIdx[ctId] = ct
+	env.log.Debug(fmt.Sprintf("Container updated due to metadata event: %+v", ct))
+	var app *AppInfo
+	if ct.AppId != "" {
+		app = env.appIdx[ct.AppId]
+		if app != nil {
+			app.ContainerIps[ctId] = ct.IpAddress
+			env.appIdx[ct.AppId] = app
+		}
+	}
+
+	if app != nil {
+		env.appUpdateQ.Add(app.AppId)
+	}
+	env.containerUpdateQ.Add(ctId)
+	return nil
+}

--- a/pkg/controller/cf_etcd_watcher_test.go
+++ b/pkg/controller/cf_etcd_watcher_test.go
@@ -1,0 +1,105 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	etcdclient "github.com/coreos/etcd/client"
+	"github.com/stretchr/testify/assert"
+
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func TestCfHandleEtcdContainerNode(t *testing.T) {
+	env := testCfEnvironment(t)
+	handler := NewCfEtcdContainersWatcher(env).NodeHandler()
+	op := "set"
+
+	env.contIdx["c-5"] = &ContainerInfo{ContainerId: "c-5", CellId: "cell-1", InstanceIndex: -1,
+		AppId: "app-1"}
+	env.contIdx["c-6"] = &ContainerInfo{ContainerId: "c-6", CellId: "cell-1", InstanceIndex: -2,
+		AppId: "app-1"}
+	env.contIdx["c-7"] = &ContainerInfo{ContainerId: "c-7", CellId: "cell-1", InstanceIndex: -2,
+		AppId: "app-2"}
+
+	ifaces_c5 := []*md.ContainerIfaceMd{
+		&md.ContainerIfaceMd{
+			HostVethName: "veth1",
+			Mac:          "1:2:3:4:5:6",
+			IPs: []md.ContainerIfaceIP{
+				md.ContainerIfaceIP{
+					Address: net.IPNet{
+						IP: net.ParseIP("10.255.0.45")}}}}}
+	ifaces_c6 := []*md.ContainerIfaceMd{
+		&md.ContainerIfaceMd{HostVethName: "veth1", Mac: "1:2:3:4:5:8"}}
+	ifaces_c7 := []*md.ContainerIfaceMd{
+		&md.ContainerIfaceMd{
+			HostVethName: "veth1",
+			Mac:          "1:2:3:4:5:7",
+			IPs: []md.ContainerIfaceIP{
+				md.ContainerIfaceIP{
+					Address: net.IPNet{
+						IP: net.ParseIP("10.255.0.46")}}}}}
+
+	ifaces_c5_str, _ := json.Marshal(ifaces_c5)
+	ifaces_c6_str, _ := json.Marshal(ifaces_c6)
+	ifaces_c7_str, _ := json.Marshal(ifaces_c7)
+
+	node_c5 := &etcdclient.Node{
+		Key: "/aci/controller/containers/c-5/metadata", Value: string(ifaces_c5_str)}
+	node_c6 := &etcdclient.Node{
+		Key: "/aci/controller/containers/c-6/metadata", Value: string(ifaces_c6_str)}
+	node_c7 := &etcdclient.Node{
+		Key: "/aci/controller/containers/c-7/metadata", Value: string(ifaces_c7_str)}
+
+	handler(&op, node_c5)
+	assert.Equal(t, "10.255.0.45", env.contIdx["c-5"].IpAddress)
+	assert.Equal(t, "10.255.0.45", env.appIdx["app-1"].ContainerIps["c-5"])
+
+	handler(&op, node_c6)
+	assert.Equal(t, "", env.contIdx["c-6"].IpAddress)
+	assert.Equal(t, "", env.appIdx["app-1"].ContainerIps["c-6"])
+
+	handler(&op, node_c7)
+	assert.Equal(t, "10.255.0.46", env.contIdx["c-7"].IpAddress)
+	assert.Equal(t, "10.255.0.46", env.appIdx["app-2"].ContainerIps["c-7"])
+
+	op = "delete"
+	node_c5.Key = "/aci/controller/containers/c-5"
+	handler(&op, node_c5)
+	assert.Equal(t, "10.255.0.45", env.contIdx["c-5"].IpAddress)
+	assert.Equal(t, "10.255.0.45", env.appIdx["app-1"].ContainerIps["c-5"])
+}
+
+func TestCfEtcdWatcherCancel(t *testing.T) {
+	env := testCfEnvironment(t)
+	cw := NewCfEtcdContainersWatcher(env)
+	ch := make(chan struct{})
+	runEnded := false
+	go func() {
+		cw.Run(ch)
+		runEnded = true
+	}()
+	tu.WaitFor(t, "Waiting to sync", 500*time.Millisecond,
+		func(bool) (bool, error) { return cw.Synced(), nil })
+	close(ch)
+	tu.WaitFor(t, "Waiting for Run() to end", 1000*time.Millisecond,
+		func(bool) (bool, error) { return runEnded, nil })
+}

--- a/pkg/controller/cf_poller.go
+++ b/pkg/controller/cf_poller.go
@@ -1,0 +1,119 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type PollFunc func() (map[string]interface{}, interface{}, error)
+type HandleFunc func(updates map[string]interface{}, deletes map[string]interface{})
+
+type CfPoller struct {
+	name         string
+	pollInterval time.Duration
+	errorDelay   time.Duration
+	poller       PollFunc
+	handler      HandleFunc
+	data         map[string]interface{}
+	synced       bool
+	log          *logrus.Logger
+}
+
+func NewCfPoller(name string, interval, errDelay time.Duration, pf PollFunc, hf HandleFunc,
+	log *logrus.Logger) *CfPoller {
+	p := &CfPoller{name: name, pollInterval: interval, errorDelay: errDelay, poller: pf,
+		handler: hf, data: make(map[string]interface{}), synced: false, log: log}
+	return p
+}
+
+func (p *CfPoller) Run(immediate bool, stopCh <-chan struct{}) {
+	initDelay := p.pollInterval
+	if immediate {
+		initDelay = 1 * time.Millisecond
+	}
+	timer := time.NewTimer(initDelay)
+	var oldRespHash interface{}
+
+	p.synced = false
+	p.data = make(map[string]interface{})
+	for {
+		select {
+		case <-stopCh:
+			p.log.Debug(fmt.Sprintf("%s polling terminated", p.name))
+			return
+
+		case <-timer.C:
+			pollRes, newRespHash, err := p.poller()
+			if err != nil {
+				p.log.Error(fmt.Sprintf("%s polling error: %s", p.name, err))
+				if p.errorDelay > 0 {
+					timer.Reset(p.errorDelay)
+				} else {
+					timer.Reset(p.pollInterval)
+				}
+				continue
+			}
+			if newRespHash != nil && reflect.DeepEqual(newRespHash, oldRespHash) {
+				// no change
+				timer.Reset(p.pollInterval)
+				continue
+			}
+			p.log.Debug(fmt.Sprintf("%s polling got updates - fetched %d objects, oldHash %v newHash %v",
+				p.name, len(pollRes), oldRespHash, newRespHash))
+
+			updated := make(map[string]interface{})
+			deleted := make(map[string]interface{})
+			to_delete := make(map[string]struct{})
+			for k, _ := range p.data {
+				to_delete[k] = struct{}{}
+			}
+			for k, v := range pollRes {
+				old_v, ok := p.data[k]
+				if !ok || !reflect.DeepEqual(old_v, v) {
+					updated[k] = v
+				}
+				p.data[k] = v
+				delete(to_delete, k)
+			}
+			for k, _ := range to_delete {
+				deleted[k] = p.data[k]
+				delete(p.data, k)
+			}
+			p.handler(updated, deleted)
+			if !p.synced {
+				p.synced = true
+			}
+			oldRespHash = newRespHash
+			timer.Reset(p.pollInterval)
+		}
+	}
+}
+
+func (p *CfPoller) Synced() bool {
+	return p.synced
+}
+
+func (p *CfPoller) Poller() PollFunc {
+	return p.poller
+}
+
+func (p *CfPoller) Handler() HandleFunc {
+	return p.handler
+}

--- a/pkg/controller/cf_poller_test.go
+++ b/pkg/controller/cf_poller_test.go
@@ -1,0 +1,91 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func TestCfPoller(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	iter := 0
+	pf := func() (map[string]interface{}, interface{}, error) {
+		out := make(map[string]interface{})
+		var hash interface{}
+		switch iter {
+		case 0:
+			iter += 1
+			return nil, nil, fmt.Errorf("fake error")
+		case 1:
+			fallthrough
+		case 2:
+			out["a"] = "a"
+			out["b"] = "b"
+			hash = "a"
+			iter += 1
+		case 3:
+			out["a"] = "a1"
+			out["c"] = "c"
+			hash = "c"
+			iter += 1
+		}
+		return out, hash, nil
+	}
+
+	handle_count := 0
+	hf := func(updates map[string]interface{}, deletes map[string]interface{}) {
+		switch iter {
+		case 2:
+			assert.Equal(t, 0, handle_count)
+			assert.Contains(t, updates, "a")
+			assert.Contains(t, updates, "b")
+			assert.Equal(t, 0, len(deletes))
+			handle_count += 1
+		case 4:
+			assert.Equal(t, 1, handle_count)
+			assert.Contains(t, updates, "a")
+			assert.Contains(t, updates, "c")
+			assert.Contains(t, deletes, "b")
+			handle_count += 1
+		default:
+			assert.False(t, true)
+		}
+	}
+
+	poller := NewCfPoller("test", 50*time.Millisecond, 0, pf, hf, env.log)
+	runEnded := false
+	ch := make(chan struct{})
+	go func() {
+		poller.Run(true, ch)
+		runEnded = true
+	}()
+	tu.WaitFor(t, "Waiting to sync", 200*time.Millisecond,
+		func(bool) (bool, error) { return poller.Synced(), nil })
+	tu.WaitFor(t, "Waiting for all poll iterations", 500*time.Millisecond,
+		func(bool) (bool, error) { return iter > 3, nil })
+	tu.WaitFor(t, "Waiting for all handle iterations", 500*time.Millisecond,
+		func(bool) (bool, error) { return handle_count == 2, nil })
+
+	close(ch)
+	tu.WaitFor(t, "Waiting for Run() to end", 500*time.Millisecond,
+		func(bool) (bool, error) { return runEnded, nil })
+}

--- a/pkg/controller/cf_update_handlers.go
+++ b/pkg/controller/cf_update_handlers.go
@@ -1,0 +1,550 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sort"
+	"strings"
+
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
+	etcdclient "github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+
+	"github.com/noironetworks/aci-containers/pkg/apicapi"
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+	"github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func (env *CfEnvironment) handleContainerUpdate(contId string) bool {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	return env.handleContainerUpdateLocked(contId)
+}
+
+func (env *CfEnvironment) handleContainerDelete(cinfo *ContainerInfo) bool {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	return env.handleContainerDeleteLocked(cinfo)
+}
+
+func (env *CfEnvironment) handleContainerUpdateLocked(contId string) bool {
+	retry := false
+	cinfo := env.contIdx[contId]
+	if cinfo == nil || cinfo.AppId == "" {
+		return false
+	}
+	epgTenant := env.cont.config.DefaultEg.PolicySpace
+	epg := env.cont.config.DefaultEg.Name
+
+	appInfo, ok := env.appIdx[cinfo.AppId]
+	var sg *[]string
+	var spaceInfo *SpaceInfo
+	if ok && appInfo != nil && appInfo.SpaceId != "" {
+		spaceInfo = env.spaceIdx[appInfo.SpaceId]
+		if spaceInfo != nil {
+			if cinfo.IsStaging() {
+				sg = &spaceInfo.StagingSecurityGroups
+			} else {
+				sg = &spaceInfo.RunningSecurityGroups
+			}
+			if is := env.isoSegIdx[spaceInfo.IsolationSegment]; is != nil && is.Name != "" {
+				epg = env.cfconfig.DefaultAppProfile + "|" + is.Name
+			} else {
+				epg_ann_db := EpgAnnotationDb{}
+				txn, _ := env.db.Begin()
+				v, err := epg_ann_db.ResolveAnnotation(txn, cinfo.AppId,
+					appInfo.SpaceId, spaceInfo.OrgId)
+				if err != nil {
+					env.log.Error("Failed to resolve EPG annotation: ", err)
+					retry = true
+				} else if v != "" {
+					if strings.Contains(v, "|") {
+						epg = v
+					} else {
+						epg = env.cfconfig.DefaultAppProfile + "|" + v
+					}
+				}
+				txn.Commit()
+			}
+		}
+	}
+	env.log.Debug(fmt.Sprintf("Handling container update: %+v", cinfo))
+	if cinfo.CellId != "" {
+
+		env.cont.indexMutex.Lock()
+		env.LoadCellNetworkInfo(cinfo.CellId)
+		newCellSvc := env.LoadCellServiceInfo(cinfo.CellId)
+		env.cont.addPodToNode(cinfo.CellId, contId)
+		env.cont.indexMutex.Unlock()
+		if newCellSvc {
+			env.log.Info("Updating device-cluster for new cell ", cinfo.CellId)
+			env.cont.updateDeviceCluster()
+		}
+
+		ctKey := etcd.CELL_KEY_BASE + "/" + cinfo.CellId + "/containers/" + cinfo.ContainerId
+		ep := etcd.EpInfo{AppId: cinfo.AppId,
+			AppName:       appInfo.AppName,
+			InstanceIndex: cinfo.InstanceIndex,
+			IpAddress:     cinfo.IpAddress,
+			EpgTenant:     epgTenant,
+			Epg:           epg,
+			TaskName:      cinfo.TaskName}
+		if spaceInfo != nil {
+			ep.SpaceId = spaceInfo.SpaceId
+			ep.OrgId = spaceInfo.OrgId
+		}
+		for _, pm := range cinfo.Ports {
+			ep.PortMapping = append(ep.PortMapping,
+				etcd.PortMap{ContainerPort: pm.ContainerPort, HostPort: pm.HostPort})
+		}
+		ep.SecurityGroups = append(ep.SecurityGroups,
+			etcd.GroupInfo{Group: env.cont.aciNameForKey("hpp", "static"),
+				Tenant: env.cont.config.AciPolicyTenant})
+		ep.SecurityGroups = append(ep.SecurityGroups,
+			etcd.GroupInfo{Group: env.cont.aciNameForKey("hpp", "cf-components"),
+				Tenant: env.cont.config.AciPolicyTenant})
+		if sg != nil {
+			for _, s := range *sg {
+				ep.SecurityGroups = append(ep.SecurityGroups,
+					etcd.GroupInfo{Group: env.cont.aciNameForKey("asg", s),
+						Tenant: env.cont.config.AciPolicyTenant})
+			}
+		}
+		_, ok := env.netpolIdx[cinfo.AppId]
+		if ok {
+			ep.SecurityGroups = append(ep.SecurityGroups,
+				etcd.GroupInfo{Group: env.cont.aciNameForKey("np", cinfo.AppId),
+					Tenant: env.cont.config.AciPolicyTenant})
+		}
+		if len(appInfo.ExternalIp) > 0 {
+			ep.SecurityGroups = append(ep.SecurityGroups,
+				etcd.GroupInfo{Group: env.cont.aciNameForKey("hpp", "app-ext-ip"),
+					Tenant: env.cont.config.AciPolicyTenant})
+		}
+		if len(env.GetAdditionalPorts(cinfo)) > 0 {
+			ep.SecurityGroups = append(ep.SecurityGroups,
+				etcd.GroupInfo{Group: env.cont.aciNameForKey("hpp", "app-port:"+cinfo.AppId),
+					Tenant: env.cont.config.AciPolicyTenant})
+		}
+		ep_json, err := json.Marshal(ep)
+		if err != nil {
+			env.log.Error("Unable to serialize EP info: ", err)
+		} else {
+			kapi := env.etcdKeysApi
+			_, err = kapi.Set(context.Background(), ctKey+"/ep", string(ep_json), nil)
+			if err != nil {
+				env.log.Error("Error setting container info: ", err)
+				retry = true
+			} else {
+				env.log.Debug(fmt.Sprintf("Wrote to etcd %s = %s", ctKey+"/ep", string(ep_json)))
+			}
+		}
+	}
+	return retry
+}
+
+func (env *CfEnvironment) handleContainerDeleteLocked(cinfo *ContainerInfo) bool {
+	retry := false
+	env.log.Debug(fmt.Sprintf("Handling container delete: %+v", *cinfo))
+	if cinfo.CellId != "" {
+		env.cont.indexMutex.Lock()
+		env.cont.removePodFromNode(cinfo.CellId, cinfo.ContainerId)
+		env.cont.indexMutex.Unlock()
+
+		kapi := env.etcdKeysApi
+		ctKey := etcd.CELL_KEY_BASE + "/" + cinfo.CellId + "/containers/" + cinfo.ContainerId
+		_, err := kapi.Delete(context.Background(), ctKey, &etcdclient.DeleteOptions{Recursive: true})
+		if err != nil {
+			env.log.Error("Error deleting container node: ", err)
+			retry = true
+		}
+	}
+	return retry
+}
+
+func (env *CfEnvironment) handleAppUpdateLocked(appId string) bool {
+	retry := false
+	ainfo, ok := env.appIdx[appId]
+	if !ok || ainfo == nil {
+		return false
+	}
+	env.log.Debug(fmt.Sprintf("Handling app update: %+v", ainfo))
+
+	ai := etcd.AppInfo{}
+	if ainfo.VipV4 != "" {
+		ai.VirtualIp = append(ai.VirtualIp, ainfo.VipV4)
+	}
+	if ainfo.VipV6 != "" {
+		ai.VirtualIp = append(ai.VirtualIp, ainfo.VipV6)
+	}
+	addPorts := make(map[int]struct{})
+	for cid, cip := range ainfo.ContainerIps {
+		if cinfo := env.contIdx[cid]; cinfo != nil {
+			if cinfo.IsApp() {
+				ai.ContainerIps = append(ai.ContainerIps, cip)
+			}
+			for p := range env.GetAdditionalPorts(cinfo) {
+				addPorts[p] = struct{}{}
+			}
+		}
+	}
+	sort.Strings(ai.ContainerIps) // mainly done for unit-tests
+	for _, eip := range ainfo.ExternalIp {
+		ai.ExternalIp = append(ai.ExternalIp, eip)
+	}
+	app_json, err := json.Marshal(ai)
+	if err != nil {
+		env.log.Error("Unable to serialize App info: ", err)
+	} else {
+		kapi := env.etcdKeysApi
+		appKey := etcd.APP_KEY_BASE + "/" + appId
+		_, err = kapi.Set(context.Background(), appKey, string(app_json), nil)
+		if err != nil {
+			env.log.Error("Error setting app info: ", err)
+			retry = true
+		}
+	}
+	if len(ai.ExternalIp) > 0 {
+		sgobjs := env.createAppServiceGraph(appId, ai.ExternalIp)
+		env.cont.apicConn.WriteApicObjects("app_ext_ip:"+appId, sgobjs)
+	} else {
+		env.cont.apicConn.ClearApicObjects("app_ext_ip:" + appId)
+	}
+
+	if len(addPorts) > 0 && (len(ai.ExternalIp) > 0 || len(env.goRouterIps) > 0) {
+		appHppName := env.cont.aciNameForKey("hpp", "app-port:"+appId)
+		hpp := apicapi.NewHostprotPol(env.cont.config.AciPolicyTenant, appHppName)
+
+		appSubj := apicapi.NewHostprotSubj(hpp.GetDn(), "app-ingress")
+		appDn := appSubj.GetDn()
+		for p, _ := range addPorts {
+			ps := fmt.Sprintf("%d", p)
+			appPort := apicapi.NewHostprotRule(appDn, "app-port:"+ps)
+			appPort.SetAttr("direction", "ingress")
+			appPort.SetAttr("ethertype", "ipv4") // TODO separate out v6
+			appPort.SetAttr("toPort", ps)
+			appPort.SetAttr("protocol", "tcp")
+			if len(ai.ExternalIp) == 0 {
+				for _, ip := range env.goRouterIps {
+					remote := apicapi.NewHostprotRemoteIp(appPort.GetDn(), ip)
+					appPort.AddChild(remote)
+				}
+			}
+			appSubj.AddChild(appPort)
+		}
+		hpp.AddChild(appSubj)
+		env.cont.apicConn.WriteApicObjects("app-port:"+appId, apicapi.ApicSlice{hpp})
+	} else {
+		env.cont.apicConn.ClearApicObjects("app-port:" + appId)
+	}
+
+	// find destination PolIds for which this App is a source
+	var dstPolIds []string
+	for k, info := range env.netpolIdx {
+		if _, ok := info[appId]; ok {
+			dstPolIds = append(dstPolIds, k)
+		}
+	}
+	env.log.Debug("Dst policy Ids to update: ", dstPolIds)
+	for _, d := range dstPolIds {
+		hpp := env.createHppForNetPol(&d)
+		env.cont.apicConn.WriteApicObjects("np:"+d, hpp)
+	}
+	return retry
+}
+
+func (env *CfEnvironment) handleAppUpdate(appId string) bool {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	return env.handleAppUpdateLocked(appId)
+}
+
+// must be called with indexLock locked
+func (env *CfEnvironment) createAppServiceGraph(appId string, extIps []string) apicapi.ApicSlice {
+	ainfo := env.appIdx[appId]
+	if ainfo == nil {
+		return nil
+	}
+	cont := env.cont
+	cont.indexMutex.Lock()
+	nodeMap := make(map[string]*metadata.ServiceEndpoint)
+	for cid, _ := range ainfo.ContainerIps {
+		if cinfo, _ := env.contIdx[cid]; cinfo != nil {
+			nodename := "diego-cell-" + cinfo.CellId
+			nodeMeta, ok := cont.nodeServiceMetaCache[nodename]
+			if !ok {
+				continue
+			}
+			_, ok = cont.fabricPathForNode(nodename)
+			if !ok {
+				continue
+			}
+			nodeMap[nodename] = &nodeMeta.serviceEp
+		}
+	}
+	cont.indexMutex.Unlock()
+
+	var nodes []string
+	for node, _ := range nodeMap {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+
+	name := cont.aciNameForKey("ext", appId)
+	graphName := cont.aciNameForKey("svc", "global")
+	var serviceObjs apicapi.ApicSlice
+
+	if len(nodes) > 0 {
+		// 1. Service redirect policy
+		rp, rpDn :=
+			apicRedirectPol(name, cont.config.AciVrfTenant, nodes, nodeMap)
+		serviceObjs = append(serviceObjs, rp)
+
+		// 2. Service graph contract and external network
+		serviceObjs = append(serviceObjs,
+			apicExtNet(name, cont.config.AciVrfTenant,
+				cont.config.AciL3Out, extIps))
+
+		serviceObjs = append(serviceObjs,
+			apicContract(name, cont.config.AciVrfTenant, graphName))
+
+		for _, net := range cont.config.AciExtNetworks {
+			serviceObjs = append(serviceObjs,
+				apicExtNetCons(name, cont.config.AciVrfTenant,
+					cont.config.AciL3Out, net))
+		}
+		{
+			filter := apicapi.NewVzFilter(cont.config.AciVrfTenant, name)
+			fe := apicapi.NewVzEntry(filter.GetDn(), "tcp")
+			fe.SetAttr("etherT", "ip")
+			fe.SetAttr("prot", "tcp")
+			filter.AddChild(fe)
+			serviceObjs = append(serviceObjs, filter)
+		}
+
+		// 3. Device cluster context
+		serviceObjs = append(serviceObjs,
+			apicDevCtx(name, cont.config.AciVrfTenant, graphName,
+				cont.aciNameForKey("bd", cont.env.ServiceBd()), rpDn))
+	}
+	return serviceObjs
+}
+
+func (env *CfEnvironment) handleAppDeleteLocked(appId string, ainfo *AppInfo) bool {
+	retry := false
+	kapi := env.etcdKeysApi
+	appKey := etcd.APP_KEY_BASE + "/" + appId
+	_, err := kapi.Delete(context.Background(), appKey, &etcdclient.DeleteOptions{Recursive: true})
+	if err != nil {
+		env.log.Error("Error deleting app etcd node: ", err)
+		retry = true
+	}
+
+	env.cleanupEpgAnnotation(appId, CF_OBJ_APP)
+	env.releaseAppVip(appId)
+	env.releaseAppExtIp(appId)
+	env.cont.apicConn.ClearApicObjects("app_ext_ip:" + appId)
+	env.cont.apicConn.ClearApicObjects("app-port:" + appId)
+	return retry
+}
+
+func (env *CfEnvironment) handleAppDelete(ainfo *AppInfo) bool {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	return env.handleAppDeleteLocked(ainfo.AppId, ainfo)
+}
+
+func (env *CfEnvironment) scheduleAppContainersUpdateLocked(appId string) {
+	ai := env.appIdx[appId]
+	if ai == nil {
+		return
+	}
+	for k := range ai.ContainerIps {
+		env.containerUpdateQ.Add(k)
+	}
+}
+
+func (env *CfEnvironment) scheduleAppContainersUpdate(appId string) {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	env.scheduleAppContainersUpdateLocked(appId)
+}
+
+func (env *CfEnvironment) handleSpaceDelete(sinfo *SpaceInfo) bool {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	return env.handleSpaceDeleteLocked(sinfo.SpaceId, sinfo)
+}
+
+func (env *CfEnvironment) handleSpaceDeleteLocked(spaceId string, sinfo *SpaceInfo) bool {
+	retry := false
+	env.cleanupEpgAnnotation(spaceId, CF_OBJ_SPACE)
+	return retry
+}
+
+func (env *CfEnvironment) scheduleSpaceContainersUpdateLocked(spaceId string) {
+	for id, a := range env.appIdx {
+		if a != nil && a.SpaceId == spaceId {
+			env.scheduleAppContainersUpdateLocked(id)
+		}
+	}
+}
+
+func (env *CfEnvironment) scheduleSpaceContainersUpdate(spaceId string) {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	env.scheduleSpaceContainersUpdateLocked(spaceId)
+}
+
+func (env *CfEnvironment) scheduleOrgContainersUpdateLocked(orgId string) {
+	for id, s := range env.spaceIdx {
+		if s != nil && s.OrgId == orgId {
+			env.scheduleSpaceContainersUpdateLocked(id)
+		}
+	}
+}
+
+func (env *CfEnvironment) handleOrgDelete(oinfo *OrgInfo) bool {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	return env.handleOrgDeleteLocked(oinfo.OrgId, oinfo)
+}
+
+func (env *CfEnvironment) handleOrgDeleteLocked(orgId string, oinfo *OrgInfo) bool {
+	retry := false
+	env.cleanupEpgAnnotation(orgId, CF_OBJ_ORG)
+	return retry
+}
+
+func (env *CfEnvironment) scheduleOrgContainersUpdate(orgId string) {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	env.scheduleOrgContainersUpdateLocked(orgId)
+}
+
+type Range struct {
+	start string
+	end   string
+}
+
+func splitIntoRanges(input *string) []Range {
+	var ranges []Range
+	if *input == "" {
+		return ranges
+	}
+	for _, cp := range strings.Split(*input, ",") {
+		parts := strings.Split(cp, "-")
+		if len(parts) <= 2 {
+			ranges = append(ranges,
+				Range{start: strings.TrimSpace(parts[0]),
+					end: strings.TrimSpace(parts[len(parts)-1])})
+		}
+	}
+	return ranges
+}
+
+func convertAsgRule(rule *cfclient.SecGroupRule, parentDn *string, baseName *string) apicapi.ApicSlice {
+	var remotes []*net.IPNet
+	if rule.Destination == "" {
+		remotes = append(remotes, &net.IPNet{IP: net.IPv4(0, 0, 0, 0), Mask: net.IPv4Mask(0, 0, 0, 0)})
+	} else {
+		dsts := splitIntoRanges(&rule.Destination)
+		for _, d := range dsts {
+			if strings.Contains(d.start, "/") {
+				_, n, _ := net.ParseCIDR(d.start)
+				remotes = append(remotes, n)
+			} else {
+				for _, n := range ipam.Range2Cidr(net.ParseIP(d.start), net.ParseIP(d.end)) {
+					remotes = append(remotes, n)
+				}
+			}
+		}
+	}
+
+	var ports []Range
+	if rule.Ports == "" {
+		ports = []Range{Range{start: "unspecified", end: "unspecified"}}
+	} else {
+		ports = splitIntoRanges(&rule.Ports)
+	}
+
+	proto := "unspecified"
+	if rule.Protocol == "tcp" || rule.Protocol == "udp" || rule.Protocol == "icmp" {
+		proto = rule.Protocol
+	}
+	// TODO convert ICMP type and ICMP code, and possibly Log
+
+	var hprs apicapi.ApicSlice
+	for pi, port := range ports {
+		hpr := apicapi.NewHostprotRule(*parentDn, fmt.Sprintf("%s_%d", *baseName, pi))
+		hpr.SetAttr("direction", "egress")
+		hpr.SetAttr("ethertype", "ipv4") // TODO use dst address
+		hpr.SetAttr("protocol", proto)
+		hpr.SetAttr("fromPort", port.start)
+		hpr.SetAttr("toPort", port.end)
+		for _, r := range remotes {
+			hpremote := apicapi.NewHostprotRemoteIp(hpr.GetDn(), r.String())
+			hpr.AddChild(hpremote)
+		}
+		hprs = append(hprs, hpr)
+	}
+	return hprs
+}
+
+func (env *CfEnvironment) handleAsgUpdate(asgId string) bool {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	retry := false
+	sginfo := env.asgIdx[asgId]
+	if sginfo == nil {
+		return false
+	}
+	env.log.Debug(fmt.Sprintf("Handling ASG update %s: rules %v", asgId, sginfo.Rules))
+
+	cont := env.cont
+
+	asgApicName := cont.aciNameForKey("asg", asgId)
+	hpp := apicapi.NewHostprotPol(cont.config.AciPolicyTenant, asgApicName)
+	hpp.SetAttr("nameAlias", "asg_"+sginfo.Name)
+	egressSubj := apicapi.NewHostprotSubj(hpp.GetDn(), "egress")
+	subjDn := egressSubj.GetDn()
+	for ri, rule := range sginfo.Rules {
+		baseName := fmt.Sprintf("rule%d", ri)
+		for _, hpr := range convertAsgRule(&rule, &subjDn, &baseName) {
+			egressSubj.AddChild(hpr)
+		}
+	}
+	hpp.AddChild(egressSubj)
+
+	cont.apicConn.WriteApicObjects("asg:"+asgId, apicapi.ApicSlice{hpp})
+	return retry
+}
+
+func (env *CfEnvironment) handleAsgDelete(sginfo *cfclient.SecGroup) bool {
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	return env.handleAsgDeleteLocked(sginfo.Guid, sginfo)
+}
+
+func (env *CfEnvironment) handleAsgDeleteLocked(asgId string, sginfo *cfclient.SecGroup) bool {
+	retry := false
+	env.cont.apicConn.ClearApicObjects("asg:" + asgId)
+	return retry
+}

--- a/pkg/controller/cf_update_handlers_test.go
+++ b/pkg/controller/cf_update_handlers_test.go
@@ -1,0 +1,223 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"testing"
+
+	"code.cloudfoundry.org/bbs/models"
+	"github.com/stretchr/testify/assert"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+)
+
+func TestCfContainerUpdateDelete(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	env.handleContainerUpdate("c-1")
+	assert.Equal(t, getExpectedEpInfo(), env.GetEpInfo("cell-1", "c-1"))
+
+	cinfo := env.contIdx["c-1"]
+	delete(env.contIdx, "c-1")
+	env.handleContainerDelete(cinfo)
+	assert.Nil(t, env.GetEpInfo("cell-1", "c-1"))
+}
+
+func TestCfContainerUpdateStaging(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	env.contIdx["c-1"].InstanceIndex = -1
+	exp_ep := getExpectedEpInfo()
+	exp_ep.InstanceIndex = -1
+	exp_ep.SecurityGroups[2].Group = "cf_asg_ASG_S1"
+
+	env.handleContainerUpdate("c-1")
+	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+}
+
+func TestCfContainerUpdateTask(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	env.contIdx["c-1"].InstanceIndex = -2
+	env.contIdx["c-1"].TaskName = "task 123"
+	exp_ep := getExpectedEpInfo()
+	exp_ep.InstanceIndex = -2
+	exp_ep.TaskName = "task 123"
+
+	env.handleContainerUpdate("c-1")
+	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+}
+
+func TestCfContainerUpdateIsolationSegment(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	env.spaceIdx["space-1"].IsolationSegment = "is1"
+	exp_ep := getExpectedEpInfo()
+	exp_ep.Epg = "auto|isolate1"
+
+	env.handleContainerUpdate("c-1")
+	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+}
+
+func TestCfContainerUpdateEpgAnnotation(t *testing.T) {
+	env := testCfEnvironment(t)
+	ea_db := EpgAnnotationDb{}
+	exp_ep := getExpectedEpInfo()
+
+	for _, prefix := range []string{"", "anno|"} {
+		app_prof := "auto|"
+		if prefix != "" {
+			app_prof = prefix
+		}
+		// add org annotation
+		txn(env.db, func(txn *sql.Tx) {
+			err := ea_db.UpdateAnnotation(txn, "org-1", CF_OBJ_ORG, prefix+"epg-org")
+			assert.Nil(t, err)
+		})
+		exp_ep.Epg = app_prof + "epg-org"
+		env.handleContainerUpdate("c-1")
+		assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+
+		// add space annotation
+		txn(env.db, func(txn *sql.Tx) {
+			err := ea_db.UpdateAnnotation(txn, "space-1", CF_OBJ_SPACE, prefix+"epg-space")
+			assert.Nil(t, err)
+		})
+		exp_ep.Epg = app_prof + "epg-space"
+		env.handleContainerUpdate("c-1")
+		assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+
+		// add app annotation
+		txn(env.db, func(txn *sql.Tx) {
+			err := ea_db.UpdateAnnotation(txn, "app-1", CF_OBJ_APP, prefix+"epg-app")
+			assert.Nil(t, err)
+		})
+		exp_ep.Epg = app_prof + "epg-app"
+		env.handleContainerUpdate("c-1")
+		assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+
+		// cleanup for next loop
+		txn(env.db, func(txn *sql.Tx) {
+			ea_db.DeleteAnnotation(txn, "org-1", CF_OBJ_ORG)
+			ea_db.DeleteAnnotation(txn, "space-1", CF_OBJ_SPACE)
+			ea_db.DeleteAnnotation(txn, "app-1", CF_OBJ_APP)
+		})
+	}
+}
+
+func TestCfContainerUpdateAdditionalPorts(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	env.contIdx["c-1"].Ports = append(env.contIdx["c-1"].Ports,
+		&models.PortMapping{ContainerPort: 7777, HostPort: 32},
+		&models.PortMapping{ContainerPort: 8888, HostPort: 33})
+	exp_ep := getExpectedEpInfo()
+	exp_ep.PortMapping = append(exp_ep.PortMapping,
+		etcd.PortMap{ContainerPort: 7777, HostPort: 32},
+		etcd.PortMap{ContainerPort: 8888, HostPort: 33})
+	exp_ep.SecurityGroups = append(exp_ep.SecurityGroups,
+		etcd.GroupInfo{Tenant: "cf", Group: "cf_hpp_app-port:app-1"})
+
+	env.handleContainerUpdate("c-1")
+	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+}
+
+func TestCfAppUpdateDelete(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	// give a container additional ports
+	env.contIdx["c-1"].Ports = append(env.contIdx["c-1"].Ports,
+		&models.PortMapping{ContainerPort: 7777, HostPort: 32},
+		&models.PortMapping{ContainerPort: 8888, HostPort: 33})
+
+	// include staging & task containers in the app
+	env.contIdx["c-5"] = &ContainerInfo{ContainerId: "c-5", CellId: "cell-5",
+		IpAddress: "1.2.3.8", AppId: "app-1", InstanceIndex: -1}
+	env.contIdx["c-6"] = &ContainerInfo{ContainerId: "c-6", CellId: "cell-6",
+		IpAddress: "1.2.3.9", AppId: "app-1", InstanceIndex: -2}
+	env.appIdx["app-1"].ContainerIps["c-5"] = "1.2.3.8"
+	env.appIdx["app-1"].ContainerIps["c-6"] = "1.2.3.9"
+
+	exp_app := getExpectedAppInfo()
+
+	env.handleAppUpdate("app-1")
+	assert.Equal(t, exp_app, env.GetAppInfo("app-1"))
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("app_ext_ip:app-1"))
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("app-port:app-1"))
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("np:app-101"))
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("np:app-102"))
+
+	ainfo := env.appIdx["app-1"]
+	delete(env.appIdx, "app-1")
+	env.handleAppDelete(ainfo)
+	assert.Nil(t, env.GetAppInfo("app-1"))
+	assert.Nil(t, env.cont.apicConn.GetDesiredState("app_ext_ip:app-1"))
+	assert.Nil(t, env.cont.apicConn.GetDesiredState("app-port:app-1"))
+}
+
+func TestCfCleanupEpgAnnotation(t *testing.T) {
+	env := testCfEnvironment(t)
+	ea_db := EpgAnnotationDb{}
+
+	txn(env.db, func(txn *sql.Tx) {
+		err := ea_db.UpdateAnnotation(txn, "org-1", CF_OBJ_ORG, "epg-org")
+		assert.Nil(t, err)
+		err = ea_db.UpdateAnnotation(txn, "space-1", CF_OBJ_SPACE, "epg-space")
+		assert.Nil(t, err)
+		err = ea_db.UpdateAnnotation(txn, "app-1", CF_OBJ_APP, "epg-app")
+		assert.Nil(t, err)
+	})
+
+	env.handleAppDelete(env.appIdx["app-1"])
+	env.handleSpaceDelete(env.spaceIdx["space-1"])
+	env.handleOrgDelete(env.orgIdx["org-1"])
+
+	txn(env.db, func(txn *sql.Tx) {
+		val, err := ea_db.List(txn, CF_OBJ_ORG)
+		assert.Nil(t, err)
+		assert.Nil(t, val)
+		val, err = ea_db.List(txn, CF_OBJ_SPACE)
+		assert.Nil(t, err)
+		assert.Nil(t, val)
+		val, err = ea_db.List(txn, CF_OBJ_APP)
+		assert.Nil(t, err)
+		assert.Nil(t, val)
+	})
+}
+
+func TestCfAsgUpdateDelete(t *testing.T) {
+	env := testCfEnvironment(t)
+
+	env.handleAsgUpdate("ASG_R1")
+	env.handleAsgUpdate("ASG_S1")
+	env.handleAsgUpdate("ASG_PUB")
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("asg:ASG_R1"))
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("asg:ASG_S1"))
+	assert.NotNil(t, env.cont.apicConn.GetDesiredState("asg:ASG_PUB"))
+
+	pub_info := env.asgIdx["ASG_PUB"]
+	r1_info := env.asgIdx["ASG_R1"]
+	s1_info := env.asgIdx["ASG_S1"]
+	delete(env.asgIdx, "ASG_PUB")
+	delete(env.asgIdx, "ASG_R1")
+	delete(env.asgIdx, "ASG_S1")
+	env.handleAsgDelete(r1_info)
+	env.handleAsgDelete(s1_info)
+	env.handleAsgDelete(pub_info)
+	assert.Nil(t, env.cont.apicConn.GetDesiredState("asg:ASG_R1"))
+	assert.Nil(t, env.cont.apicConn.GetDesiredState("asg:ASG_S1"))
+	assert.Nil(t, env.cont.apicConn.GetDesiredState("asg:ASG_PUB"))
+}


### PR DESCRIPTION
Implements CfEnvironment to watch/poll CloudFoundry
components for changes and accordingly update etcd
with info required by host-agent. Also configures
ACI host-protection policies to implement ASGs and
container-to-container network policies. Similarly
service-graphs are configured to support app
external-IP.
Adds REST API endpoints to allow EPG annotations
on apps, spaces, orgs as well to assign external-IP
to apps.

Signed-off-by: Amit Bose <amitbose@gmail.com>