### PR TITLE
Add ability to pass a Kubernetes context argument to acikubectl

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -31,7 +31,7 @@ import (
 )
 
 func execKubectl(args []string, out io.Writer) error {
-	baseargs := []string{"--kubeconfig", kubeconfig}
+	baseargs := []string{"--kubeconfig", kubeconfig, "--context", context}
 	cmd := exec.Command("kubectl", append(baseargs, args...)...)
 
 	cmd.Stdout = out


### PR DESCRIPTION
I'm using current context in the test automation.