### PR TITLE
Enable password to be passed in via environment

### DIFF
--- a/provision/README.md
+++ b/provision/README.md
@@ -22,6 +22,6 @@ optional arguments:
   -u , --username   APIC admin username to use for APIC API access
   -p , --password   APIC admin password to use for APIC API access
   -v, --verbose     Enable debug
-  
-Passw
+
+Password can also be set via the ACC_PROVISION_PASS environment variable.
 ```

--- a/provision/README.md
+++ b/provision/README.md
@@ -22,5 +22,6 @@ optional arguments:
   -u , --username   APIC admin username to use for APIC API access
   -p , --password   APIC admin password to use for APIC API access
   -v, --verbose     Enable debug
-
+  
+Passw
 ```

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import argparse
 import base64
 import json
+import os
 import pkg_resources
 import pkgutil
 import random
@@ -911,8 +912,12 @@ def provision(args, apic_file, no_random):
     }
     if args.username:
         config["aci_config"]["apic_login"]["username"] = args.username
-    if args.password:
-        config["aci_config"]["apic_login"]["password"] = args.password
+
+    try:
+        config["aci_config"]["apic_login"]["password"] = os.environ['ACC_PROVISION_PASS']
+    except KeyError:
+        if args.password:
+            config["aci_config"]["apic_login"]["password"] = args.password
     config["aci_config"]["apic_login"]["timeout"] = timeout
 
     # Create config

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -913,11 +913,8 @@ def provision(args, apic_file, no_random):
     if args.username:
         config["aci_config"]["apic_login"]["username"] = args.username
 
-    try:
-        config["aci_config"]["apic_login"]["password"] = os.environ['ACC_PROVISION_PASS']
-    except KeyError:
-        if args.password:
-            config["aci_config"]["apic_login"]["password"] = args.password
+    config["aci_config"]["apic_login"]["password"] = \
+        args.password if args.password else os.environ.get('ACC_PROVISION_PASS')
     config["aci_config"]["apic_login"]["timeout"] = timeout
 
     # Create config


### PR DESCRIPTION
* Enables user to pass ACI password in via the
  ACC_PROVISION_PASS environment variable.