### PR TITLE
[CloudFoundry] Be less restrictive for legacy CF networking

### DIFF
--- a/pkg/controller/cf_environment_test.go
+++ b/pkg/controller/cf_environment_test.go
@@ -148,7 +148,6 @@ func TestCfUpdateHppForCfComponents(t *testing.T) {
 	env := testCfEnvironment(t)
 	env.cfconfig.GoRouterAddress = "96.97.98.99"
 	env.cfconfig.TcpRouterAddress = "75.57.55.77"
-	env.cfconfig.SshProxyAddress = "86.87.88.89"
 	env.contIdx["c-1"].Ports = append(env.contIdx["c-1"].Ports,
 		&models.PortMapping{ContainerPort: 7777, HostPort: 32},
 		&models.PortMapping{ContainerPort: 8888, HostPort: 33})


### PR DESCRIPTION
Instead of allowing only the SSH port in the host
protection policy for legacy CF networking, allow access
to all ports. This should be okay because IPTables rules
on the Diego-cell created for legacy CF networking restrict
access to the mapped ports only.

Signed-off-by: Amit Bose <amitbose@gmail.com>