### PR TITLE
Use the default apigroup apps for Kubernetes 1.8 because it seems like the upstream bug is fixed.

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -85,11 +85,6 @@ FLAVORS = {
     "kubernetes-1.8": {
         "desc": "Kubernetes 1.8",
         "default_version": "1.8",
-        "config": {
-            "kube_config": {
-                "use_apps_apigroup": "extensions",
-            }
-        }
     },
     "kubernetes-1.7": {
         "desc": "Kubernetes 1.7",


### PR DESCRIPTION
Using the extensions apigroup in sauto is causing aci-containers-controller to crash on Kubernetes 1.8.