### PR TITLE
Change how we disable insecure request warnings

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -4,8 +4,9 @@ import json
 import sys
 
 import requests
+import urllib3
 
-requests.packages.urllib3.disable_warnings()
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 apic_debug = False
 
 


### PR DESCRIPTION
* The existing code apparently causes problems with very new requests
  library, and the "newer" way seems OK on RHEL7 and Ubuntu
  16.04 and 17.10 at least

Signed-off-by: Rob Adams <readams@readams.net>