### PR TITLE
[CloudFoundry] Handle some more BBS events

### DIFF
--- a/pkg/controller/cf_bbs_listener.go
+++ b/pkg/controller/cf_bbs_listener.go
@@ -267,9 +267,12 @@ func (env *CfEnvironment) processContainerDelete(ctId string) {
 	}
 
 	if cinfo != nil {
+		env.log.Debug("BBS LRP/Task - Queuing delete for container ",
+			cinfo.ContainerId)
 		env.containerDeleteQ.Add(cinfo)
 	}
 	if appInfo != nil {
+		env.log.Debug("BBS LRP/Task - Queuing update for app ", appInfo.AppId)
 		env.appUpdateQ.Add(appInfo.AppId)
 	}
 }
@@ -390,8 +393,15 @@ func NewCfBbsLrpListener(env *CfEnvironment) *CfBbsEventListener {
 			env.processBbsActualLrp(ev.After, dlrp2app, pending)
 		case *models.ActualLRPRemovedEvent:
 			if ev.ActualLrpGroup.Instance != nil {
-				env.processContainerDelete(ev.ActualLrpGroup.Instance.GetInstanceGuid())
+				env.processContainerDelete(
+					ev.ActualLrpGroup.Instance.GetInstanceGuid())
 			}
+			if ev.ActualLrpGroup.Evacuating != nil {
+				env.processContainerDelete(
+					ev.ActualLrpGroup.Evacuating.GetInstanceGuid())
+			}
+		case *models.ActualLRPCrashedEvent:
+			env.processContainerDelete(ev.GetInstanceGuid())
 		}
 		return nil
 	}


### PR DESCRIPTION
Crash and evacuation related events were not being
handled which left stale entries in the controller
indexes. This eventually results in stale ACI injected
objects, host-protection policies and iptables rules
on the Diego-cell.

Signed-off-by: Amit Bose <amitbose@gmail.com>