### PR TITLE
If acc-provision encounters an error, set the exit code to 1

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -952,7 +952,7 @@ def main(args=None, apic_file=None, no_random=False):
         return
     if args.flavor is not None and args.flavor not in FLAVORS:
         err("Invalid configuration flavor: " + args.flavor)
-        return
+        sys.exit(1)
 
     if args.debug:
         provision(args, apic_file, no_random)
@@ -963,6 +963,7 @@ def main(args=None, apic_file=None, no_random=False):
             pass
         except Exception as e:
             err("%s: %s" % (e.__class__.__name__, e))
+            sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is just to make acc-provision match the expectations of command-line scripting libraries like fabric.