### PR TITLE
More work to support Kubernetes 1.8

### DIFF
--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.6
 COPY ovs-musl.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \
     libtool pkgconfig autoconf automake cmake doxygen file py-six \

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -15,8 +15,8 @@
 package controller
 
 import (
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	framework "k8s.io/client-go/tools/cache/testing"
@@ -210,9 +210,9 @@ func pod(namespace string, name string, egAnnot string, sgAnnot string) *v1.Pod 
 	return pod
 }
 
-func deployment(namespace string, name string, egAnnot string, sgAnnot string) *v1beta1.Deployment {
-	return &v1beta1.Deployment{
-		Spec: v1beta1.DeploymentSpec{
+func deployment(namespace string, name string, egAnnot string, sgAnnot string) *appsv1beta2.Deployment {
+	return &appsv1beta2.Deployment{
+		Spec: appsv1beta2.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app":  "sample-app",

--- a/pkg/controller/deployments.go
+++ b/pkg/controller/deployments.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
@@ -39,14 +39,14 @@ func (cont *AciController) initDeploymentInformerFromClient(
 
 	cont.initDeploymentInformerBase(
 		cache.NewListWatchFromClient(
-			kubeClient.ExtensionsV1beta1().RESTClient(), "deployments",
+			kubeClient.AppsV1beta2().RESTClient(), "deployments",
 			metav1.NamespaceAll, fields.Everything()))
 }
 
 func (cont *AciController) initDeploymentInformerBase(listWatch *cache.ListWatch) {
 	cont.deploymentIndexer, cont.deploymentInformer = cache.NewIndexerInformer(
 		listWatch,
-		&v1beta1.Deployment{}, 0,
+		&appsv1beta2.Deployment{}, 0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				cont.deploymentAdded(obj)
@@ -67,7 +67,7 @@ func (cont *AciController) initDepPodIndex() {
 		cont.podIndexer, cont.namespaceIndexer, cont.deploymentIndexer,
 		cache.MetaNamespaceKeyFunc,
 		func(obj interface{}) []index.PodSelector {
-			dep := obj.(*v1beta1.Deployment)
+			dep := obj.(*appsv1beta2.Deployment)
 			return index.PodSelectorFromNsAndSelector(dep.ObjectMeta.Namespace,
 				dep.Spec.Selector)
 		},
@@ -80,14 +80,14 @@ func (cont *AciController) initDepPodIndex() {
 	})
 }
 
-func deploymentLogger(log *logrus.Logger, dep *v1beta1.Deployment) *logrus.Entry {
+func deploymentLogger(log *logrus.Logger, dep *appsv1beta2.Deployment) *logrus.Entry {
 	return log.WithFields(logrus.Fields{
 		"namespace": dep.ObjectMeta.Namespace,
 		"name":      dep.ObjectMeta.Name,
 	})
 }
 
-func (cont *AciController) writeApicDepl(dep *v1beta1.Deployment) {
+func (cont *AciController) writeApicDepl(dep *appsv1beta2.Deployment) {
 	depkey, err :=
 		cache.MetaNamespaceKeyFunc(dep)
 	if err != nil {
@@ -110,15 +110,15 @@ func (cont *AciController) writeApicDepl(dep *v1beta1.Deployment) {
 }
 
 func (cont *AciController) deploymentAdded(obj interface{}) {
-	cont.writeApicDepl(obj.(*v1beta1.Deployment))
+	cont.writeApicDepl(obj.(*appsv1beta2.Deployment))
 	cont.depPods.UpdateSelectorObj(obj)
 }
 
 func (cont *AciController) deploymentChanged(oldobj interface{},
 	newobj interface{}) {
 
-	olddep := oldobj.(*v1beta1.Deployment)
-	newdep := newobj.(*v1beta1.Deployment)
+	olddep := oldobj.(*appsv1beta2.Deployment)
+	newdep := newobj.(*appsv1beta2.Deployment)
 
 	cont.writeApicDepl(newdep)
 
@@ -146,7 +146,7 @@ func (cont *AciController) deploymentChanged(oldobj interface{},
 }
 
 func (cont *AciController) deploymentDeleted(obj interface{}) {
-	dep := obj.(*v1beta1.Deployment)
+	dep := obj.(*appsv1beta2.Deployment)
 	depkey, err :=
 		cache.MetaNamespaceKeyFunc(dep)
 	if err != nil {

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/Sirupsen/logrus"
 
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	v1 "k8s.io/api/core/v1"
-	v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1net "k8s.io/api/networking/v1"
 	kubeerr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -249,7 +249,7 @@ func (cont *AciController) handlePodUpdate(pod *v1.Pod) bool {
 			continue
 		}
 		if exists && deploymentobj != nil {
-			deployment := deploymentobj.(*v1beta1.Deployment)
+			deployment := deploymentobj.(*appsv1beta2.Deployment)
 
 			if og, ok := deployment.ObjectMeta.Annotations[metadata.EgAnnotation]; ok && og != "" {
 				egval = &og

--- a/pkg/controller/replicasets.go
+++ b/pkg/controller/replicasets.go
@@ -20,7 +20,7 @@ package controller
 import (
 	"github.com/Sirupsen/logrus"
 
-	v1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
@@ -34,13 +34,13 @@ func (cont *AciController) initReplicaSetInformerFromClient(
 
 	cont.initReplicaSetInformerBase(
 		cache.NewListWatchFromClient(
-			kubeClient.ExtensionsV1beta1().RESTClient(), "replicasets",
+			kubeClient.AppsV1beta2().RESTClient(), "replicasets",
 			metav1.NamespaceAll, fields.Everything()))
 }
 
 func (cont *AciController) initReplicaSetInformerBase(listWatch *cache.ListWatch) {
 	cont.replicaSetIndexer, cont.replicaSetInformer = cache.NewIndexerInformer(
-		listWatch, &v1beta1.ReplicaSet{}, 0,
+		listWatch, &appsv1beta2.ReplicaSet{}, 0,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				cont.replicaSetAdded(obj)
@@ -56,14 +56,14 @@ func (cont *AciController) initReplicaSetInformerBase(listWatch *cache.ListWatch
 	)
 }
 
-func replicaSetLogger(log *logrus.Logger, rs *v1beta1.ReplicaSet) *logrus.Entry {
+func replicaSetLogger(log *logrus.Logger, rs *appsv1beta2.ReplicaSet) *logrus.Entry {
 	return log.WithFields(logrus.Fields{
 		"namespace": rs.ObjectMeta.Namespace,
 		"name":      rs.ObjectMeta.Name,
 	})
 }
 
-func (cont *AciController) writeApicRs(rs *v1beta1.ReplicaSet) {
+func (cont *AciController) writeApicRs(rs *appsv1beta2.ReplicaSet) {
 	rskey, err :=
 		cache.MetaNamespaceKeyFunc(rs)
 	if err != nil {
@@ -87,18 +87,18 @@ func (cont *AciController) writeApicRs(rs *v1beta1.ReplicaSet) {
 }
 
 func (cont *AciController) replicaSetAdded(obj interface{}) {
-	cont.writeApicRs(obj.(*v1beta1.ReplicaSet))
+	cont.writeApicRs(obj.(*appsv1beta2.ReplicaSet))
 }
 
 func (cont *AciController) replicaSetChanged(oldobj interface{},
 	newobj interface{}) {
-	newrs := newobj.(*v1beta1.ReplicaSet)
+	newrs := newobj.(*appsv1beta2.ReplicaSet)
 
 	cont.writeApicRs(newrs)
 }
 
 func (cont *AciController) replicaSetDeleted(obj interface{}) {
-	rs := obj.(*v1beta1.ReplicaSet)
+	rs := obj.(*appsv1beta2.ReplicaSet)
 	rskey, err :=
 		cache.MetaNamespaceKeyFunc(rs)
 	if err != nil {

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -61,6 +61,11 @@ FLAVORS = {
     "kubernetes-1.8": {
         "desc": "Kubernetes 1.8",
         "default_version": "1.8",
+        "config": {
+            "kube_config": {
+                "use_apps_apigroup": "extensions",
+            }
+        }
     },
     "kubernetes-1.7": {
         "desc": "Kubernetes 1.7",
@@ -68,6 +73,8 @@ FLAVORS = {
         "config": {
             "kube_config": {
                 "use_rbac_api": "rbac.authorization.k8s.io/v1beta1",
+                "use_apps_api": "extensions/v1beta1",
+                "use_apps_apigroup": "extensions",
             }
         }
     },
@@ -77,6 +84,8 @@ FLAVORS = {
         "config": {
             "kube_config": {
                 "use_rbac_api": "rbac.authorization.k8s.io/v1beta1",
+                "use_apps_api": "extensions/v1beta1",
+                "use_apps_apigroup": "extensions",
                 "use_netpol_annotation": True,
                 "use_netpol_apigroup": "extensions",
             },
@@ -93,6 +102,8 @@ FLAVORS = {
                 "use_cnideploy_initcontainer": True,
                 "allow_kube_api_default_epg": True,
                 "use_rbac_api": "v1",
+                "use_apps_api": "extensions/v1beta1",
+                "use_apps_apigroup": "extensions",
                 "use_netpol_apigroup": "extensions",
                 "use_netpol_annotation": True,
                 "kubectl": "oc",
@@ -174,6 +185,8 @@ def config_default():
         "kube_config": {
             "controller": "1.1.1.1",
             "use_rbac_api": "rbac.authorization.k8s.io/v1",
+            "use_apps_api": "apps/v1beta2",
+            "use_apps_apigroup": "apps",
             "use_netpol_apigroup": "networking.k8s.io",
             "use_netpol_annotation": False,
             "image_pull_policy": "Always",

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -127,7 +127,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "extensions"
+  - "{{ config.kube_config.use_apps_apigroup }}"
   resources:
   - deployments
   - replicasets
@@ -230,7 +230,7 @@ volumes:
 priority: 100
 ---
 {% endif %}
-apiVersion: extensions/v1beta1
+apiVersion: {{ config.kube_config.use_apps_api }}
 kind: DaemonSet
 metadata:
   name: aci-containers-host
@@ -241,6 +241,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -380,7 +384,7 @@ spec:
               - key: opflex-agent-config
                 path: local.conf
 ---
-apiVersion: extensions/v1beta1
+apiVersion: {{ config.kube_config.use_apps_api }}
 kind: DaemonSet
 metadata:
   name: aci-containers-openvswitch
@@ -391,6 +395,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -458,7 +466,7 @@ spec:
           hostPath:
             path: /lib/modules
 ---
-apiVersion: extensions/v1beta1
+apiVersion: {{ config.kube_config.use_apps_api }}
 kind: Deployment
 metadata:
   name: aci-containers-controller
@@ -466,20 +474,22 @@ metadata:
   labels:
     aci-containers-config-version: "{{ config.registry.configuration_version }}"
     network-plugin: aci-containers
-    k8s-app: aci-containers-controller
     name: aci-containers-controller
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
   template:
     metadata:
       name: aci-containers-controller
       namespace: kube-system
       labels:
-        network-plugin: aci-containers
-        k8s-app: aci-containers-controller
         name: aci-containers-controller
+        network-plugin: aci-containers
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -223,7 +223,7 @@ subjects:
   name: aci-containers-host-agent
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-host
@@ -234,6 +234,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -343,7 +347,7 @@ spec:
               - key: opflex-agent-config
                 path: local.conf
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-openvswitch
@@ -354,6 +358,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -414,7 +422,7 @@ spec:
           hostPath:
             path: /lib/modules
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: aci-containers-controller
@@ -422,20 +430,22 @@ metadata:
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
-    k8s-app: aci-containers-controller
     name: aci-containers-controller
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
   template:
     metadata:
       name: aci-containers-controller
       namespace: kube-system
       labels:
-        network-plugin: aci-containers
-        k8s-app: aci-containers-controller
         name: aci-containers-controller
+        network-plugin: aci-containers
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/provision/testdata/flavor_openshift_36.kube.yaml
+++ b/provision/testdata/flavor_openshift_36.kube.yaml
@@ -269,6 +269,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -405,6 +409,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -474,20 +482,22 @@ metadata:
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
-    k8s-app: aci-containers-controller
     name: aci-containers-controller
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
   template:
     metadata:
       name: aci-containers-controller
       namespace: kube-system
       labels:
-        network-plugin: aci-containers
-        k8s-app: aci-containers-controller
         name: aci-containers-controller
+        network-plugin: aci-containers
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -223,7 +223,7 @@ subjects:
   name: aci-containers-host-agent
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-host
@@ -234,6 +234,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -343,7 +347,7 @@ spec:
               - key: opflex-agent-config
                 path: local.conf
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-openvswitch
@@ -354,6 +358,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -414,7 +422,7 @@ spec:
           hostPath:
             path: /lib/modules
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: aci-containers-controller
@@ -422,20 +430,22 @@ metadata:
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
-    k8s-app: aci-containers-controller
     name: aci-containers-controller
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
   template:
     metadata:
       name: aci-containers-controller
       namespace: kube-system
       labels:
-        network-plugin: aci-containers
-        k8s-app: aci-containers-controller
         name: aci-containers-controller
+        network-plugin: aci-containers
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -223,7 +223,7 @@ subjects:
   name: aci-containers-host-agent
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-host
@@ -234,6 +234,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -343,7 +347,7 @@ spec:
               - key: opflex-agent-config
                 path: local.conf
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-openvswitch
@@ -354,6 +358,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -414,7 +422,7 @@ spec:
           hostPath:
             path: /lib/modules
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: aci-containers-controller
@@ -422,20 +430,22 @@ metadata:
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
-    k8s-app: aci-containers-controller
     name: aci-containers-controller
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
   template:
     metadata:
       name: aci-containers-controller
       namespace: kube-system
       labels:
-        network-plugin: aci-containers
-        k8s-app: aci-containers-controller
         name: aci-containers-controller
+        network-plugin: aci-containers
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -223,7 +223,7 @@ subjects:
   name: aci-containers-host-agent
   namespace: kube-system
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-host
@@ -234,6 +234,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -343,7 +347,7 @@ spec:
               - key: opflex-agent-config
                 path: local.conf
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-openvswitch
@@ -354,6 +358,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -414,7 +422,7 @@ spec:
           hostPath:
             path: /lib/modules
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: aci-containers-controller
@@ -422,20 +430,22 @@ metadata:
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
-    k8s-app: aci-containers-controller
     name: aci-containers-controller
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
   template:
     metadata:
       name: aci-containers-controller
       namespace: kube-system
       labels:
-        network-plugin: aci-containers
-        k8s-app: aci-containers-controller
         name: aci-containers-controller
+        network-plugin: aci-containers
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -259,7 +259,7 @@ volumes:
 - '*'
 priority: 100
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-host
@@ -270,6 +270,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-host
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -383,7 +387,7 @@ spec:
               - key: opflex-agent-config
                 path: local.conf
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: aci-containers-openvswitch
@@ -394,6 +398,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      name: aci-containers-openvswitch
+      network-plugin: aci-containers
   template:
     metadata:
       labels:
@@ -455,7 +463,7 @@ spec:
           hostPath:
             path: /lib/modules
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: aci-containers-controller
@@ -463,20 +471,22 @@ metadata:
   labels:
     aci-containers-config-version: "dummy"
     network-plugin: aci-containers
-    k8s-app: aci-containers-controller
     name: aci-containers-controller
 spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      name: aci-containers-controller
+      network-plugin: aci-containers
   template:
     metadata:
       name: aci-containers-controller
       namespace: kube-system
       labels:
-        network-plugin: aci-containers
-        k8s-app: aci-containers-controller
         name: aci-containers-controller
+        network-plugin: aci-containers
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:


### PR DESCRIPTION
* Move "apps" apis to use apps/v1beta2 endpoint
* Update deployment files to work with 1.8

Signed-off-by: Rob Adams <readams@readams.net>