### PR TITLE
Fix flaky hostagent tests

### DIFF
--- a/pkg/hostagent/pods_test.go
+++ b/pkg/hostagent/pods_test.go
@@ -175,6 +175,12 @@ func TestPodSync(t *testing.T) {
 	agent.run()
 
 	for i, pt := range podTests {
+		if i%2 == 0 {
+			ioutil.WriteFile(filepath.Join(tempdir,
+				pt.uuid+"_"+pt.cont+"_"+pt.veth+".ep"),
+				[]byte("random gibberish"), 0644)
+		}
+
 		pod := pod(pt.uuid, pt.namespace, pt.name, pt.eg, pt.sg)
 		cnimd := cnimd(pt.namespace, pt.name, pt.ip, pt.cont, pt.veth)
 		agent.epMetadata[pt.namespace+"/"+pt.name] =
@@ -182,12 +188,6 @@ func TestPodSync(t *testing.T) {
 				cnimd.Id.ContId: cnimd,
 			}
 		agent.fakePodSource.Add(pod)
-
-		if i%2 == 0 {
-			ioutil.WriteFile(filepath.Join(tempdir,
-				pt.uuid+"_"+pt.cont+"_"+pt.veth+".ep"),
-				[]byte("random gibberish"), 0644)
-		}
 		agent.doTestPod(t, tempdir, &pt, "create")
 	}
 

--- a/pkg/hostagent/services_test.go
+++ b/pkg/hostagent/services_test.go
@@ -229,18 +229,18 @@ func TestServiceSync(t *testing.T) {
 	agent.run()
 
 	for i, st := range serviceTests {
-		service := service(st.uuid, st.namespace, st.name,
-			st.clusterIp, st.externalIp, st.ports)
-		endpoints := endpoints(st.namespace, st.name, st.nextHopIps, st.ports)
-		agent.fakeServiceSource.Add(service)
-		agent.fakeEndpointsSource.Add(endpoints)
-
 		if i%2 == 0 {
 			ioutil.WriteFile(filepath.Join(tempdir, st.uuid+".service"),
 				[]byte("random gibberish"), 0644)
 			ioutil.WriteFile(filepath.Join(tempdir, st.uuid+"-external.service"),
 				[]byte("random gibberish"), 0644)
 		}
+
+		service := service(st.uuid, st.namespace, st.name,
+			st.clusterIp, st.externalIp, st.ports)
+		endpoints := endpoints(st.namespace, st.name, st.nextHopIps, st.ports)
+		agent.fakeServiceSource.Add(service)
+		agent.fakeEndpointsSource.Add(endpoints)
 		agent.doTestService(t, tempdir, &st, "create")
 	}
 


### PR DESCRIPTION
Sometimes TestPodSync and TestServiceSync would overwrite
the generated EP/service file with gibberish after the
correct files were created by the code under test.

Signed-off-by: Amit Bose <amitbose@gmail.com>