### PR TITLE
Add support for Kubernetes 1.8 NetworkPolicy semantics

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -87,6 +87,7 @@ type AciController struct {
 	depPods           *index.PodSelectorIndex
 	netPolPods        *index.PodSelectorIndex
 	netPolIngressPods *index.PodSelectorIndex
+	netPolEgressPods  *index.PodSelectorIndex
 
 	apicConn *apicapi.ApicConnection
 

--- a/pkg/ipam/ipalloc.go
+++ b/pkg/ipam/ipalloc.go
@@ -139,6 +139,12 @@ func (ipa *IpAlloc) AddIp(ip net.IP) {
 	ipa.AddRange(ip, ip)
 }
 
+// Add the given subnet to the free list.  Note that this will include
+// the network address ip|mask in the range.
+func (ipa *IpAlloc) AddSubnet(subnet *net.IPNet) {
+	ipa.AddRange(subnetRange(subnet))
+}
+
 func cutRange(target IpRange, start net.IP, end net.IP) ([]IpRange, bool) {
 	result := make([]IpRange, 0)
 	changed := true
@@ -193,6 +199,11 @@ func (ipa *IpAlloc) RemoveRange(start net.IP, end net.IP) bool {
 		i += len(r)
 	}
 	return changed
+}
+
+// Remove the given subnet from the free list
+func (ipa *IpAlloc) RemoveSubnet(subnet *net.IPNet) bool {
+	return ipa.RemoveRange(subnetRange(subnet))
 }
 
 // Remove the given IP address from the free list

--- a/pkg/ipam/iprange.go
+++ b/pkg/ipam/iprange.go
@@ -32,18 +32,25 @@ func Range2Cidr(start, end net.IP) (r []*net.IPNet) {
 			m := net.CIDRMask(l-1, maxLen)
 			firstAddr := start.Mask(m)
 			lastAddr := last(start, m)
-			if bytes.Compare(start, firstAddr) != 0 || bytes.Compare(lastAddr, end) > 0 {
+			if bytes.Compare(start, firstAddr) != 0 ||
+				bytes.Compare(lastAddr, end) > 0 {
 				break
 			}
 			l--
 		}
-		r = append(r, &net.IPNet{IP: start, Mask:net.CIDRMask(l, maxLen)})
+		r = append(r, &net.IPNet{IP: start, Mask: net.CIDRMask(l, maxLen)})
 		lastAddr := last(start, net.CIDRMask(l, maxLen))
 		if bytes.Compare(lastAddr, endOfRange) == 0 {
 			break
 		}
 		start = next(lastAddr)
 	}
+	return
+}
+
+func subnetRange(subnet *net.IPNet) (start net.IP, end net.IP) {
+	start = subnet.IP.Mask(subnet.Mask)
+	end = last(start, subnet.Mask)
 	return
 }
 

--- a/pkg/ipam/iprange_test.go
+++ b/pkg/ipam/iprange_test.go
@@ -23,8 +23,8 @@ import (
 )
 
 type range2cidrTest struct {
-	input       []string
-	output      []string
+	input  []string
+	output []string
 }
 
 var range2cidrTests = []range2cidrTest{
@@ -213,7 +213,7 @@ func TestRange2Cidr(t *testing.T) {
 		for _, n := range Range2Cidr(in.Start, in.End) {
 			out = append(out, n.String())
 		}
-		assert.Equal(t, rt.output, out, fmt.Sprintf("%s - %s", rt.input[0], rt.input[1]))
+		assert.Equal(t, rt.output, out,
+			fmt.Sprintf("%s - %s", rt.input[0], rt.input[1]))
 	}
 }
-


### PR DESCRIPTION
* Apply egress policy rules when present/applicable
* Implicitly allow egress traffic only when no rules with egress apply
  to a pod.

Signed-off-by: Rob Adams <readams@readams.net>