### PR TITLE
Add description for service redirect policy containing the node name.

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -364,8 +364,9 @@ var metadata = map[string]*apicMeta{
 	},
 	"vnsRedirectDest": {
 		attributes: map[string]interface{}{
-			"ip":  "",
-			"mac": "",
+			"ip":    "",
+			"mac":   "",
+			"descr": "",
 		},
 		normalizer: redirectDestNormalizer,
 	},

--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -238,7 +238,7 @@ func (o ApicObject) SetTag(tag string) {
 	o.AddChild(NewTagInst(o.GetDn(), tag))
 }
 
-func (o ApicObject) SetAttr(name string, value interface{}) {
+func (o ApicObject) SetAttr(name string, value interface{}) ApicObject {
 	for _, body := range o {
 		if body.Attributes == nil {
 			body.Attributes = make(map[string]interface{})
@@ -246,6 +246,7 @@ func (o ApicObject) SetAttr(name string, value interface{}) {
 		body.Attributes[name] = value
 		break
 	}
+	return o
 }
 
 func (o ApicObject) GetAttr(name string) interface{} {

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -237,11 +237,11 @@ func apicRedirectPol(name string, tenantName string, nodes []string,
 		}
 		if serviceEp.Ipv4 != nil {
 			rp.AddChild(apicapi.NewVnsRedirectDest(rpDn,
-				serviceEp.Ipv4.String(), serviceEp.Mac))
+				serviceEp.Ipv4.String(), serviceEp.Mac).SetAttr("descr", node))
 		}
 		if serviceEp.Ipv6 != nil {
 			rp.AddChild(apicapi.NewVnsRedirectDest(rpDn,
-				serviceEp.Ipv6.String(), serviceEp.Mac))
+				serviceEp.Ipv6.String(), serviceEp.Mac).SetAttr("descr", node))
 		}
 	}
 	return rp, rpDn


### PR DESCRIPTION
Also adds ability to chain SetAttr calls on ApicObject.

Signed-off-by: Rob Adams <readams@readams.net>