### PR TITLE
[CloudFoundry] Store cell info in DB

### DIFF
--- a/pkg/controller/cf_cell_db.go
+++ b/pkg/controller/cf_cell_db.go
@@ -1,0 +1,150 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"fmt"
+	"net"
+
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+	m "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+type CellPodNetDb struct {
+}
+
+func (db *CellPodNetDb) Get(txn *sql.Tx, cell string) (
+	result *m.NetIps, err error) {
+
+	rows, err := txn.Query("SELECT start, end FROM "+
+		"aci_cell_pod_networks WHERE guid=? ORDER BY start ASC", cell)
+	if err != nil {
+		return
+	}
+	ips := &m.NetIps{}
+	defer rows.Close()
+	nr := 0
+	for rows.Next() {
+		nr++
+		var start, end string
+		if err := rows.Scan(&start, &end); err == nil {
+			start_ip, end_ip := net.ParseIP(start), net.ParseIP(end)
+			if start_ip == nil || end_ip == nil {
+				continue
+			}
+			if start_ip.To4() != nil && end_ip.To4() != nil {
+				ips.V4 = append(ips.V4, ipam.IpRange{start_ip, end_ip})
+			} else if start_ip.To16() != nil && end_ip.To16() != nil {
+				ips.V6 = append(ips.V6, ipam.IpRange{start_ip, end_ip})
+			}
+		}
+	}
+	if err = rows.Err(); err != nil {
+		return
+	}
+	if len(ips.V4) > 0 || len(ips.V6) > 0 {
+		result = ips
+	}
+	return
+}
+
+func (db *CellPodNetDb) Set(txn *sql.Tx, cell string, ips *m.NetIps) (
+	err error) {
+
+	err = db.Delete(txn, cell)
+	if err != nil {
+		err = fmt.Errorf("Error deleting old rows - %s", err.Error())
+		return
+	}
+	for _, ipl := range [][]ipam.IpRange{ips.V4, ips.V6} {
+		for _, ip := range ipl {
+			if len(ip.Start) == 0 || len(ip.End) == 0 {
+				continue
+			}
+			_, err = txn.Exec("INSERT INTO aci_cell_pod_networks(guid, start, "+
+				"end) VALUES(?, ?, ?)",
+				cell, ip.Start.String(), ip.End.String())
+			if err != nil {
+				return
+			}
+		}
+	}
+	return
+}
+
+func (db *CellPodNetDb) Delete(txn *sql.Tx, cell string) (err error) {
+	q := "DELETE FROM aci_cell_pod_networks WHERE guid=?"
+	_, err = txn.Exec(q, cell)
+	return
+}
+
+type CellServiceEpDb struct {
+}
+
+func (db *CellServiceEpDb) Get(txn *sql.Tx, cell string) (
+	result *m.ServiceEndpoint, err error) {
+
+	ep := &m.ServiceEndpoint{}
+	var ipv4_s, ipv6_s string
+	err = txn.QueryRow("SELECT mac, ip_v4, ip_v6 FROM "+
+		"aci_cell_service_ep WHERE guid=?",
+		cell).Scan(&ep.Mac, &ipv4_s, &ipv6_s)
+	if err == nil {
+		ipv4, ipv6 := net.ParseIP(ipv4_s), net.ParseIP(ipv6_s)
+		if ipv4 != nil && ipv4.To4() != nil {
+			ep.Ipv4 = ipv4
+		}
+		if ipv6 != nil && ipv6.To16() != nil {
+			ep.Ipv6 = ipv6
+		}
+		result = ep
+	} else if err == sql.ErrNoRows {
+		err = nil
+		return
+	}
+	return
+}
+
+func (db *CellServiceEpDb) Set(txn *sql.Tx, cell string,
+	svcep *m.ServiceEndpoint) (err error) {
+
+	var v4_s, v6_s string
+	if len(svcep.Ipv4) > 0 {
+		v4_s = svcep.Ipv4.String()
+	}
+	if len(svcep.Ipv6) > 0 {
+		v6_s = svcep.Ipv6.String()
+	}
+	res, err := txn.Exec("UPDATE aci_cell_service_ep SET "+
+		"mac=?, ip_v4=?, ip_v6=? WHERE guid=?",
+		svcep.Mac, v4_s, v6_s, cell)
+	if err != nil {
+		return
+	}
+	nrows, _ := res.RowsAffected()
+	if nrows == 0 {
+		_, err = txn.Exec("INSERT INTO aci_cell_service_ep("+
+			"guid, mac, ip_v4, ip_v6) VALUES(?, ?, ?, ?)",
+			cell, svcep.Mac, v4_s, v6_s)
+	}
+	return
+}
+
+func (db *CellServiceEpDb) Delete(txn *sql.Tx, cell string) (err error) {
+	q := "DELETE FROM aci_cell_service_ep WHERE guid=?"
+	_, err = txn.Exec(q, cell)
+	return
+}

--- a/pkg/controller/cf_cell_db_test.go
+++ b/pkg/controller/cf_cell_db_test.go
@@ -1,0 +1,175 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"database/sql"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+	m "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func TestCfCellServiceEpDbOps(t *testing.T) {
+	env := testCfEnvironment(t)
+	epdb := CellServiceEpDb{}
+
+	// get with no record
+	txn(env.db, func(txn *sql.Tx) {
+		ep, err := epdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Nil(t, ep)
+	})
+
+	// set with mac, v4, v6
+	svcep := &m.ServiceEndpoint{
+		Mac:  "aa:bb:cc:dd:ee:ff",
+		Ipv4: net.ParseIP("1.2.3.4"),
+		Ipv6: net.ParseIP("::fe80")}
+
+	txn(env.db, func(txn *sql.Tx) {
+		err := epdb.Set(txn, "cell1", svcep)
+		assert.Nil(t, err)
+		ep, err := epdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Equal(t, *svcep, *ep)
+	})
+
+	// set with v4 only
+	svcep.Ipv6 = nil
+	txn(env.db, func(txn *sql.Tx) {
+		err := epdb.Set(txn, "cell1", svcep)
+		assert.Nil(t, err)
+		ep, err := epdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Equal(t, *svcep, *ep)
+	})
+
+	// set again
+	txn(env.db, func(txn *sql.Tx) {
+		err := epdb.Set(txn, "cell1", svcep)
+		assert.Nil(t, err)
+		ep, err := epdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Equal(t, *svcep, *ep)
+	})
+
+	// reset
+	svcep.Ipv4 = nil
+	txn(env.db, func(txn *sql.Tx) {
+		err := epdb.Set(txn, "cell1", svcep)
+		assert.Nil(t, err)
+		ep, err := epdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Equal(t, *svcep, *ep)
+	})
+
+	// delete
+	txn(env.db, func(txn *sql.Tx) {
+		err := epdb.Delete(txn, "cell1")
+		assert.Nil(t, err)
+		ep, err := epdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Nil(t, ep)
+	})
+
+	// delete again
+	txn(env.db, func(txn *sql.Tx) {
+		err := epdb.Delete(txn, "cell1")
+		assert.Nil(t, err)
+	})
+}
+
+func TestCfCellPodNetDbOps(t *testing.T) {
+	env := testCfEnvironment(t)
+	netdb := CellPodNetDb{}
+
+	// get with no record
+	txn(env.db, func(txn *sql.Tx) {
+		podnet, err := netdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Nil(t, podnet)
+	})
+
+	// set v4 and v6
+	podnet := &m.NetIps{
+		V4: []ipam.IpRange{
+			{Start: net.ParseIP("1.2.3.4"), End: net.ParseIP("1.2.3.8")},
+			{Start: net.ParseIP("5.6.6.2"), End: net.ParseIP("5.8.8.7")}},
+		V6: []ipam.IpRange{
+			{Start: net.ParseIP("::1:2"), End: net.ParseIP("::1:8")},
+			{Start: net.ParseIP("::5:6"), End: net.ParseIP("::5:9")}}}
+
+	txn(env.db, func(txn *sql.Tx) {
+		err := netdb.Set(txn, "cell1", podnet)
+		assert.Nil(t, err)
+		n, err := netdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Equal(t, *podnet, *n)
+	})
+
+	// append more ranges
+	podnet.V4 = append(podnet.V4,
+		ipam.IpRange{Start: net.ParseIP("9.8.7.2"),
+			End: net.ParseIP("9.8.8.9")})
+	podnet.V6 = append(podnet.V6,
+		ipam.IpRange{Start: net.ParseIP("::9:4"),
+			End: net.ParseIP("::9:8")})
+	txn(env.db, func(txn *sql.Tx) {
+		err := netdb.Set(txn, "cell1", podnet)
+		assert.Nil(t, err)
+		n, err := netdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Equal(t, *podnet, *n)
+	})
+
+	// set with v4 only
+	podnet1 := &m.NetIps{V4: podnet.V4}
+	txn(env.db, func(txn *sql.Tx) {
+		err := netdb.Set(txn, "cell1", podnet1)
+		assert.Nil(t, err)
+		n, err := netdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Equal(t, *podnet1, *n)
+	})
+
+	// set with v6 only
+	podnet2 := &m.NetIps{V6: podnet.V6}
+	txn(env.db, func(txn *sql.Tx) {
+		err := netdb.Set(txn, "cell1", podnet2)
+		assert.Nil(t, err)
+		n, err := netdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Equal(t, *podnet2, *n)
+	})
+
+	// delete
+	txn(env.db, func(txn *sql.Tx) {
+		err := netdb.Delete(txn, "cell1")
+		assert.Nil(t, err)
+		n, err := netdb.Get(txn, "cell1")
+		assert.Nil(t, err)
+		assert.Nil(t, n)
+	})
+
+	// delete again
+	txn(env.db, func(txn *sql.Tx) {
+		err := netdb.Delete(txn, "cell1")
+		assert.Nil(t, err)
+	})
+}

--- a/pkg/controller/cf_db_test.go
+++ b/pkg/controller/cf_db_test.go
@@ -78,6 +78,45 @@ func TestCfDbMigration(t *testing.T) {
 		assert.Equal(t, "pool", cts[3].Name())
 		assert.Equal(t, "VARCHAR(255)", cts[3].DatabaseTypeName())
 	}
+
+	{
+		rows, err := env.db.Query(
+			"SELECT guid, start, end from aci_cell_pod_networks")
+		cts, err := rows.ColumnTypes()
+		rows.Close()
+		assert.Nil(t, err)
+
+		assert.Equal(t, 3, len(cts))
+		assert.Equal(t, "guid", cts[0].Name())
+		assert.Equal(t, "VARCHAR(255)", cts[0].DatabaseTypeName())
+
+		assert.Equal(t, "start", cts[1].Name())
+		assert.Equal(t, "VARCHAR(64)", cts[1].DatabaseTypeName())
+
+		assert.Equal(t, "end", cts[2].Name())
+		assert.Equal(t, "VARCHAR(64)", cts[2].DatabaseTypeName())
+	}
+
+	{
+		rows, err := env.db.Query(
+			"SELECT guid, mac, ip_v4, ip_v6 from aci_cell_service_ep")
+		cts, err := rows.ColumnTypes()
+		rows.Close()
+		assert.Nil(t, err)
+
+		assert.Equal(t, 4, len(cts))
+		assert.Equal(t, "guid", cts[0].Name())
+		assert.Equal(t, "VARCHAR(255)", cts[0].DatabaseTypeName())
+
+		assert.Equal(t, "mac", cts[1].Name())
+		assert.Equal(t, "VARCHAR(24)", cts[1].DatabaseTypeName())
+
+		assert.Equal(t, "ip_v4", cts[2].Name())
+		assert.Equal(t, "VARCHAR(16)", cts[2].DatabaseTypeName())
+
+		assert.Equal(t, "ip_v6", cts[3].Name())
+		assert.Equal(t, "VARCHAR(64)", cts[3].DatabaseTypeName())
+	}
 }
 
 func TestCfDbMigrationIdempotent(t *testing.T) {


### PR DESCRIPTION
Moving cell pod-network and service-EP info to
DB from etcd so that we have a single persistent
store. Information in etcd still gets updated,
but only to serve as a notification for the host
agent.

Signed-off-by: Amit Bose <bose@noironetworks.com>