### PR TITLE
Disable health redirect group for now and use tags by default

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -246,6 +246,7 @@ def config_default():
             },
             "client_cert": False,
             "client_ssl": True,
+            "use_inst_tag": True,
         },
         "net_config": {
             "node_subnet": None,
@@ -255,7 +256,7 @@ def config_default():
             "node_svc_subnet": None,
             "kubeapi_vlan": None,
             "service_vlan": None,
-            "service_monitor_interval": 15,
+            "service_monitor_interval": 0,
         },
         "kube_config": {
             "controller": "1.1.1.1",

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -13,6 +13,7 @@ data:
         "apic-hosts": {{config.aci_config.apic_hosts|json|indent(width=8)}},
         "apic-username": {{config.aci_config.sync_login.username|json}},
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": {{config.aci_config.use_inst_tag|json}},
         "aci-prefix": {{config.aci_config.system_id|json}},
         "aci-vmm-type": {{config.aci_config.vmm_domain.type|json}},
         "aci-vmm-domain": {{config.aci_config.vmm_domain.domain|json}},

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "kube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "kube",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "kube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "kube",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/flavor_openshift_36.kube.yaml
+++ b/provision/testdata/flavor_openshift_36.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "kube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "kube",
         "aci-vmm-type": "OpenShift",
         "aci-vmm-domain": "kube",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": true,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "kube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "kube",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "kube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "kube",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "mykube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "mykube",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "mykube",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "mykube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
         "aci-l3out": "mykube_l3out",
         "aci-ext-networks": [

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "kube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "kube",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "kube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "kube",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "kube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "kube",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kubernetes1",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kubernetes-control",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "common",
         "aci-l3out": "l3out",
         "aci-ext-networks": [

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -15,6 +15,7 @@ data:
         ],
         "apic-username": "kube",
         "apic-private-key-path": "/usr/local/etc/aci-cert/user.key",
+        "apic-use-inst-tag": true,
         "aci-prefix": "kube",
         "aci-vmm-type": "Kubernetes",
         "aci-vmm-domain": "kube",
@@ -23,7 +24,7 @@ data:
         "require-netpol-annot": false,
         "aci-service-phys-dom": "kube-pdom",
         "aci-service-encap": "vlan-4003",
-        "aci-service-monitor-interval": 15,
+        "aci-service-monitor-interval": 0,
         "aci-vrf-tenant": "kube",
         "aci-l3out": "l3out",
         "aci-ext-networks": [


### PR DESCRIPTION
* Allows EuMR support.

Signed-off-by: Rob Adams <readams@readams.net>