### PR TITLE
[CloudFoundry] Key-value service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,16 +14,17 @@ SIMPLESERVICE_SRC=$(wildcard cmd/simpleservice/*.go)
 CFAPI_SRC=$(wildcard pkg/cfapi/*.go)
 CF_ETCD_SRC=$(wildcard pkg/cf_etcd/*.go)
 CF_ETCD_FAKES_SRC=$(wildcard pkg/cf_etcd_fakes/*.go)
+KEYVALUESVC_SRC=$(wildcard pkg/cf_remotekeyvalue/*.go)
 DEBIAN_FILES=$(wildcard debian/*)
 GOPKG_FILES=$(wildcard Gopkg.*)
 
 HOSTAGENT_DEPS=${METADATA_SRC} ${IPAM_SRC} ${HOSTAGENT_SRC} \
-	${CF_ETCD_SRC} vendor
+	${CF_ETCD_SRC} ${KEYVALUESVC_SRC} vendor
 AGENTCNI_DEPS=${METADATA_SRC} ${EPRPCCLIENT_SRC} ${AGENTCNI_SRC} vendor
 CONTROLLER_DEPS= \
 	${METADATA_SRC} ${IPAM_SRC} ${INDEX_SRC} \
 	${APICAPI_SRC} ${CONTROLLER_SRC} ${CF_ETCD_SRC} \
-	${CFAPI_SRC} vendor
+	${CFAPI_SRC} ${KEYVALUESVC_SRC} vendor
 ACIKUBECTL_DEPS=${METADATA_SRC} ${ACIKUBECTL_SRC} vendor
 OVSRESYNC_DEPS=${METADATA_SRC} ${OVSRESYNC_SRC} vendor
 SIMPLESERVICE_DEPS=${SIMPLESERVICE_SRC} vendor
@@ -79,6 +80,7 @@ dist: ${METADATA_SRC} \
 	${CF_ETCD_SRC} \
 	${CF_ETCD_FAKES_SRC} \
 	${CFAPI_SRC} \
+	${KEYVALUESVC_SRC} \
 	${DEBIAN_FILES} ${GOPKG_FILES} Makefile
 	- rm -rf ${PACKAGE_DIR}
 	mkdir -p ${GOSRC_PATH}
@@ -140,7 +142,7 @@ container-cnideploy:
 container-simpleservice: dist-static/simpleservice
 	${DOCKER_BUILD_CMD} -t noiro/simpleservice -f ./docker/Dockerfile-simpleservice .
 
-check: check-ipam check-index check-apicapi check-controller check-hostagent check-cf_etcd
+check: check-ipam check-index check-apicapi check-controller check-hostagent check-cf_etcd check-keyvalueservice
 check-ipam:
 	${TEST_CMD} ${BASE}/pkg/ipam ${TEST_ARGS}
 check-index:
@@ -153,6 +155,8 @@ check-controller:
 	${TEST_CMD} ${BASE}/pkg/controller ${TEST_ARGS}
 check-cf_etcd:
 	${TEST_CMD} ${BASE}/pkg/cf_etcd ${TEST_ARGS}
+check-keyvalueservice:
+	${TEST_CMD} ${BASE}/pkg/keyvalueservice ${TEST_ARGS}
 
 DEB_PKG_DIR=build-deb-pkg
 dsc: dist

--- a/pkg/controller/cf_apps.go
+++ b/pkg/controller/cf_apps.go
@@ -294,6 +294,7 @@ func (env *CfEnvironment) spaceFetchQueueHandler(spaceId interface{}) bool {
 }
 
 func (env *CfEnvironment) cleanupEtcdContainers() error {
+	// TODO Remove when we don't use etcd anymore for container/app info
 	kapi := env.etcdKeysApi
 	cellKey := etcd.ACI_KEY_BASE
 	resp, err := kapi.Get(context.Background(), cellKey, &etcdclient.GetOptions{Recursive: true})

--- a/pkg/controller/cf_common_test.go
+++ b/pkg/controller/cf_common_test.go
@@ -37,6 +37,7 @@ import (
 	apic "github.com/noironetworks/aci-containers/pkg/apicapi"
 	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
 	etcd_f "github.com/noironetworks/aci-containers/pkg/cf_etcd_fakes"
+	rkv "github.com/noironetworks/aci-containers/pkg/keyvalueservice"
 	"github.com/noironetworks/aci-containers/pkg/cfapi"
 	"github.com/noironetworks/aci-containers/pkg/cfapi/cfapi_fakes"
 	"github.com/noironetworks/aci-containers/pkg/ipam"
@@ -95,6 +96,7 @@ func testCfEnvironmentNoMigration(t *testing.T) *CfEnvironment {
 	env.cfLogger = lager.NewLogger("CfEnv")
 
 	env.etcdKeysApi = etcd_f.NewFakeEtcdKeysApi(log)
+	env.kvmgr = rkv.NewKvManager()
 	env.initIndexes()
 	env.setupIndexes()
 	env.setupCcClientFakes()
@@ -257,6 +259,22 @@ func (e *CfEnvironment) GetAppInfo(appId string) *etcd.AppInfo {
 			panic(er.Error())
 		}
 		return &app
+	}
+	return nil
+}
+
+func (e *CfEnvironment) GetKvEpInfo(cell, cont string) *etcd.EpInfo {
+	v, err := e.kvmgr.Get("cell/" + cell, "ct/" + cont)
+	if err == nil {
+		return v.Value.(*etcd.EpInfo)
+	}
+	return nil
+}
+
+func (e *CfEnvironment) GetKvAppInfo(appId string) *etcd.AppInfo {
+	v, err := e.kvmgr.Get("apps", appId)
+	if err == nil {
+		return v.Value.(*etcd.AppInfo)
 	}
 	return nil
 }

--- a/pkg/controller/cf_environment_test.go
+++ b/pkg/controller/cf_environment_test.go
@@ -71,6 +71,9 @@ func TestCfLoadCellNetworkInfo(t *testing.T) {
 	assert.Equal(t, nodeMeta.podNetIpsAnnotation, r.podNetIpsAnnotation)
 	v, _ = k.Get(ctx, key, nil)
 	assert.Equal(t, nodeMeta.podNetIpsAnnotation, v.Node.Value)
+	item, _ := env.kvmgr.Get("cell/cell-1", "network")
+	assert.NotNil(t, item.Value)
+	assert.Equal(t, r.podNetIpsAnnotation, item.Value.(string))
 }
 
 func TestCfSetCellServiceInfo(t *testing.T) {
@@ -118,6 +121,9 @@ func TestCfSetCellServiceInfo(t *testing.T) {
 	svcEpStr, _ := json.Marshal(r.serviceEp)
 	v, _ = k.Get(ctx, key, nil)
 	assert.Equal(t, string(svcEpStr), v.Node.Value)
+	item, _ := env.kvmgr.Get("cell/cell-1", "service")
+	assert.NotNil(t, item.Value)
+	assert.Equal(t, r.serviceEp, *(item.Value.(*metadata.ServiceEndpoint)))
 
 	// outdated info in DB
 	delete(env.cont.nodeServiceMetaCache, nodename)
@@ -144,6 +150,9 @@ func TestCfSetCellServiceInfo(t *testing.T) {
 	svcEpStr, _ = json.Marshal(r.serviceEp)
 	v, _ = k.Get(ctx, key, nil)
 	assert.Equal(t, string(svcEpStr), v.Node.Value)
+	item, _ = env.kvmgr.Get("cell/cell-1", "service")
+	assert.NotNil(t, item.Value)
+	assert.Equal(t, r.serviceEp, *(item.Value.(*metadata.ServiceEndpoint)))
 }
 
 func TestCfEtcdStaleCleanup(t *testing.T) {
@@ -214,6 +223,9 @@ func TestCfNodePodNetworkChanged(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, nodeMeta.podNetIps, *podnet)
 	})
+	item, _ := env.kvmgr.Get("cell/cell-10", "network")
+	assert.NotNil(t, item.Value)
+	assert.Equal(t, nodeMeta.podNetIpsAnnotation, item.Value.(string))
 }
 
 func TestCfNodeServiceChanged(t *testing.T) {

--- a/pkg/controller/cf_kv_server.go
+++ b/pkg/controller/cf_kv_server.go
@@ -1,0 +1,131 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+
+	"code.cloudfoundry.org/cfhttp"
+
+	rkv "github.com/noironetworks/aci-containers/pkg/keyvalueservice"
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func NewCfKvServer(env *CfEnvironment) *rkv.KvServer {
+	lf := func() (net.Listener, error) {
+		tlscfg, err := cfhttp.NewTLSConfig(
+			env.cfconfig.ControllerServerCertFile,
+			env.cfconfig.ControllerServerKeyFile,
+			env.cfconfig.ControllerCACertFile)
+		if err != nil {
+			env.log.Warning("CfKvServer: Failed to create server-side "+
+				"TLS config: ", err)
+			return nil, err
+		}
+		return tls.Listen("tcp",
+			fmt.Sprintf(":%d", env.cfconfig.KeyValuePort), tlscfg)
+	}
+	w := rkv.NewKvWatcher([]string{"container"}, env.log, env.handleKvItems,
+		env.handleKvActions)
+	return rkv.NewKvServer(lf, env.kvmgr, w, env.log)
+}
+
+func (env *CfEnvironment) handleKvItems(ns string, items []rkv.KvItem) {
+	switch ns {
+	case "container":
+		env.handleContainerKvItems(items)
+	}
+}
+
+func (env *CfEnvironment) handleKvActions(ns string, acts []rkv.KvAction) {
+	switch ns {
+	case "container":
+		env.handleContainerKvActions(acts)
+	}
+}
+
+func (env *CfEnvironment) handleContainerKvItems(items []rkv.KvItem) {
+	if len(items) == 0 {
+		return
+	}
+
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+	for i, _ := range items {
+		env.handleContainerIpUpdate(&items[i])
+	}
+}
+
+func (env *CfEnvironment) handleContainerKvActions(acts []rkv.KvAction) {
+	if len(acts) == 0 {
+		return
+	}
+	env.indexLock.Lock()
+	defer env.indexLock.Unlock()
+
+	for i, _ := range acts {
+		if acts[i].Action != rkv.OP_DELETE {
+			env.handleContainerIpUpdate(&acts[i].Item)
+		}
+	}
+}
+
+// expect env.indexLock to be held
+func (env *CfEnvironment) handleContainerIpUpdate(item *rkv.KvItem) {
+	ctId := item.Key
+	ifs, ok := item.Value.([]interface{})
+	l := env.log.WithField("ctx", "KvItem:Container")
+	if !ok {
+		l.Error("Unexpected value type: ", item.Value)
+		return
+	}
+	if len(ifs) == 0 {
+		return
+	}
+	if0_m, ok := ifs[0].(map[string]interface{})
+	if !ok {
+		l.Error("Unexpected item #0 value type: ", ifs[0])
+		return
+	}
+	if0 := &md.ContainerIfaceMd{}
+	if err := rkv.MapToStruct(if0_m, if0); err != nil {
+		l.WithField("value", item.Value).Error("Decode error: ", err)
+		return
+	}
+	if len(if0.IPs) == 0 {
+		return
+	}
+	ct := env.contIdx[ctId]
+	if ct == nil || ct.IsApp() {
+		return
+	}
+	ct.IpAddress = if0.IPs[0].Address.IP.String()
+	env.contIdx[ctId] = ct
+	l.WithField("ctId", ctId).Debug("KV IP update: ", ct.IpAddress)
+	var app *AppInfo
+	if ct.AppId != "" {
+		if app = env.appIdx[ct.AppId]; app != nil {
+			app.ContainerIps[ctId] = ct.IpAddress
+			env.appIdx[ct.AppId] = app
+		}
+	}
+
+	if app != nil {
+		env.appUpdateQ.Add(app.AppId)
+	}
+	env.containerUpdateQ.Add(ctId)
+}

--- a/pkg/controller/cf_kv_server_test.go
+++ b/pkg/controller/cf_kv_server_test.go
@@ -1,0 +1,76 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	rkv "github.com/noironetworks/aci-containers/pkg/keyvalueservice"
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func TestCfHandleKvContainer(t *testing.T) {
+	env := testCfEnvironment(t)
+	w := NewCfKvServer(env).Watcher()
+	allf := w.AllHandler()
+	updf := w.UpdateHandler()
+
+	env.contIdx["c-5"] = &ContainerInfo{ContainerId: "c-5", CellId: "cell-1", InstanceIndex: -1,
+		AppId: "app-1"}
+	env.contIdx["c-6"] = &ContainerInfo{ContainerId: "c-6", CellId: "cell-1", InstanceIndex: -2,
+		AppId: "app-1"}
+	env.contIdx["c-7"] = &ContainerInfo{ContainerId: "c-7", CellId: "cell-1", InstanceIndex: -2,
+		AppId: "app-2"}
+
+	ifaces_c5 := []interface{}{
+		rkv.StructToMap(&md.ContainerIfaceMd{
+			HostVethName: "veth1",
+			Mac:          "1:2:3:4:5:6",
+			IPs: []md.ContainerIfaceIP{
+				{Address: net.IPNet{IP: net.ParseIP("10.255.0.45")}}}})}
+	ifaces_c6 := []interface{}{
+		rkv.StructToMap(&md.ContainerIfaceMd{
+			HostVethName: "veth1", Mac: "1:2:3:4:5:8"})}
+	ifaces_c7 := []interface{}{
+		rkv.StructToMap(&md.ContainerIfaceMd{
+			HostVethName: "veth1",
+			Mac:          "1:2:3:4:5:7",
+			IPs: []md.ContainerIfaceIP{
+				{Address: net.IPNet{IP: net.ParseIP("10.255.0.46")}}}})}
+
+	item_c5 := rkv.KvItem{Key: "c-5", Value: ifaces_c5}
+	item_c6 := rkv.KvItem{Key: "c-6", Value: ifaces_c6}
+	action_c7 := rkv.KvAction{Action: rkv.OP_SET,
+		Item: rkv.KvItem{Key: "c-7", Value: ifaces_c7}}
+	action_c5 := rkv.KvAction{Action: rkv.OP_DELETE,
+		Item: rkv.KvItem{Key: "c-5", Value: ifaces_c5}}
+
+	allf("container", []rkv.KvItem{item_c5, item_c6})
+	assert.Equal(t, "10.255.0.45", env.contIdx["c-5"].IpAddress)
+	assert.Equal(t, "10.255.0.45", env.appIdx["app-1"].ContainerIps["c-5"])
+
+	assert.Equal(t, "", env.contIdx["c-6"].IpAddress)
+	assert.Equal(t, "", env.appIdx["app-1"].ContainerIps["c-6"])
+
+	updf("container", []rkv.KvAction{action_c7, action_c5})
+	assert.Equal(t, "10.255.0.46", env.contIdx["c-7"].IpAddress)
+	assert.Equal(t, "10.255.0.46", env.appIdx["app-2"].ContainerIps["c-7"])
+
+	assert.Equal(t, "10.255.0.45", env.contIdx["c-5"].IpAddress)
+	assert.Equal(t, "10.255.0.45", env.appIdx["app-1"].ContainerIps["c-5"])
+}

--- a/pkg/controller/cf_update_handlers_test.go
+++ b/pkg/controller/cf_update_handlers_test.go
@@ -30,6 +30,7 @@ func TestCfContainerUpdateDelete(t *testing.T) {
 
 	env.handleContainerUpdate("c-1")
 	assert.Equal(t, getExpectedEpInfo(), env.GetEpInfo("cell-1", "c-1"))
+	assert.Equal(t, getExpectedEpInfo(), env.GetKvEpInfo("cell-1", "c-1"))
 
 	exp_inj_cont := apicapi.NewVmmInjectedOrgUnitContGrp(
 		"CloudFoundry", "cf-dom", "cf-ctrl", "org-1", "space-1", "c-1")
@@ -44,6 +45,7 @@ func TestCfContainerUpdateDelete(t *testing.T) {
 	delete(env.contIdx, "c-1")
 	env.handleContainerDelete(cinfo)
 	assert.Nil(t, env.GetEpInfo("cell-1", "c-1"))
+	assert.Nil(t, env.GetKvEpInfo("cell-1", "c-1"))
 	env.checkApicDesiredState(t, "inj_contgrp:c-1", nil)
 }
 
@@ -57,6 +59,7 @@ func TestCfContainerUpdateStaging(t *testing.T) {
 
 	env.handleContainerUpdate("c-1")
 	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+	assert.Equal(t, exp_ep, env.GetKvEpInfo("cell-1", "c-1"))
 }
 
 func TestCfContainerUpdateTask(t *testing.T) {
@@ -70,6 +73,7 @@ func TestCfContainerUpdateTask(t *testing.T) {
 
 	env.handleContainerUpdate("c-1")
 	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+	assert.Equal(t, exp_ep, env.GetKvEpInfo("cell-1", "c-1"))
 }
 
 func TestCfContainerUpdateIsolationSegment(t *testing.T) {
@@ -81,6 +85,7 @@ func TestCfContainerUpdateIsolationSegment(t *testing.T) {
 
 	env.handleContainerUpdate("c-1")
 	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+	assert.Equal(t, exp_ep, env.GetKvEpInfo("cell-1", "c-1"))
 }
 
 func TestCfContainerUpdateSharedIsolationSegment(t *testing.T) {
@@ -93,6 +98,7 @@ func TestCfContainerUpdateSharedIsolationSegment(t *testing.T) {
 
 	env.handleContainerUpdate("c-1")
 	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+	assert.Equal(t, exp_ep, env.GetKvEpInfo("cell-1", "c-1"))
 
 	// EPG annotations are honored for "shared" IS
 	ea_db := EpgAnnotationDb{}
@@ -103,6 +109,7 @@ func TestCfContainerUpdateSharedIsolationSegment(t *testing.T) {
 	exp_ep.Epg = "auto|epg-app"
 	env.handleContainerUpdate("c-1")
 	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+	assert.Equal(t, exp_ep, env.GetKvEpInfo("cell-1", "c-1"))
 }
 
 func TestCfContainerUpdateEpgAnnotation(t *testing.T) {
@@ -123,6 +130,7 @@ func TestCfContainerUpdateEpgAnnotation(t *testing.T) {
 		exp_ep.Epg = app_prof + "epg-org"
 		env.handleContainerUpdate("c-1")
 		assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+		assert.Equal(t, exp_ep, env.GetKvEpInfo("cell-1", "c-1"))
 
 		// add space annotation
 		txn(env.db, func(txn *sql.Tx) {
@@ -132,6 +140,7 @@ func TestCfContainerUpdateEpgAnnotation(t *testing.T) {
 		exp_ep.Epg = app_prof + "epg-space"
 		env.handleContainerUpdate("c-1")
 		assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+		assert.Equal(t, exp_ep, env.GetKvEpInfo("cell-1", "c-1"))
 
 		// add app annotation
 		txn(env.db, func(txn *sql.Tx) {
@@ -141,6 +150,7 @@ func TestCfContainerUpdateEpgAnnotation(t *testing.T) {
 		exp_ep.Epg = app_prof + "epg-app"
 		env.handleContainerUpdate("c-1")
 		assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+		assert.Equal(t, exp_ep, env.GetKvEpInfo("cell-1", "c-1"))
 
 		// cleanup for next loop
 		txn(env.db, func(txn *sql.Tx) {
@@ -166,6 +176,7 @@ func TestCfContainerUpdateAdditionalPorts(t *testing.T) {
 
 	env.handleContainerUpdate("c-1")
 	assert.Equal(t, exp_ep, env.GetEpInfo("cell-1", "c-1"))
+	assert.Equal(t, exp_ep, env.GetKvEpInfo("cell-1", "c-1"))
 }
 
 func TestCfAppUpdateDelete(t *testing.T) {
@@ -193,6 +204,7 @@ func TestCfAppUpdateDelete(t *testing.T) {
 
 	env.handleAppUpdate("app-1")
 	assert.Equal(t, exp_app, env.GetAppInfo("app-1"))
+	assert.Equal(t, exp_app, env.GetKvAppInfo("app-1"))
 	env.checkApicDesiredState(t, "inj_depl:app-1", exp_inj_depl)
 	assert.NotNil(t, env.cont.apicConn.GetDesiredState("app_ext_ip:app-1"))
 	assert.NotNil(t, env.cont.apicConn.GetDesiredState("app-port:app-1"))
@@ -203,6 +215,7 @@ func TestCfAppUpdateDelete(t *testing.T) {
 	delete(env.appIdx, "app-1")
 	env.handleAppDelete(ainfo)
 	assert.Nil(t, env.GetAppInfo("app-1"))
+	assert.Nil(t, env.GetKvAppInfo("app-1"))
 	env.checkApicDesiredState(t, "inj_depl:app-1", nil)
 	assert.Nil(t, env.cont.apicConn.GetDesiredState("app_ext_ip:app-1"))
 	assert.Nil(t, env.cont.apicConn.GetDesiredState("app-port:app-1"))

--- a/pkg/hostagent/cf_apps_test.go
+++ b/pkg/hostagent/cf_apps_test.go
@@ -30,7 +30,7 @@ func TestCfContainerUpdate(t *testing.T) {
 	id := "one"
 	ep := getTestEpInfo()
 	env.epIdx[id] = ep
-	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata()
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata("one")
 	expected_ep := getExpectedOpflexEp()
 	expected_svc := getExpectedOpflexServiceForLegacyNet(env)
 
@@ -109,7 +109,7 @@ func TestCfStagingContainerUpdate(t *testing.T) {
 	ep := getTestEpInfo()
 	ep.InstanceIndex = etcd.INST_IDX_STAGING
 	env.epIdx[id] = ep
-	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata()
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata("one")
 	expected_ep := getExpectedOpflexEp()
 	expected_ep.Attributes["vm-name"] = "a1-name (staging)"
 
@@ -133,7 +133,7 @@ func TestCfTaskContainerUpdate(t *testing.T) {
 	ep.InstanceIndex = etcd.INST_IDX_TASK
 	ep.TaskName = "errand"
 	env.epIdx[id] = ep
-	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata()
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata("one")
 	expected_ep := getExpectedOpflexEp()
 	expected_ep.Attributes["vm-name"] = "a1-name (task errand)"
 

--- a/pkg/hostagent/cf_etcd_watcher_test.go
+++ b/pkg/hostagent/cf_etcd_watcher_test.go
@@ -33,7 +33,7 @@ func TestCfHandleEtcdContainerNode(t *testing.T) {
 	handler := NewCfEtcdCellWatcher(env).NodeHandler()
 	op := "create"
 
-	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata()
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata("one")
 	ep := getTestEpInfo()
 	ep_str, _ := json.Marshal(ep)
 	node := &etcdclient.Node{Key: "/aci/cells/cell1/containers/one/ep", Value: string(ep_str)}

--- a/pkg/hostagent/cf_kv_client.go
+++ b/pkg/hostagent/cf_kv_client.go
@@ -1,0 +1,294 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"reflect"
+	"strings"
+
+	"code.cloudfoundry.org/cfhttp"
+	"github.com/Sirupsen/logrus"
+
+	etcd "github.com/noironetworks/aci-containers/pkg/cf_etcd"
+	rkv "github.com/noironetworks/aci-containers/pkg/keyvalueservice"
+	"github.com/noironetworks/aci-containers/pkg/metadata"
+)
+
+func NewCfKvClient(env *CfEnvironment) *rkv.KvClient {
+	cf := func() (net.Conn, error) {
+		tlscfg, err := cfhttp.NewTLSConfig(
+			env.cfconfig.ControllerClientCertFile,
+			env.cfconfig.ControllerClientKeyFile,
+			env.cfconfig.ControllerCACertFile)
+		if err != nil {
+			env.log.Warning("CfKvClient: Failed to create "+
+				"client-side TLS config: ", err)
+			return nil, err
+		}
+		return tls.Dial("tcp", env.cfconfig.ControllerAddress, tlscfg)
+	}
+	w := rkv.NewKvWatcher([]string{"apps", "cell/" + env.cfconfig.CellID},
+		env.log, env.handleKvItems, env.handleKvActions)
+	return rkv.NewKvClient(cf, env.kvmgr, w, env.log)
+}
+
+type appKvHandler struct {
+	env *CfEnvironment
+}
+
+type cellKvHandler struct {
+	env *CfEnvironment
+}
+
+func (env *CfEnvironment) handleKvItems(ns string, items []rkv.KvItem) {
+	env.log.WithFields(
+		logrus.Fields{"ctx": "handleKvItems", "ns": ns, "#items": len(items)},
+	).Info("Got all items")
+	switch ns {
+	case "apps":
+		(&appKvHandler{env}).All(items)
+		env.appsSynced = true
+	case "cell/" + env.cfconfig.CellID:
+		env.cellSynced = true
+		(&cellKvHandler{env}).All(items)
+	}
+	if env.appsSynced && env.cellSynced {
+		env.agent.EnableSync()
+		env.agent.cleanupSetup()
+	}
+}
+
+func (env *CfEnvironment) handleKvActions(ns string, acts []rkv.KvAction) {
+	switch ns {
+	case "apps":
+		(&appKvHandler{env}).Update(acts)
+	case "cell/" + env.cfconfig.CellID:
+		(&cellKvHandler{env}).Update(acts)
+	}
+}
+
+type idSet map[string]struct{}
+
+func (h *appKvHandler) All(items []rkv.KvItem) {
+	ids := make(idSet)
+	for i, _ := range items {
+		h.do(&items[i], ids, false)
+	}
+
+	h.env.indexLock.Lock()
+	tonotify := make(map[string]*etcd.AppInfo)
+	for app, info := range h.env.appIdx {
+		if _, ok := ids[app]; !ok {
+			tonotify[app] = info
+			delete(h.env.appIdx, app)
+		}
+	}
+	h.env.indexLock.Unlock()
+	for app, info := range tonotify {
+		h.env.cfAppDeleted(&app, info)
+	}
+}
+
+func (h *appKvHandler) Update(acts []rkv.KvAction) {
+	for i, _ := range acts {
+		h.do(&acts[i].Item, nil, acts[i].Action == rkv.OP_DELETE)
+	}
+}
+
+func (h *appKvHandler) do(item *rkv.KvItem, ids idSet, del bool) {
+	appId := item.Key
+	l := h.env.log.WithFields(
+		logrus.Fields{"ctx": "KvItem:App", "appId": appId})
+	if !del {
+		if m, ok := item.Value.(map[string]interface{}); !ok {
+			l.Error("Unexpected value type: ", item.Value)
+		} else {
+			app := &etcd.AppInfo{}
+			if err := rkv.MapToStruct(m, app); err != nil {
+				l.WithField("value", item.Value).Error("Decode error: ", err)
+			} else {
+				l.Info("KV update, new value: ", fmt.Sprintf("%+v", app))
+				h.env.indexLock.Lock()
+				h.env.appIdx[appId] = app
+				h.env.indexLock.Unlock()
+				if ids != nil {
+					ids[appId] = struct{}{}
+				}
+				h.env.cfAppChanged(&appId, app)
+			}
+		}
+	} else {
+		l.Info("KV delete")
+		h.env.indexLock.Lock()
+		app := h.env.appIdx[appId]
+		delete(h.env.appIdx, appId)
+		h.env.indexLock.Unlock()
+
+		h.env.cfAppDeleted(&appId, app)
+	}
+}
+
+func (h *cellKvHandler) All(items []rkv.KvItem) {
+	ids := make(idSet)
+	hasNet, hasSvc := false, false
+	for i, _ := range items {
+		n, s := h.do(&items[i], ids, false)
+		hasNet = hasNet || n
+		hasSvc = hasSvc || s
+	}
+
+	if !hasNet {
+		h.doNetwork(nil, true)
+	}
+	if !hasSvc {
+		h.doService(nil, true)
+	}
+
+	h.env.indexLock.Lock()
+	tonotify := make(map[string]*etcd.EpInfo)
+	for ctId, info := range h.env.epIdx {
+		if _, ok := ids[ctId]; !ok {
+			tonotify[ctId] = info
+			delete(h.env.epIdx, ctId)
+		}
+	}
+	h.env.indexLock.Unlock()
+	for ctId, ep := range tonotify {
+		l := h.env.log.WithFields(
+			logrus.Fields{"ctx": "KvItem:Container", "ctId": ctId})
+		l.Info("KV delete on full sync")
+		h.env.cfAppContainerDeleted(&ctId, ep)
+	}
+}
+
+func (h *cellKvHandler) Update(acts []rkv.KvAction) {
+	for i, _ := range acts {
+		h.do(&acts[i].Item, nil, acts[i].Action == rkv.OP_DELETE)
+	}
+}
+
+func (h *cellKvHandler) do(item *rkv.KvItem, ids idSet, del bool) (
+	netChanged, svcChanged bool) {
+	if item.Key == "network" {
+		netChanged = h.doNetwork(item, del)
+	} else if item.Key == "service" {
+		svcChanged = h.doService(item, del)
+	} else if strings.HasPrefix(item.Key, "ct/") {
+		h.doContainer(item, ids, del)
+	}
+	return
+}
+
+func (h *cellKvHandler) doNetwork(item *rkv.KvItem, del bool) (updated bool) {
+	l := h.env.log.WithField("ctx", "KvItem:CellNetwork")
+	if del {
+		l.Info("Resetting network pool to default")
+		h.env.agent.updateIpamAnnotation(h.env.getDefaultIpPool())
+	} else {
+		if ann, ok := item.Value.(string); !ok {
+			l.Error("Unexpected value type: ", item.Value)
+		} else {
+			h.env.agent.updateIpamAnnotation(ann)
+			updated = true
+		}
+	}
+	return
+}
+
+func (h *cellKvHandler) doService(item *rkv.KvItem, del bool) (updated bool) {
+	env := h.env
+	agent := env.agent
+	l := env.log.WithField("ctx", "KvItem:CellService")
+	if del {
+		l.Info("Clearing service EP info")
+		agent.indexMutex.Lock()
+		agent.serviceEp = metadata.ServiceEndpoint{}
+		agent.indexMutex.Unlock()
+	} else {
+		if m, ok := item.Value.(map[string]interface{}); !ok {
+			l.Error("Unexpected value type: ", item.Value)
+		} else {
+			sep := &metadata.ServiceEndpoint{}
+			if err := rkv.MapToStruct(m, sep); err != nil {
+				l.WithField("value", item.Value).Error("Decode error: ", err)
+			} else {
+				agent.indexMutex.Lock()
+				if !reflect.DeepEqual(sep, &agent.serviceEp) {
+					l.Info("Cell service EP updated: ",
+						fmt.Sprintf("%+v", sep))
+					agent.serviceEp = *sep
+					updated = true
+				}
+				agent.indexMutex.Unlock()
+			}
+		}
+	}
+	if updated || del {
+		// update service files for all apps that have a container
+		apps := make(idSet)
+		env.indexLock.Lock()
+		for _, ep := range env.epIdx {
+			if ep != nil {
+				apps[ep.AppId] = struct{}{}
+			}
+		}
+		env.indexLock.Unlock()
+		// TODO Use a queue for updating all apps
+		go func() {
+			for id := range apps {
+				env.cfAppIdChanged(&id)
+			}
+		}()
+	}
+	return
+}
+
+func (h *cellKvHandler) doContainer(item *rkv.KvItem, ids idSet, del bool) {
+	env := h.env
+	ctId := strings.Split(item.Key, "/")[1]
+	l := env.log.WithFields(
+		logrus.Fields{"ctx": "KvItem:Container", "ctId": ctId})
+	if del {
+		l.Info("KV delete")
+
+		env.indexLock.Lock()
+		ep := env.epIdx[ctId]
+		delete(env.epIdx, ctId)
+		env.indexLock.Unlock()
+
+		env.cfAppContainerDeleted(&ctId, ep)
+	} else {
+		if m, ok := item.Value.(map[string]interface{}); !ok {
+			l.Error("Unexpected value type: ", item.Value)
+		} else {
+			ep := &etcd.EpInfo{}
+			if err := rkv.MapToStruct(m, ep); err != nil {
+				l.WithField("value", item.Value).Error("Decode error: ", err)
+			} else {
+				l.Info("KV update, new value: ", fmt.Sprintf("%+v", ep))
+				env.indexLock.Lock()
+				env.epIdx[ctId] = ep
+				env.indexLock.Unlock()
+				if ids != nil {
+					ids[ctId] = struct{}{}
+				}
+				env.cfAppContainerChanged(&ctId, ep)
+			}
+		}
+	}
+}

--- a/pkg/hostagent/cf_kv_client_test.go
+++ b/pkg/hostagent/cf_kv_client_test.go
@@ -1,0 +1,224 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	rkv "github.com/noironetworks/aci-containers/pkg/keyvalueservice"
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+	md "github.com/noironetworks/aci-containers/pkg/metadata"
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func TestCfHandleKvContainer(t *testing.T) {
+	env := testCfEnvironment(t)
+	w := NewCfKvClient(env).Watcher()
+	allf := w.AllHandler()
+	updf := w.UpdateHandler()
+
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata("one")
+	env.agent.epMetadata["_cf_/two"] = getTestEpMetadata("two")
+	ep_one := getTestEpInfo()
+	ep_two := getTestEpInfo()
+
+	allf("cell/cell1", []rkv.KvItem{
+		{Key: "ct/one", Value: rkv.StructToMap(ep_one)},
+		{Key: "ct/two", Value: rkv.StructToMap(ep_two)}})
+	assert.Equal(t, ep_one, env.epIdx["one"])
+	assert.NotNil(t, env.agent.opflexEps["one"])
+	assert.Equal(t, ep_two, env.epIdx["two"])
+	assert.NotNil(t, env.agent.opflexEps["two"])
+
+	ep_two.AppName = "a2-name"
+	updf("cell/cell1", []rkv.KvAction{
+		{Action: rkv.OP_DELETE,
+			Item: rkv.KvItem{Key: "ct/one",
+				Value: rkv.StructToMap(ep_one)}},
+		{Action: rkv.OP_SET,
+			Item: rkv.KvItem{Key: "ct/two",
+				Value: rkv.StructToMap(ep_two)}},
+		{Action: rkv.OP_SET,
+			Item: rkv.KvItem{Key: "ct/three",
+				Value: rkv.StructToMap(ep_one)}}})
+	assert.Nil(t, env.epIdx["one"])
+	assert.Nil(t, env.agent.opflexEps["one"])
+	assert.Equal(t, ep_two, env.epIdx["two"])
+	assert.Equal(t, ep_one, env.epIdx["three"])
+
+	// full sync
+	allf("cell/cell1", []rkv.KvItem{
+		{Key: "ct/four", Value: rkv.StructToMap(ep_one)}})
+	assert.Nil(t, env.epIdx["two"])
+	assert.Nil(t, env.agent.opflexEps["two"])
+	assert.Nil(t, env.epIdx["three"])
+	assert.Nil(t, env.agent.opflexEps["three"])
+	assert.Equal(t, ep_one, env.epIdx["four"])
+}
+
+func TestCfHandleKvApp(t *testing.T) {
+	env := testCfEnvironment(t)
+	w := NewCfKvClient(env).Watcher()
+	allf := w.AllHandler()
+	updf := w.UpdateHandler()
+
+	env.epIdx["one"] = getTestEpInfo()
+	env.epIdx["two"] = getTestEpInfo()
+	env.epIdx["two"].AppId = "a2"
+	app_one := getTestAppInfo()
+	app_two := getTestAppInfo()
+
+	allf("apps", []rkv.KvItem{
+		{Key: "a1", Value: rkv.StructToMap(app_one)},
+		{Key: "a2", Value: rkv.StructToMap(app_two)}})
+	assert.Equal(t, app_one, env.appIdx["a1"])
+	assert.NotNil(t, env.agent.opflexServices["a1"])
+	assert.NotNil(t, env.agent.opflexServices["a1-external"])
+	assert.Equal(t, app_two, env.appIdx["a2"])
+	assert.NotNil(t, env.agent.opflexServices["a2"])
+	assert.NotNil(t, env.agent.opflexServices["a2-external"])
+
+	app_two.ContainerIps = append(app_two.ContainerIps, "10.255.0.101")
+	updf("apps", []rkv.KvAction{
+		{Action: rkv.OP_DELETE,
+			Item: rkv.KvItem{Key: "a1",
+				Value: rkv.StructToMap(app_one)}},
+		{Action: rkv.OP_SET,
+			Item: rkv.KvItem{Key: "a2",
+				Value: rkv.StructToMap(app_two)}},
+		{Action: rkv.OP_SET,
+			Item: rkv.KvItem{Key: "a3",
+				Value: rkv.StructToMap(app_one)}}})
+	assert.Nil(t, env.appIdx["a1"])
+	assert.Nil(t, env.agent.opflexServices["a1"])
+	assert.Nil(t, env.agent.opflexServices["a1-external"])
+	assert.Equal(t, app_two, env.appIdx["a2"])
+	assert.Equal(t, app_one, env.appIdx["a3"])
+
+	// full sync
+	allf("apps", []rkv.KvItem{
+		{Key: "a4", Value: rkv.StructToMap(app_one)}})
+	assert.Nil(t, env.appIdx["a2"])
+	assert.Nil(t, env.appIdx["a3"])
+	assert.Equal(t, app_one, env.appIdx["a4"])
+}
+
+func TestCfHandleKvCellNetwork(t *testing.T) {
+	env := testCfEnvironment(t)
+	w := NewCfKvClient(env).Watcher()
+	allf := w.AllHandler()
+	updf := w.UpdateHandler()
+
+	pod_ip := md.NetIps{}
+	pod_ip.V4 = append(pod_ip.V4,
+		ipam.IpRange{Start: net.ParseIP("10.255.0.2"),
+			End: net.ParseIP("10.255.0.127")},
+		ipam.IpRange{Start: net.ParseIP("10.255.1.2"),
+			End: net.ParseIP("10.255.1.127")})
+	pod_ip.V6 = append(pod_ip.V6,
+		ipam.IpRange{Start: net.ParseIP("::ff02"),
+			End: net.ParseIP("::ffef")},
+		ipam.IpRange{Start: net.ParseIP("::fe02"),
+			End: net.ParseIP("::feef")})
+	pod_ann, _ := json.Marshal(pod_ip)
+
+	allf("cell/cell1", []rkv.KvItem{{Key: "network", Value: string(pod_ann)}})
+	assert.Equal(t, string(pod_ann), env.agent.podNetAnnotation)
+
+	// full sync
+	allf("cell/cell1", []rkv.KvItem{})
+	assert.Equal(t, "{}", env.agent.podNetAnnotation)
+
+	pod_ip.V4 = pod_ip.V4[1:]
+	pod_ip.V6 = pod_ip.V6[1:]
+	pod_ann, _ = json.Marshal(pod_ip)
+
+	updf("cell/cell1", []rkv.KvAction{
+		{Action: rkv.OP_SET,
+			Item: rkv.KvItem{Key: "network", Value: string(pod_ann)}}})
+	assert.Equal(t, string(pod_ann), env.agent.podNetAnnotation)
+
+	updf("cell/cell1", []rkv.KvAction{
+		{Action: rkv.OP_DELETE,
+			Item: rkv.KvItem{Key: "network", Value: string(pod_ann)}}})
+	assert.Equal(t, "{}", env.agent.podNetAnnotation)
+}
+
+func TestCfHandleKvCellService(t *testing.T) {
+	env := testCfEnvironment(t)
+	w := NewCfKvClient(env).Watcher()
+	allf := w.AllHandler()
+	updf := w.UpdateHandler()
+
+	env.epIdx["one"] = getTestEpInfo()
+	env.appIdx["a1"] = getTestAppInfo()
+	ep_one := getTestEpInfo()
+
+	svc_ep := md.ServiceEndpoint{Mac: "de:ad:be:ef:00:01",
+		Ipv4: net.ParseIP("10.150.0.10")}
+	allf("cell/cell1",
+		[]rkv.KvItem{
+			{Key: "service", Value: rkv.StructToMap(&svc_ep)},
+			{Key: "ct/one", Value: rkv.StructToMap(ep_one)}})
+	assert.Equal(t, svc_ep, env.agent.serviceEp)
+	tu.WaitFor(t, "Ext-IP service ep created", 500*time.Millisecond,
+		func(last bool) (bool, error) {
+			return env.agent.opflexServices["a1-external"] != nil, nil
+		})
+
+	updf("cell/cell1", []rkv.KvAction{
+		{Action: rkv.OP_DELETE,
+			Item: rkv.KvItem{Key: "service",
+				Value: rkv.StructToMap(&svc_ep)}}})
+	assert.Equal(t, "", env.agent.serviceEp.Mac)
+	assert.Nil(t, env.agent.serviceEp.Ipv4)
+	tu.WaitFor(t, "Ext-IP service ep removed", 500*time.Millisecond,
+		func(last bool) (bool, error) {
+			svc := env.agent.opflexServices["a1-external"]
+			return (svc != nil && svc.ServiceMac == "" &&
+				svc.InterfaceIp == ""), nil
+		})
+
+	updf("cell/cell1", []rkv.KvAction{
+		{Action: rkv.OP_SET,
+			Item: rkv.KvItem{Key: "service",
+				Value: rkv.StructToMap(&svc_ep)}}})
+	assert.Equal(t, svc_ep, env.agent.serviceEp)
+	// full sync
+	allf("cell/cell1", []rkv.KvItem{
+		{Key: "ct/one", Value: rkv.StructToMap(ep_one)}})
+	assert.Equal(t, "", env.agent.serviceEp.Mac)
+	assert.Nil(t, env.agent.serviceEp.Ipv4)
+}
+
+func TestCfStaleContCleanup(t *testing.T) {
+	env := testCfEnvironment(t)
+	w := NewCfKvClient(env).Watcher()
+	allf := w.AllHandler()
+
+	env.agent.epMetadata["_cf_/one"] = getTestEpMetadata("one")
+	env.agent.epMetadata["_cf_/two"] = getTestEpMetadata("two")
+	env.agent.epMetadata["_cf_/three"] = getTestEpMetadata("three")
+
+	allf("cell/cell1", []rkv.KvItem{})
+	allf("apps", []rkv.KvItem{})
+	assert.True(t, env.agent.syncEnabled)
+	assert.Empty(t, env.agent.epMetadata)
+}

--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -30,7 +30,7 @@ import (
 
 type Environment interface {
 	Init(agent *HostAgent) error
-	PrepareRun(stopCh <-chan struct{}) error
+	PrepareRun(stopCh <-chan struct{}) (bool, error)
 
 	CniDeviceChanged(metadataKey *string, id *md.ContainerId)
 	CniDeviceDeleted(metadataKey *string, id *md.ContainerId)
@@ -99,7 +99,7 @@ func (env *K8sEnvironment) Init(agent *HostAgent) error {
 	return nil
 }
 
-func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
+func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 	env.agent.log.Debug("Discovering node configuration")
 	env.agent.updateOpflexConfig()
 	go env.agent.runTickers(stopCh)
@@ -121,7 +121,7 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 		env.agent.podInformer.HasSynced, env.agent.endpointsInformer.HasSynced,
 		env.agent.serviceInformer.HasSynced)
 	env.agent.log.Info("Cache sync successful")
-	return nil
+	return true, nil
 }
 
 func (env *K8sEnvironment) CniDeviceChanged(metadataKey *string, id *md.ContainerId) {

--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -352,6 +352,11 @@ func (agent *HostAgent) cleanupSetup() {
 	agent.log.Info("Checking for stale container setup")
 
 	agent.indexMutex.Lock()
+	if !agent.syncEnabled {
+		agent.indexMutex.Unlock()
+		agent.log.Info("Sync not enabled, skipping stale container setup")
+		return
+	}
 	mdcopy := agent.epMetadata
 	agent.indexMutex.Unlock()
 

--- a/pkg/keyvalueservice/manager.go
+++ b/pkg/keyvalueservice/manager.go
@@ -1,0 +1,213 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalueservice
+
+import (
+	"errors"
+	"sync"
+)
+
+type KvItem struct {
+	Key     string
+	Value   interface{}
+	Version uint64
+}
+
+const (
+	OP_SET = iota
+	OP_DELETE
+)
+
+type KvAction struct {
+	Action uint
+	Item   KvItem
+}
+
+var KvErrorInternal = errors.New("KvError: Internal Error")
+var KvErrorVersionTooOld = errors.New("KvError: Requested version is too old")
+var KvErrorNotFound = errors.New("KvError: Key or namespace not found")
+
+type KvManager struct {
+	lock       sync.Locker
+	namespaces map[string]*kvNamespace
+
+	servingWatch bool
+	watchReqChan chan *watchReq
+	changedChan  chan string
+	pending      map[string][]*watchReq
+	maxRetained  int
+}
+
+func NewKvManager() *KvManager {
+	return &KvManager{
+		lock:         &sync.Mutex{},
+		namespaces:   make(map[string]*kvNamespace),
+		servingWatch: false,
+		watchReqChan: make(chan *watchReq),
+		changedChan:  make(chan string),
+		pending:      make(map[string][]*watchReq),
+		maxRetained:  50}
+}
+
+func (m *KvManager) List(namespace string) (uint64, []KvItem) {
+	ns := m.getNamespace(namespace)
+	if ns != nil {
+		return ns.GetAll()
+	}
+	return 0, nil
+}
+
+func (m *KvManager) Watch(namespace string, version uint64) (uint64,
+	[]KvAction, error) {
+
+	ch, err := m.watchAsync(namespace, version)
+	if err != nil {
+		return version, nil, err
+	}
+	res, ok := <-ch
+	if ok {
+		return res.Version, res.Actions, res.Error
+	}
+	// TODO: return an error here?
+	return version, nil, nil
+}
+
+func (m *KvManager) watchAsync(namespace string, version uint64) (
+	chan *watchRes, error) {
+	if !m.servingWatch {
+		return nil, KvErrorInternal
+	}
+	ns := m.getOrCreateNamespace(namespace)
+
+	r := &watchReq{Namespace: ns,
+		Version: version,
+		ResChan: make(chan *watchRes, 1)}
+	m.watchReqChan <- r
+	return r.ResChan, nil
+}
+
+func (m *KvManager) Get(namespace, key string) (KvItem, error) {
+	ns := m.getNamespace(namespace)
+	if ns != nil {
+		return ns.Get(key)
+	}
+	return KvItem{}, KvErrorNotFound
+}
+
+func (m *KvManager) Set(namespace, key string, value interface{}) error {
+	ns := m.getOrCreateNamespace(namespace)
+	ns.Set(key, value)
+	if m.servingWatch {
+		m.changedChan <- namespace
+	}
+	return nil
+}
+
+func (m *KvManager) Delete(namespace, key string) error {
+	ns := m.getNamespace(namespace)
+	if ns != nil {
+		if deleted, _, _ := ns.Delete(key); deleted && m.servingWatch {
+			m.changedChan <- namespace
+		}
+	}
+	return nil
+}
+
+func (m *KvManager) ServeWatch(stopCh <-chan struct{}) {
+	m.servingWatch = true
+
+	// TODO: should we timeout watches if there are no updates?
+	for {
+		select {
+		case req := <-m.watchReqChan:
+			// Handle watch req
+			if !req.Process() {
+				m.pending[req.Namespace.Name] = append(
+					m.pending[req.Namespace.Name], req)
+			}
+		case ns := <-m.changedChan:
+			// Handle changes
+			reqs, found := m.pending[ns]
+			if !found {
+				continue
+			}
+			new_pending := make([]*watchReq, 0)
+			for _, r := range reqs {
+				if !r.Process() {
+					new_pending = append(new_pending, r)
+				}
+			}
+			if len(new_pending) > 0 {
+				m.pending[ns] = new_pending
+			} else {
+				delete(m.pending, ns)
+			}
+		case <-stopCh:
+			m.servingWatch = false
+			// Abort all watch requests
+			for _, reqs := range m.pending {
+				for _, r := range reqs {
+					r.Abort()
+				}
+			}
+			m.pending = make(map[string][]*watchReq)
+			return
+		}
+	}
+}
+
+func (m *KvManager) getNamespace(namespace string) *kvNamespace {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	return m.namespaces[namespace]
+}
+
+func (m *KvManager) getOrCreateNamespace(namespace string) *kvNamespace {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	ns, ok := m.namespaces[namespace]
+	if !ok {
+		ns = newKvNamespace(namespace, m.maxRetained)
+		m.namespaces[namespace] = ns
+	}
+	return ns
+}
+
+type watchReq struct {
+	Namespace *kvNamespace
+	Version   uint64
+	ResChan   chan *watchRes
+}
+
+type watchRes struct {
+	Actions []KvAction
+	Version uint64
+	Error   error
+}
+
+func (r *watchReq) Process() bool {
+	last, acts, err := r.Namespace.FindUpdatedAfter(r.Version)
+	if err != nil || len(acts) > 0 {
+		r.ResChan <- &watchRes{Actions: acts, Version: last, Error: err}
+		close(r.ResChan)
+		return true
+	}
+	return false
+}
+
+func (r *watchReq) Abort() {
+	r.ResChan <- &watchRes{Actions: nil, Version: r.Version, Error: nil}
+	close(r.ResChan)
+}

--- a/pkg/keyvalueservice/manager_test.go
+++ b/pkg/keyvalueservice/manager_test.go
@@ -1,0 +1,355 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalueservice
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func lesser(lhs, rhs uint64) assert.Comparison {
+	f := func() bool {
+		return lhs < rhs
+	}
+	return f
+}
+
+func TestKvManagerGetSet(t *testing.T) {
+	mgr := NewKvManager()
+
+	oldver, items := mgr.List("ns1")
+	assert.Nil(t, items)
+	assert.Equal(t, uint64(0), oldver)
+
+	_, err := mgr.Get("ns1", "key1")
+	assert.Equal(t, KvErrorNotFound, err)
+
+	mgr.Set("ns1", "key1", "value1")
+	newver, items := mgr.List("ns1")
+	assert.Condition(t, lesser(oldver, newver))
+	assert.ElementsMatch(t, []KvItem{{Key: "key1", Value: "value1"}}, items)
+	oldver = newver
+
+	item, err := mgr.Get("ns1", "key1")
+	assert.Nil(t, err)
+	assert.Equal(t, KvItem{Key: "key1", Value: "value1"}, item)
+
+	_, err = mgr.Get("ns1", "key2")
+	assert.Equal(t, KvErrorNotFound, err)
+
+	mgr.Set("ns1", "key2", "value2")
+	newver, items = mgr.List("ns1")
+	assert.Condition(t, lesser(oldver, newver))
+	assert.ElementsMatch(t,
+		[]KvItem{{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"}},
+		items)
+	oldver = newver
+
+	mgr.Delete("ns1", "key2")
+	newver, items = mgr.List("ns1")
+	assert.Condition(t, lesser(oldver, newver))
+	assert.ElementsMatch(t, []KvItem{{Key: "key1", Value: "value1"}}, items)
+	oldver = newver
+
+	// delete non-existing key
+	mgr.Delete("ns1", "key2")
+	newver1, items1 := mgr.List("ns1")
+	assert.Equal(t, newver, newver1)
+	assert.ElementsMatch(t, items, items1)
+
+	mgr.Set("ns1", "key1", "value3")
+	newver, items = mgr.List("ns1")
+	assert.Condition(t, lesser(oldver, newver))
+	assert.ElementsMatch(t, []KvItem{{Key: "key1", Value: "value3"}}, items)
+}
+
+func TestKvManagerWatchNotRunning(t *testing.T) {
+	mgr := NewKvManager()
+
+	// not serving watches
+	_, _, err := mgr.Watch("ns1", 0)
+	assert.Equal(t, KvErrorInternal, err)
+}
+
+func initWatching(t *testing.T, mgr *KvManager, stopCh <-chan struct{}) {
+	go mgr.ServeWatch(stopCh)
+	tu.WaitFor(t, "Waiting for watching enabled", 500*time.Millisecond,
+		func(bool) (bool, error) { return mgr.servingWatch, nil })
+}
+
+func TestKvManagerWatchImmediate(t *testing.T) {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+
+	// setup few items
+	mgr.Set("ns1", "key1", "value1")
+	mgr.Set("ns1", "key10", "value10")
+	veryoldver, _ := mgr.List("ns1")
+
+	mgr.Set("ns1", "key2", "value2")
+	newver, items := mgr.List("ns1")
+	assert.Equal(t, 3, len(items))
+	oldver := newver
+
+	// do some updates before watch
+	mgr.Set("ns1", "key1", "value1_1")
+	mgr.Delete("ns1", "key2")
+	mgr.Set("ns1", "key3", "value3")
+
+	newver, acts, err := mgr.Watch("ns1", oldver)
+	assert.Nil(t, err)
+	assert.Condition(t, lesser(oldver, newver))
+	assert.ElementsMatch(t,
+		[]KvAction{
+			{Action: OP_SET, Item: KvItem{Key: "key1", Value: "value1_1"}},
+			{Action: OP_SET, Item: KvItem{Key: "key3", Value: "value3"}},
+			{Action: OP_DELETE, Item: KvItem{Key: "key2", Value: "value2"}}},
+		acts)
+	oldver = newver
+
+	// get updates from much older version
+	newver1, acts1, err1 := mgr.Watch("ns1", veryoldver)
+	assert.Nil(t, err1)
+	assert.Equal(t, newver, newver1)
+	assert.ElementsMatch(t, acts, acts1)
+}
+
+func TestKvManagerWatchCoalesce(t *testing.T) {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+
+	// setup few items
+	mgr.Set("ns1", "key1", "value1")
+	oldver, _ := mgr.List("ns1")
+
+	mgr.Set("ns1", "key2", "value2")
+	oldver, _, _ = mgr.Watch("ns1", oldver)
+
+	// delete followed by set -> set only
+	mgr.Delete("ns1", "key2")
+	mgr.Set("ns1", "key2", "value2_1")
+
+	newver, acts1, err := mgr.Watch("ns1", oldver)
+	assert.Nil(t, err)
+	assert.Condition(t, lesser(oldver, newver))
+	assert.ElementsMatch(t,
+		[]KvAction{
+			{Action: OP_SET, Item: KvItem{Key: "key2", Value: "value2_1"}}},
+		acts1)
+	oldver = newver
+
+	// add followed by delete -> delete only
+	mgr.Set("ns1", "key3", "value3")
+	mgr.Delete("ns1", "key3")
+	newver, acts2, err := mgr.Watch("ns1", oldver)
+	assert.Nil(t, err)
+	assert.Condition(t, lesser(oldver, newver))
+	assert.ElementsMatch(t,
+		[]KvAction{
+			{Action: OP_DELETE, Item: KvItem{Key: "key3", Value: "value3"}}},
+		acts2)
+}
+
+func TestKvManagerWatchWait(t *testing.T) {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+
+	// setup few items
+	mgr.Set("ns1", "key1", "value1")
+	mgr.Set("ns1", "key2", "value2")
+	newver, items := mgr.List("ns1")
+	assert.Equal(t, 2, len(items))
+
+	var allacts []KvAction
+	go func() {
+		oldver := newver
+		for {
+			ver, acts, err := mgr.Watch("ns1", oldver)
+			assert.Nil(t, err)
+			if err == nil {
+				assert.Condition(t, lesser(oldver, ver))
+				allacts = append(allacts, acts...)
+				oldver = ver
+			}
+		}
+	}()
+	tu.WaitFor(t, "Waiting for pending watches", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(mgr.pending["ns1"]) > 0, nil })
+
+	// do some updates after watch
+	mgr.Delete("ns1", "key1")
+	mgr.Set("ns1", "key3", "value3_1")
+	mgr.Set("ns1", "key2", "value2_1")
+
+	tu.WaitFor(t, "Waiting for watch results", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(allacts) == 3, nil })
+
+	assert.ElementsMatch(t,
+		[]KvAction{
+			{Action: OP_DELETE, Item: KvItem{Key: "key1", Value: "value1"}},
+			{Action: OP_SET, Item: KvItem{Key: "key3", Value: "value3_1"}},
+			{Action: OP_SET, Item: KvItem{Key: "key2", Value: "value2_1"}}},
+		allacts)
+}
+
+func TestKvManagerWatchMultiple(t *testing.T) {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+	allns := []string{"ns0", "ns1", "ns2"}
+
+	foreachns := func(f func(ns string)) {
+		for _, n := range allns {
+			f(n)
+		}
+	}
+	vers := make(map[string]uint64)
+
+	// setup few items
+	foreachns(func(ns string) {
+		mgr.Set(ns, "key1", "value1")
+		newver, _ := mgr.List(ns)
+		vers[ns] = newver
+		mgr.Set(ns, "key2", "value2")
+	})
+
+	// watch each namespace - should return immediately
+	foreachns(func(ns string) {
+		newver, acts, err := mgr.Watch(ns, vers[ns])
+		assert.Nil(t, err)
+		assert.Condition(t, lesser(vers[ns], newver))
+		assert.Equal(t,
+			[]KvAction{
+				{Action: OP_SET, Item: KvItem{Key: "key2", Value: "value2"}}},
+			acts)
+		vers[ns] = newver
+	})
+
+	// setup multiple watches in each namespace
+	var wg sync.WaitGroup
+	foreachns(func(ns string) {
+		for w := 0; w < 5; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				acts := make([]KvAction, 0)
+				startver := vers[ns]
+				for len(acts) < 2 {
+					newver, a, err := mgr.Watch(ns, startver)
+					assert.Nil(t, err)
+					assert.Condition(t, lesser(startver, newver))
+					acts = append(acts, a...)
+					startver = newver
+				}
+				assert.ElementsMatch(t,
+					[]KvAction{
+						{Action: OP_DELETE, Item: KvItem{Key: "key1", Value: "value1"}},
+						{Action: OP_SET, Item: KvItem{Key: "key2", Value: "value2_1"}}},
+					acts)
+			}()
+		}
+	})
+	foreachns(func(ns string) {
+		tu.WaitFor(t, "Waiting for pending watches", 500*time.Millisecond,
+			func(bool) (bool, error) { return len(mgr.pending[ns]) >= 5, nil })
+	})
+	// unblock the watches
+	foreachns(func(ns string) {
+		mgr.Delete(ns, "key1")
+		mgr.Set(ns, "key2", "value2_1")
+	})
+	watchesUnblocked := false
+	go func() {
+		wg.Wait()
+		watchesUnblocked = true
+	}()
+	tu.WaitFor(t, "Waiting for watches to unblock", 500*time.Millisecond,
+		func(bool) (bool, error) { return watchesUnblocked, nil })
+}
+
+func TestKvManagerWatchCancel(t *testing.T) {
+	mgr := NewKvManager()
+	ch := make(chan struct{})
+	serveEnded := false
+	go func() {
+		mgr.ServeWatch(ch)
+		serveEnded = true
+	}()
+	tu.WaitFor(t, "Waiting for watching enabled", 500*time.Millisecond,
+		func(bool) (bool, error) { return mgr.servingWatch, nil })
+
+	var wg sync.WaitGroup
+	for n := 0; n < 2; n++ {
+		nsname := fmt.Sprintf("ns%d", n)
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			oldver := uint64(i + 1)
+			go func() {
+				defer wg.Done()
+				ver, acts, err := mgr.Watch(nsname, oldver)
+				assert.Nil(t, err)
+				assert.Equal(t, oldver, ver)
+				assert.Empty(t, acts)
+			}()
+		}
+	}
+	tu.WaitFor(t, "Waiting for pending watches", 500*time.Millisecond,
+		func(bool) (bool, error) {
+			len_ns0 := len(mgr.pending["ns0"])
+			len_ns1 := len(mgr.pending["ns1"])
+			return len_ns0 >= 5 && len_ns1 >= 5, nil
+		})
+
+	watchStopped := false
+	go func() {
+		wg.Wait()
+		watchStopped = true
+	}()
+
+	close(ch)
+	tu.WaitFor(t, "Waiting for serve watch to end", 500*time.Millisecond,
+		func(bool) (bool, error) { return serveEnded, nil })
+	assert.False(t, mgr.servingWatch)
+	assert.Empty(t, mgr.pending)
+	tu.WaitFor(t, "Waiting for watch to return", 500*time.Millisecond,
+		func(bool) (bool, error) { return watchStopped, nil })
+}
+
+func TestKvManagerWatchTooOld(t *testing.T) {
+	mgr := NewKvManager()
+	mgr.maxRetained = 2
+	initWatching(t, mgr, nil)
+
+	mgr.Set("ns1", "init", "0")
+	ver, _ := mgr.List("ns1")
+
+	for i := 0; i <= 2*mgr.maxRetained; i++ {
+		k := fmt.Sprintf("key%d", i)
+		mgr.Set("ns1", k, "value")
+		mgr.Delete("ns1", k)
+	}
+	_, _, err := mgr.Watch("ns1", ver)
+	assert.Equal(t, KvErrorVersionTooOld, err)
+
+	newver, items := mgr.List("ns1")
+	assert.Condition(t, lesser(ver, newver))
+	assert.ElementsMatch(t, []KvItem{{Key: "init", Value: "0"}}, items)
+}

--- a/pkg/keyvalueservice/namespace.go
+++ b/pkg/keyvalueservice/namespace.go
@@ -1,0 +1,177 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalueservice
+
+import (
+	"sort"
+	"sync"
+)
+
+type kvNsValue struct {
+	Value   interface{}
+	Version uint64
+}
+
+type kvChange struct {
+	Key    string
+	Value  *kvNsValue
+	Action uint
+}
+
+type kvNamespace struct {
+	Name        string
+	Store       map[string]*kvNsValue
+	ChangeLog   []*kvChange
+	LastVersion uint64
+	rwLock      sync.RWMutex
+	maxRetained int
+
+	lastExpiredChange uint64
+}
+
+func newKvNamespace(name string, maxRetained int) *kvNamespace {
+	return &kvNamespace{
+		Name:        name,
+		Store:       make(map[string]*kvNsValue),
+		ChangeLog:   make([]*kvChange, 0),
+		maxRetained: maxRetained}
+}
+
+func (n *kvNamespace) Set(key string, value interface{}) {
+	n.rwLock.Lock()
+	defer n.rwLock.Unlock()
+
+	n.LastVersion = n.LastVersion + 1
+	oldv, ok := n.Store[key]
+	oldver := uint64(0)
+	if ok {
+		oldver = oldv.Version
+	}
+	newv := &kvNsValue{Value: value, Version: n.LastVersion}
+	n.Store[key] = newv
+	n.logChange(key, newv, oldver, OP_SET)
+}
+
+func (n *kvNamespace) Get(key string) (KvItem, error) {
+	n.rwLock.RLock()
+	defer n.rwLock.RUnlock()
+
+	v, ok := n.Store[key]
+	if !ok {
+		return KvItem{}, KvErrorNotFound
+	}
+	return KvItem{Key: key, Value: v.Value}, nil
+}
+
+func (n *kvNamespace) Delete(key string) (bool, interface{}, uint64) {
+	n.rwLock.Lock()
+	defer n.rwLock.Unlock()
+
+	oldv, ok := n.Store[key]
+	if !ok {
+		return false, nil, 0
+	}
+	delete(n.Store, key)
+	oldver := oldv.Version
+	n.LastVersion = n.LastVersion + 1
+	n.logChange(key,
+		&kvNsValue{Version: n.LastVersion, Value: oldv.Value},
+		oldver, OP_DELETE)
+	return true, oldv.Value, n.LastVersion
+}
+
+func (n *kvNamespace) FindUpdatedAfter(version uint64) (uint64,
+	[]KvAction, error) {
+	n.rwLock.RLock()
+	defer n.rwLock.RUnlock()
+
+	if n.LastVersion <= version {
+		return n.LastVersion, nil, nil
+	}
+	if n.lastExpiredChange > 0 && version <= n.lastExpiredChange {
+		return 0, nil, KvErrorVersionTooOld
+	}
+	res := make([]KvAction, 0)
+	start := sort.Search(len(n.ChangeLog),
+		func(i int) bool { return n.ChangeLog[i].Value.Version > version })
+	for ; start < len(n.ChangeLog); start++ {
+		c := n.ChangeLog[start]
+		res = append(res,
+			KvAction{Action: c.Action,
+				Item: KvItem{Key: c.Key, Value: c.Value.Value}})
+	}
+	return n.LastVersion, res, nil
+}
+
+func (n *kvNamespace) GetAll() (uint64, []KvItem) {
+	n.rwLock.RLock()
+	defer n.rwLock.RUnlock()
+
+	res := make([]KvItem, 0)
+	for k, v := range n.Store {
+		res = append(res, KvItem{Key: k, Value: v.Value})
+	}
+	return n.LastVersion, res
+}
+
+// must be called with rwLock.Lock()
+func (n *kvNamespace) logChange(key string, val *kvNsValue,
+	oldver uint64, op uint) {
+
+	// check if oldver or key is in the log, if so remove that change
+	sz := len(n.ChangeLog)
+	oldi := sz
+	if oldver != 0 {
+		oldi = sort.Search(sz,
+			func(i int) bool {
+				return n.ChangeLog[i].Value.Version >= oldver
+			})
+		if oldi < sz && n.ChangeLog[oldi].Value.Version != oldver {
+			// not a match
+			oldi = sz
+		}
+	} else {
+		// check all keys in changelog since we don't know old version
+		for i := sz - 1; i >= 0; i-- {
+			if n.ChangeLog[i].Key == key {
+				oldi = i
+				break
+			}
+		}
+	}
+	if oldi < sz {
+		if oldi < sz-1 { // move elements to left one position
+			copy(n.ChangeLog[oldi:], n.ChangeLog[oldi+1:])
+		}
+		// truncate last element
+		n.ChangeLog = n.ChangeLog[0 : sz-1]
+	}
+
+	// purge older half of change log if it has become too long
+	if len(n.ChangeLog) >= 2*n.maxRetained {
+		n.lastExpiredChange = n.ChangeLog[n.maxRetained-1].Value.Version
+		n.ChangeLog = n.ChangeLog[n.maxRetained:]
+	}
+	n.ChangeLog = append(n.ChangeLog,
+		&kvChange{Key: key, Value: val, Action: op})
+	/*
+		fmt.Printf("LastVersion: %v, ChangeLog: ", n.LastVersion)
+		for i := 0; i < len(n.ChangeLog); i++ {
+			fmt.Printf("%v:%v(%d) ", n.ChangeLog[i].Key,
+				n.ChangeLog[i].Value.Version, n.ChangeLog[i].Action)
+		}
+		fmt.Printf("\n")
+	*/
+}

--- a/pkg/keyvalueservice/rpc.go
+++ b/pkg/keyvalueservice/rpc.go
@@ -1,0 +1,299 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalueservice
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/rpc"
+	"sync"
+)
+
+type RpcListArgs struct {
+	Namespace string
+}
+
+type RpcListReply struct {
+	Items   []KvItem
+	Version uint64
+}
+
+type RpcWatchArgs struct {
+	Namespace string
+	Version   uint64
+}
+
+type RpcWatchReply struct {
+	Actions []KvAction
+	Version uint64
+}
+
+type KvService struct {
+	manager      *KvManager
+	abortWatchCh chan struct{}
+	abortOnce    sync.Once
+}
+
+func NewKvService(mgr *KvManager) *KvService {
+	return &KvService{manager: mgr, abortWatchCh: make(chan struct{})}
+}
+
+func (s *KvService) List(args *RpcListArgs, reply *RpcListReply) error {
+	last, items := s.manager.List(args.Namespace)
+	reply.Version = last
+	reply.Items = items
+	return nil
+}
+
+func (s *KvService) Watch(args *RpcWatchArgs, reply *RpcWatchReply) error {
+	ch, err := s.manager.watchAsync(args.Namespace, args.Version)
+	if err != nil {
+		return err
+	}
+	select {
+	case res, ok := <-ch:
+		if ok {
+			reply.Version = res.Version
+			reply.Actions = res.Actions
+			return res.Error
+		}
+	case <-s.abortWatchCh:
+	}
+	// watch aborted
+	reply.Version = args.Version
+	return nil
+}
+
+func (s *KvService) abortWatch() {
+	s.abortOnce.Do(func() { close(s.abortWatchCh) })
+}
+
+func NewKvRpcServer(mgr *KvManager) (*rpc.Server, *KvService, error) {
+	svc := NewKvService(mgr)
+	rpcServer := rpc.NewServer()
+	err := rpcServer.Register(svc)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rpcServer, svc, nil
+}
+
+type MultiplexCodec struct {
+	conn net.Conn
+	dec  *json.Decoder
+	enc  *json.Encoder
+
+	writeLock sync.Locker
+
+	readCond     *sync.Cond
+	reading      bool
+	readErr      error
+	responses    []*codecMessage
+	lastResponse *codecMessage
+	requests     []*codecMessage
+	lastRequest  *codecMessage
+}
+
+func NewMultiplexCodec(c net.Conn) *MultiplexCodec {
+	m := &MultiplexCodec{conn: c,
+		dec:       json.NewDecoder(c),
+		enc:       json.NewEncoder(c),
+		readCond:  sync.NewCond(new(sync.Mutex)),
+		writeLock: new(sync.Mutex),
+		reading:   false}
+
+	// TODO use bounded queues
+	m.responses = make([]*codecMessage, 0)
+	m.requests = make([]*codecMessage, 0)
+	return m
+}
+
+type codecMessageClientRequest struct {
+	IsRequest bool        `json:"req"`
+	Id        uint64      `json:"id"`
+	Method    string      `json:"method"`
+	Params    interface{} `json:"params"`
+}
+
+type codecMessageServerResponse struct {
+	IsRequest bool        `json:"req"`
+	Id        uint64      `json:"id"`
+	Method    string      `json:"method"`
+	Result    interface{} `json:"result"`
+	Error     interface{} `json:"error"`
+}
+
+type codecMessage struct {
+	IsRequest bool             `json:"req"`
+	Id        uint64           `json:"id"`
+	Method    string           `json:"method"`
+	Params    *json.RawMessage `json:"params"`
+	Result    *json.RawMessage `json:"result"`
+	Error     interface{}      `json:"error"`
+}
+
+// Client codec methods
+func (c *MultiplexCodec) WriteRequest(req *rpc.Request, b interface{}) error {
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+	m := codecMessageClientRequest{
+		IsRequest: true, Id: req.Seq, Method: req.ServiceMethod, Params: b}
+	err := c.enc.Encode(m)
+	return err
+}
+
+func (c *MultiplexCodec) ReadResponseHeader(resp *rpc.Response) (err error) {
+	var msg *codecMessage
+	// log.Println("Waiting to read RESPONSE header")
+	if msg, err = c.read(false); err == nil {
+		resp.ServiceMethod = msg.Method
+		resp.Seq = msg.Id
+		if msg.Error != nil || msg.Result == nil {
+			e, ok := msg.Error.(string)
+			if !ok {
+				err = fmt.Errorf("Invalid error %v", msg.Error)
+				return
+			}
+			if e == "" {
+				e = "No error specified"
+			}
+			resp.Error = e
+		}
+		c.lastResponse = msg
+	}
+	return
+}
+
+func (c *MultiplexCodec) ReadResponseBody(body interface{}) error {
+	if body == nil {
+		return nil
+	}
+	return json.Unmarshal(*c.lastResponse.Result, body)
+}
+
+// Server codec methods
+func (c *MultiplexCodec) ReadRequestHeader(req *rpc.Request) (err error) {
+	var msg *codecMessage
+	// log.Println("Waiting to read REQUEST header")
+	if msg, err = c.read(true); err == nil {
+		req.ServiceMethod = msg.Method
+		req.Seq = msg.Id
+		c.lastRequest = msg
+	}
+	return
+}
+
+func (c *MultiplexCodec) ReadRequestBody(body interface{}) error {
+	if body == nil {
+		return nil
+	}
+	return json.Unmarshal(*c.lastRequest.Params, body)
+}
+
+func (c *MultiplexCodec) WriteResponse(resp *rpc.Response,
+	body interface{}) error {
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+	m := codecMessageServerResponse{
+		IsRequest: false, Id: resp.Seq, Method: resp.ServiceMethod}
+	if resp.Error != "" {
+		m.Error = resp.Error
+	} else {
+		m.Result = body
+	}
+	err := c.enc.Encode(m)
+	return err
+}
+
+// Common codec methods
+func (c *MultiplexCodec) Close() error {
+	return c.conn.Close()
+}
+
+// Other methods
+func (c *MultiplexCodec) Conn() net.Conn {
+	return c.conn
+}
+
+func (c *MultiplexCodec) read(req bool) (msg *codecMessage, readErr error) {
+	c.readCond.L.Lock()
+	defer c.readCond.L.Unlock()
+	found := false
+	for !found && readErr == nil {
+		if req && len(c.requests) > 0 {
+			found = true
+			msg, c.requests = c.requests[0], c.requests[1:]
+			// log.Println("Found rpc REQUEST ", *msg)
+		} else if !req && len(c.responses) > 0 {
+			found = true
+			msg, c.responses = c.responses[0], c.responses[1:]
+			// log.Println("Found rpc RESPONSE ", *msg)
+		} else {
+			if c.reading {
+				// we need to wait till concurrent read finishes
+				c.readCond.Wait()
+				readErr = c.readErr
+			} else {
+				c.reading = true
+				c.readErr = nil
+				c.readCond.L.Unlock()
+
+				// Now read from conn without holding lock
+				var newmsg codecMessage
+				readErr = c.dec.Decode(&newmsg)
+
+				c.readCond.L.Lock()
+				if readErr == nil {
+					// populate c.requests or c.responses
+					if newmsg.IsRequest {
+						c.requests = append(c.requests, &newmsg)
+					} else {
+						c.responses = append(c.responses, &newmsg)
+					}
+				}
+				c.reading = false
+				c.readErr = readErr
+				c.readCond.Signal()
+			}
+		}
+	}
+	return
+}
+
+func MapToStruct(in map[string]interface{}, out interface{}) error {
+	// TODO use reflect to avoid encode-map-to-JSON then decode-JSON-to-struct
+	if enc, err := json.Marshal(in); err != nil {
+		return err
+	} else {
+		return json.Unmarshal(enc, out)
+	}
+}
+
+// This method is provided for help with unit-testing
+func StructToMap(in interface{}) (out map[string]interface{}) {
+	// TODO use reflect to avoid encode-map-to-JSON then decode-JSON-to-struct
+	out = nil
+	if enc, err := json.Marshal(in); err == nil {
+		out = make(map[string]interface{})
+		err1 := json.Unmarshal(enc, &out)
+		if err1 != nil {
+			panic(err1)
+		}
+	} else {
+		panic(err)
+	}
+	return
+}

--- a/pkg/keyvalueservice/rpc_test.go
+++ b/pkg/keyvalueservice/rpc_test.go
@@ -1,0 +1,501 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalueservice
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/rpc"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func setup(t *testing.T, mgr *KvManager) (net.Conn, net.Conn) {
+	server, _, err := NewKvRpcServer(mgr)
+	assert.Nil(t, err)
+	serverConn, clientConn := net.Pipe()
+	go server.ServeConn(serverConn)
+	return serverConn, clientConn
+}
+
+func TestKvServiceList(t *testing.T) {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+
+	serverConn, clientConn := setup(t, mgr)
+	client := rpc.NewClient(clientConn)
+	reply := RpcListReply{}
+	err := client.Call("KvService.List",
+		&RpcListArgs{Namespace: "ns1"},
+		&reply)
+	assert.Nil(t, err)
+	assert.Empty(t, reply.Items)
+	assert.Equal(t, uint64(0), reply.Version)
+
+	mgr.Set("ns1", "key1", "value1")
+	mgr.Set("ns1", "key2", "value2")
+
+	err = client.Call("KvService.List",
+		&RpcListArgs{Namespace: "ns1"},
+		&reply)
+	assert.Nil(t, err)
+	assert.ElementsMatch(t,
+		[]KvItem{{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"}},
+		reply.Items)
+	assert.Condition(t, lesser(0, reply.Version))
+
+	serverConn.Close()
+	clientConn.Close()
+}
+
+func callUnblocked(c *rpc.Call) bool {
+	select {
+	case <-c.Done:
+		return true
+	default:
+		return false
+	}
+}
+
+func TestKvServiceWatch(t *testing.T) {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+	mgr.Set("ns1", "key1", "value1")
+
+	serverConn, clientConn := setup(t, mgr)
+	client := rpc.NewClient(clientConn)
+
+	list_reply := RpcListReply{}
+	err := client.Call("KvService.List",
+		&RpcListArgs{Namespace: "ns1"},
+		&list_reply)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(list_reply.Items))
+
+	mgr.Set("ns1", "key2", "value2")
+	mgr.Delete("ns1", "key1")
+
+	// watch returns immediately with results
+	watch_reply := RpcWatchReply{}
+	err = client.Call("KvService.Watch",
+		&RpcWatchArgs{Namespace: "ns1", Version: list_reply.Version},
+		&watch_reply)
+	assert.Nil(t, err)
+	assert.ElementsMatch(t,
+		[]KvAction{
+			{Action: OP_SET, Item: KvItem{Key: "key2", Value: "value2"}},
+			{Action: OP_DELETE, Item: KvItem{Key: "key1", Value: "value1"}}},
+		watch_reply.Actions)
+	assert.Condition(t, lesser(list_reply.Version, watch_reply.Version))
+
+	// asynchronous watch
+	watch_reply1 := RpcWatchReply{}
+	call := client.Go("KvService.Watch",
+		&RpcWatchArgs{Namespace: "ns1", Version: watch_reply.Version},
+		&watch_reply1, nil)
+	tu.WaitFor(t, "Waiting for pending watches", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(mgr.pending["ns1"]) > 0, nil })
+	mgr.Set("ns1", "key3", "value3")
+
+	tu.WaitFor(t, "Waiting for async watch reply", 500*time.Millisecond,
+		func(bool) (bool, error) { return callUnblocked(call), nil })
+	assert.Nil(t, call.Error)
+	assert.ElementsMatch(t,
+		[]KvAction{
+			{Action: OP_SET, Item: KvItem{Key: "key3", Value: "value3"}}},
+		watch_reply1.Actions)
+	assert.Condition(t, lesser(watch_reply.Version, watch_reply1.Version))
+
+	serverConn.Close()
+	clientConn.Close()
+}
+
+func TestKvServiceAbortWatch(t *testing.T) {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+
+	server, svc, err := NewKvRpcServer(mgr)
+	assert.Nil(t, err)
+	serverConn, clientConn := net.Pipe()
+	client := rpc.NewClient(clientConn)
+	go server.ServeConn(serverConn)
+
+	watch_reply := RpcWatchReply{}
+	call := client.Go("KvService.Watch",
+		&RpcWatchArgs{Namespace: "ns1", Version: uint64(0)},
+		&watch_reply, nil)
+	tu.WaitFor(t, "Waiting for pending watches", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(mgr.pending["ns1"]) > 0, nil })
+
+	svc.abortWatch()
+
+	tu.WaitFor(t, "Waiting for watch abort", 500*time.Millisecond,
+		func(bool) (bool, error) { return callUnblocked(call), nil })
+	assert.Nil(t, call.Error)
+	assert.Equal(t, uint64(0), watch_reply.Version)
+	assert.Empty(t, watch_reply.Actions)
+
+	serverConn.Close()
+	clientConn.Close()
+}
+
+func TestKvServiceListBadConnection(t *testing.T) {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+
+	serverConn, clientConn := setup(t, mgr)
+	client := rpc.NewClient(clientConn)
+
+	serverConn.Close()
+	list_reply := RpcListReply{}
+	err := client.Call("KvService.List",
+		&RpcListArgs{Namespace: "ns1"},
+		&list_reply)
+	assert.NotNil(t, err)
+	assert.NotContains(t, "KvError:", err)
+}
+
+func TestKvServiceWatchBadConnection(t *testing.T) {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+
+	serverConn, clientConn := setup(t, mgr)
+	client := rpc.NewClient(clientConn)
+
+	watch_reply := RpcWatchReply{}
+	call := client.Go("KvService.Watch",
+		&RpcWatchArgs{Namespace: "ns1", Version: uint64(0)},
+		&watch_reply, nil)
+	tu.WaitFor(t, "Waiting for pending watches", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(mgr.pending["ns1"]) > 0, nil })
+
+	serverConn.Close()
+	tu.WaitFor(t, "Waiting for async watch reply", 500*time.Millisecond,
+		func(bool) (bool, error) { return callUnblocked(call), nil })
+
+	assert.NotNil(t, call.Error)
+	assert.NotContains(t, "KvError:", call.Error)
+}
+
+func TestMultiplexCodecInterleavedRead(t *testing.T) {
+	c1, c2 := net.Pipe()
+	c := NewMultiplexCodec(c2)
+	enc := json.NewEncoder(c1)
+
+	type bodyType struct {
+		F1, F2 uint64
+	}
+	type requestBody struct {
+		rpc.Request
+		body bodyType
+	}
+	type responseBody struct {
+		rpc.Response
+		body bodyType
+	}
+	var c1_messages []codecMessage
+	var expected_requests []requestBody
+	var expected_responses []responseBody
+	for i := 1; i <= 3; i++ {
+		for j := 0; j < i; j++ {
+			id := uint64(i*10 + j)
+			param := json.RawMessage(
+				fmt.Sprintf(`{"F1": %d, "F2": %d}`, id, -id))
+			c1_messages = append(c1_messages,
+				codecMessage{IsRequest: true,
+					Id: id, Method: "L", Params: &param})
+			expected_requests = append(expected_requests,
+				requestBody{
+					Request: rpc.Request{Seq: id, ServiceMethod: "L"},
+					body:    bodyType{F1: id, F2: -id}})
+		}
+		for j := 0; j < i; j++ {
+			id := uint64(i*10 + j)
+			res := json.RawMessage(
+				fmt.Sprintf(`{"F1": %d, "F2": %d}`, -id, id))
+			c1_messages = append(c1_messages,
+				codecMessage{IsRequest: false,
+					Id: id, Method: "W", Result: &res})
+			expected_responses = append(expected_responses,
+				responseBody{
+					Response: rpc.Response{Seq: id, ServiceMethod: "W"},
+					body:     bodyType{F1: -id, F2: id}})
+		}
+	}
+
+	var c2_requests []requestBody
+	var c2_responses []responseBody
+	go func() {
+		for {
+			req := requestBody{}
+			err := c.ReadRequestHeader(&req.Request)
+			assert.Nil(t, err)
+			err = c.ReadRequestBody(&req.body)
+			assert.Nil(t, err)
+			c2_requests = append(c2_requests, req)
+		}
+	}()
+
+	go func() {
+		for {
+			resp := responseBody{}
+			err := c.ReadResponseHeader(&resp.Response)
+			assert.Nil(t, err)
+			err = c.ReadResponseBody(&resp.body)
+			assert.Nil(t, err)
+			c2_responses = append(c2_responses, resp)
+		}
+	}()
+	for _, m := range c1_messages {
+		err := enc.Encode(m)
+		assert.Nil(t, err)
+	}
+	tu.WaitFor(t, "Waiting for all request", 500*time.Millisecond,
+		func(bool) (bool, error) {
+			return len(c2_requests) == len(expected_requests), nil
+		})
+	assert.ElementsMatch(t, expected_requests, c2_requests)
+	tu.WaitFor(t, "Waiting for all responses", 500*time.Millisecond,
+		func(bool) (bool, error) {
+			return len(c2_responses) == len(expected_responses), nil
+		})
+	assert.ElementsMatch(t, expected_responses, c2_responses)
+}
+
+func TestMultiplexCodecConcurrentWrite(t *testing.T) {
+	c1, c2 := net.Pipe()
+	c := NewMultiplexCodec(c1)
+	dec := json.NewDecoder(c2)
+
+	expected_reqIds := make(map[uint64]struct{})
+	expected_respIds := make(map[uint64]struct{})
+	count := 10
+	go func() {
+		for id := 1; id <= count; id++ {
+			req := &rpc.Request{Seq: uint64(id), ServiceMethod: "L"}
+			expected_reqIds[uint64(id)] = struct{}{}
+			err := c.WriteRequest(req, "abc")
+			assert.Nil(t, err)
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+	go func() {
+		for id := 1; id <= count; id++ {
+			resp := &rpc.Response{Seq: uint64(id), ServiceMethod: "W"}
+			expected_respIds[uint64(id)] = struct{}{}
+			err := c.WriteResponse(resp, "xyz")
+			assert.Nil(t, err)
+			time.Sleep(5 * time.Millisecond)
+		}
+	}()
+	reqIds := make(map[uint64]struct{})
+	respIds := make(map[uint64]struct{})
+	for len(reqIds) < count || len(respIds) < count {
+		var m codecMessage
+		err := dec.Decode(&m)
+		assert.Nil(t, err)
+		if m.IsRequest {
+			reqIds[m.Id] = struct{}{}
+		} else {
+			respIds[m.Id] = struct{}{}
+		}
+	}
+	assert.Equal(t, expected_reqIds, reqIds)
+	assert.Equal(t, expected_respIds, respIds)
+}
+
+func TestMultiplexCodecReadConnError(t *testing.T) {
+	c1, c2 := net.Pipe()
+	c := NewMultiplexCodec(c2)
+	enc := json.NewEncoder(c1)
+
+	var reqErr, respErr error
+	reqRead, respRead := false, false
+	go func() {
+		for reqErr == nil {
+			reqErr = c.ReadRequestHeader(&rpc.Request{})
+			if reqErr == nil {
+				reqRead = true
+			}
+		}
+	}()
+	go func() {
+		for respErr == nil {
+			respErr = c.ReadResponseHeader(&rpc.Response{})
+			if respErr == nil {
+				respRead = true
+			}
+		}
+	}()
+	// send sentinel messages
+	param := json.RawMessage(`{"A": 1}`)
+	result := json.RawMessage(`{"Z": 1}`)
+	err := enc.Encode(&codecMessage{IsRequest: true, Id: uint64(1),
+		Method: "L", Params: &param})
+	assert.Nil(t, err)
+	err = enc.Encode(&codecMessage{IsRequest: false, Id: uint64(1),
+		Method: "W", Result: &result})
+	assert.Nil(t, err)
+	tu.WaitFor(t, "Waiting for sentinel reads",
+		500*time.Millisecond,
+		func(bool) (bool, error) { return reqRead && respRead, nil })
+	c1.Close()
+	tu.WaitFor(t, "Waiting for request read error",
+		500*time.Millisecond,
+		func(bool) (bool, error) { return reqErr != nil, nil })
+	tu.WaitFor(t, "Waiting for response read error",
+		500*time.Millisecond,
+		func(bool) (bool, error) { return respErr != nil, nil })
+	assert.Equal(t, io.EOF, reqErr)
+	assert.Equal(t, io.EOF, respErr)
+}
+
+func TestMultiplexCodecWriteConnError(t *testing.T) {
+	c1, c2 := net.Pipe()
+	c := NewMultiplexCodec(c1)
+
+	c2.Close()
+	err := c.WriteRequest(
+		&rpc.Request{Seq: uint64(1), ServiceMethod: "L"}, "abc")
+	assert.Equal(t, io.ErrClosedPipe, err)
+
+	err = c.WriteResponse(
+		&rpc.Response{Seq: uint64(1), ServiceMethod: "W"}, "abc")
+	assert.Equal(t, io.ErrClosedPipe, err)
+}
+
+func TestMultiplexCodecClose(t *testing.T) {
+	c1, _ := net.Pipe()
+	c := NewMultiplexCodec(c1)
+	assert.Equal(t, c1, c.Conn())
+	c.Close()
+	assert.Equal(t, io.ErrClosedPipe, c.WriteRequest(&rpc.Request{}, ""))
+}
+
+func TestMultiplexCodecReadDrain(t *testing.T) {
+	c1, _ := net.Pipe()
+	c := NewMultiplexCodec(c1)
+	assert.Nil(t, c.ReadRequestBody(nil))
+	assert.Nil(t, c.ReadResponseBody(nil))
+}
+
+func TestMultiplexCodecBadResponseError(t *testing.T) {
+	c1, c2 := net.Pipe()
+	c := NewMultiplexCodec(c2)
+	enc := json.NewEncoder(c1)
+	count := 0
+	go func() {
+		for {
+			resp := rpc.Response{}
+			err := c.ReadResponseHeader(&resp)
+			if err == nil {
+				assert.Contains(t, resp.Error, "No error specified")
+			} else {
+				assert.Contains(t, err.Error(), "Invalid error")
+			}
+			count++
+		}
+	}()
+	err := enc.Encode(&codecMessage{IsRequest: false, Id: uint64(1),
+		Method: "W", Error: 42})
+	assert.Nil(t, err)
+	err = enc.Encode(&codecMessage{IsRequest: false, Id: uint64(1),
+		Method: "W", Error: ""})
+	assert.Nil(t, err)
+	tu.WaitFor(t, "Waiting for all errors",
+		500*time.Millisecond,
+		func(bool) (bool, error) { return count >= 2, nil })
+}
+
+func TestMultiplexCodecServerClient(t *testing.T) {
+	type numPair struct {
+		First, Second int
+	}
+	conn1, conn2 := net.Pipe()
+	c1 := NewMultiplexCodec(conn1)
+	c2 := NewMultiplexCodec(conn2)
+	count := 10
+	wg := sync.WaitGroup{}
+	serverFunc := func(c rpc.ServerCodec, other string) {
+		for i := 1; i <= count; i++ {
+			req, pair, resp := rpc.Request{}, numPair{}, rpc.Response{}
+			assert.Nil(t, c.ReadRequestHeader(&req))
+			assert.Contains(t, req.ServiceMethod, other+"-add-sub")
+			assert.Nil(t, c.ReadRequestBody(&pair))
+			time.Sleep(2 * time.Millisecond)
+			pair = numPair{First: pair.First + pair.Second,
+				Second: pair.First - pair.Second}
+			resp.Seq = req.Seq
+			resp.ServiceMethod = req.ServiceMethod
+			assert.Nil(t, c.WriteResponse(&resp, &pair))
+		}
+		wg.Done()
+	}
+	clientFunc := func(c rpc.ClientCodec, name string) {
+		for i := 1; i <= count; i++ {
+			req := rpc.Request{Seq: uint64(1),
+				ServiceMethod: fmt.Sprintf("%s-add-sub-%d", name, i)}
+			pair, resp := numPair{3 * i, 2 * i}, rpc.Response{}
+			assert.Nil(t, c.WriteRequest(&req, &pair))
+
+			assert.Nil(t, c.ReadResponseHeader(&resp))
+			assert.Equal(t, req.Seq, resp.Seq)
+			assert.Equal(t, resp.ServiceMethod, resp.ServiceMethod)
+			assert.Nil(t, c.ReadResponseBody(&pair))
+			assert.Equal(t, numPair{5 * i, i}, pair)
+			time.Sleep(3 * time.Millisecond)
+		}
+		wg.Done()
+	}
+	wg.Add(4)
+	go serverFunc(c1, "peer2")
+	go clientFunc(c1, "peer1")
+	go serverFunc(c2, "peer1")
+	go clientFunc(c2, "peer2")
+	wg.Wait()
+}
+
+func TestMapToStruct(t *testing.T) {
+	type A struct {
+		F1 int
+		F2 []string
+	}
+	m := make(map[string]interface{})
+	m["F1"] = 10
+	m["F2"] = []string{"1", "2", "3"}
+	a := &A{}
+	assert.Nil(t, MapToStruct(m, a))
+	assert.Equal(t, A{F1: 10, F2: []string{"1", "2", "3"}}, *a)
+}
+
+func TestStructToMap(t *testing.T) {
+	type A struct {
+		F1 int
+		F2 []string
+	}
+	m := make(map[string]interface{})
+	m["F1"] = float64(10)
+	m["F2"] = []interface{}{"1", "2", "3"}
+	a := &A{F1: 10, F2: []string{"1", "2", "3"}}
+	assert.Equal(t, m, StructToMap(a))
+}

--- a/pkg/keyvalueservice/server_client.go
+++ b/pkg/keyvalueservice/server_client.go
@@ -1,0 +1,201 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalueservice
+
+import (
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type ListenFunc func() (net.Listener, error)
+type ConnectFunc func() (net.Conn, error)
+
+type KvServer struct {
+	listenFunc ListenFunc
+	manager    *KvManager
+	watcher    *KvWatcher
+	log        *logrus.Entry
+	errDelay   time.Duration
+}
+
+func NewKvServer(lf ListenFunc, m *KvManager, w *KvWatcher,
+	l *logrus.Logger) *KvServer {
+	return &KvServer{
+		listenFunc: lf,
+		manager:    m,
+		watcher:    w,
+		log:        l.WithField("ctx", "KvServer"),
+		errDelay:   time.Duration(10 * time.Second)}
+}
+
+func (s *KvServer) Watcher() *KvWatcher {
+	return s.watcher
+}
+
+func (s *KvServer) Run(stopCh <-chan struct{}) {
+	accepted := sync.Map{}
+	cancelled := false
+	var savedListener atomic.Value
+	go func() {
+		<-stopCh
+		cancelled = true
+		l := savedListener.Load()
+		if l != nil {
+			l.(net.Listener).Close()
+		}
+	}()
+	for !cancelled && s.listenFunc != nil {
+		s.log.Debug("Trying to listen for connections")
+		listener, err := s.listenFunc()
+		if err != nil {
+			s.log.Error("Unable to listen for connections: ", err)
+		} else {
+			savedListener.Store(listener)
+			for !cancelled {
+				s.log.Debug("Waiting to accept")
+				conn, err := listener.Accept()
+				if err != nil {
+					s.log.Error("Failed to accept connection: ", err)
+					break
+				}
+				if conn == nil {
+					continue
+				}
+				connLog := s.log.WithField("remote",
+					conn.RemoteAddr().String())
+				connLog.Debug("Accepted new connection")
+
+				rpcServer, rpcService, err := NewKvRpcServer(s.manager)
+				if err != nil {
+					connLog.Error("Unable to create RPC server: ", err)
+					conn.Close()
+					cancelled = true // no point continuing to listen
+					continue
+				}
+
+				cdc := NewMultiplexCodec(
+					&closer{Conn: conn, svc: rpcService, log: connLog})
+				accepted.Store(cdc, struct{}{})
+				go func() {
+					if s.watcher != nil {
+						connLog.Debug("Watching connection")
+						s.watcher.ServeConn(cdc)
+					}
+					connLog.Debug("Serving connection")
+					rpcServer.ServeCodec(cdc)
+					connLog.Debug("Finished serving connection")
+					cdc.Close()
+					accepted.Delete(cdc)
+				}()
+			}
+			listener.Close()
+		}
+		if !cancelled && err != nil {
+			// TOOD Use interruptible delay
+			time.Sleep(s.errDelay)
+		}
+	}
+	accepted.Range(func(key, value interface{}) bool {
+		cdc := key.(*MultiplexCodec)
+		cdc.Close()
+		return true
+	})
+}
+
+type KvClient struct {
+	connectFunc ConnectFunc
+	manager     *KvManager
+	watcher     *KvWatcher
+	log         *logrus.Entry
+	errDelay    time.Duration
+}
+
+func NewKvClient(cf ConnectFunc, m *KvManager, w *KvWatcher,
+	l *logrus.Logger) *KvClient {
+	return &KvClient{
+		connectFunc: cf,
+		manager:     m,
+		watcher:     w,
+		log:         l.WithField("ctx", "KvClient"),
+		errDelay:    time.Duration(10 * time.Second)}
+}
+
+func (c *KvClient) Watcher() *KvWatcher {
+	return c.watcher
+}
+
+func (c *KvClient) Run(stopCh <-chan struct{}) {
+	cancelled := false
+	var savedConn atomic.Value
+	go func() {
+		<-stopCh
+		cancelled = true
+		c := savedConn.Load()
+		if c != nil {
+			c.(*MultiplexCodec).Close()
+		}
+	}()
+	iter := 0
+	for !cancelled && c.connectFunc != nil {
+		iterLog := c.log.WithField("iter", iter)
+		iter++
+		iterLog.Debug("Connecting to server")
+		conn, err := c.connectFunc()
+		if err != nil {
+			iterLog.Error("Failed to connect to server: ", err)
+			// TOOD Use interruptible delay
+			time.Sleep(c.errDelay)
+		} else {
+			connLog := iterLog.WithField("remote", conn.RemoteAddr().String())
+			connLog.Debug("Connection successful")
+
+			rpcServer, rpcService, err := NewKvRpcServer(c.manager)
+			if err != nil {
+				connLog.Error("Unable to create RPC server: ", err)
+				conn.Close()
+				return
+			}
+
+			cdc := NewMultiplexCodec(
+				&closer{Conn: conn, svc: rpcService, log: connLog})
+			savedConn.Store(cdc)
+			if c.watcher != nil {
+				connLog.Debug("Watching connection")
+				c.watcher.ServeConn(cdc)
+			}
+			connLog.Debug("Serving connection")
+			rpcServer.ServeCodec(cdc)
+			connLog.Debug("Finished serving connection")
+			cdc.Close()
+		}
+	}
+}
+
+type closer struct {
+	net.Conn
+	svc *KvService
+	log *logrus.Entry
+}
+
+func (c *closer) Close() error {
+	err := c.Conn.Close()
+	if err == nil && c.svc != nil {
+		c.log.Info("Aborting watches on close")
+		c.svc.abortWatch()
+	}
+	return err
+}

--- a/pkg/keyvalueservice/server_client_test.go
+++ b/pkg/keyvalueservice/server_client_test.go
@@ -1,0 +1,306 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalueservice
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"net/rpc"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func newLogger() (log *logrus.Logger) {
+	log = logrus.New()
+	log.Level = logrus.DebugLevel
+	return
+}
+
+type MockListener struct {
+	conn    net.Conn
+	conns   chan net.Conn
+	stopped bool
+}
+
+func NewMockListener(c net.Conn) *MockListener {
+	l := &MockListener{conn: c, conns: make(chan net.Conn, 1)}
+	if c != nil {
+		l.conns <- c
+	}
+	return l
+}
+
+func (l *MockListener) Addr() net.Addr {
+	return l.conn.LocalAddr()
+}
+
+func (l *MockListener) Accept() (net.Conn, error) {
+	c := <-l.conns
+	l.conn = c
+	return c, nil
+}
+
+func (l *MockListener) Close() error {
+	if !l.stopped {
+		close(l.conns)
+		l.stopped = true
+	}
+	return nil
+}
+
+type WatcherWrapper struct {
+	allItems   []KvItem
+	allActions []KvAction
+	W          *KvWatcher
+}
+
+func NewWatchWrapper(ns string) *WatcherWrapper {
+	r := &WatcherWrapper{allItems: make([]KvItem, 0),
+		allActions: make([]KvAction, 0)}
+	allfunc := func(n string, items []KvItem) {
+		if n == ns {
+			r.allItems = items
+		}
+	}
+	updatefunc := func(n string, acts []KvAction) {
+		if n == ns {
+			r.allActions = append(r.allActions, acts...)
+		}
+	}
+	r.W = NewKvWatcher([]string{ns}, newLogger(), allfunc, updatefunc)
+	return r
+}
+
+func NewTestKvManager(t *testing.T, ns_prefix string) *KvManager {
+	mgr := NewKvManager()
+	initWatching(t, mgr, nil)
+	ns1 := ns_prefix + "ns1"
+	ns2 := ns_prefix + "ns2"
+	mgr.Set(ns1, "key1", "value1")
+	mgr.Set(ns1, "key2", "value2")
+	mgr.Set(ns2, "key2_1", "value1")
+	mgr.Set(ns2, "key2_2", "value2")
+	return mgr
+}
+
+func doTestServerClientRun(t *testing.T,
+	setupLocal func(c_local net.Conn) *WatcherWrapper) {
+	c_local, c_remote := net.Pipe()
+	cdc_remote := NewMultiplexCodec(c_remote)
+
+	remote_mgr := NewTestKvManager(t, "remote-")
+	remote_rpc_server, _, _ := NewKvRpcServer(remote_mgr)
+	remote_rpc_client := rpc.NewClientWithCodec(cdc_remote)
+	go remote_rpc_server.ServeCodec(cdc_remote)
+
+	local_wr := setupLocal(c_local)
+	// Verify we can receive remote items
+	tu.WaitFor(t, "Waiting for all remote items", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(local_wr.allItems) == 2, nil })
+	assert.ElementsMatch(t,
+		[]KvItem{{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"}},
+		local_wr.allItems)
+
+	// Verify we can serve local items
+	reply := RpcListReply{}
+	err := remote_rpc_client.Call("KvService.List",
+		&RpcListArgs{Namespace: "local-ns1"},
+		&reply)
+	assert.Nil(t, err)
+	assert.ElementsMatch(t,
+		[]KvItem{{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"}},
+		reply.Items)
+
+	// Install a watch from remote side before closing connection
+	replyWatch := RpcWatchReply{}
+	remote_rpc_client.Go("KvService.Watch",
+		&RpcWatchArgs{Namespace: "local-ns1", Version: reply.Version},
+		&replyWatch, nil)
+
+	// Close remote side of connection -> verify local is also closed
+	c_remote.Close()
+	err = nil
+	tu.WaitFor(t, "Waiting for local conn close", 500*time.Millisecond,
+		func(bool) (bool, error) {
+			_, err = c_local.Write([]byte("a"))
+			return err != nil, nil
+		})
+	assert.Equal(t, io.ErrClosedPipe, err)
+}
+
+func TestKvServerRun(t *testing.T) {
+	setupLocalServer := func(c_local net.Conn) *WatcherWrapper {
+		local_wr := NewWatchWrapper("remote-ns1")
+		local_mgr := NewTestKvManager(t, "local-")
+		listnr := NewMockListener(c_local)
+		kvserver := NewKvServer(
+			func() (net.Listener, error) { return listnr, nil },
+			local_mgr, local_wr.W, newLogger())
+		go kvserver.Watcher().Watch(nil)
+		go kvserver.Run(nil)
+		return local_wr
+	}
+	doTestServerClientRun(t, setupLocalServer)
+}
+
+func TestKvServerReconnectClient(t *testing.T) {
+	local_mgr := NewTestKvManager(t, "local-")
+	local_wr := NewWatchWrapper("remote-something")
+	listnr := NewMockListener(nil)
+	kvserver := NewKvServer(
+		func() (net.Listener, error) { return listnr, nil },
+		local_mgr, local_wr.W, newLogger())
+	go kvserver.Watcher().Watch(nil)
+	go kvserver.Run(nil)
+
+	expected_all_count := 2
+	for iter := 1; iter <= 5; iter++ {
+		iter_s := fmt.Sprintf("%d", iter)
+		c_local, c_remote := net.Pipe()
+
+		remote_watcher := NewWatchWrapper("local-ns1")
+		remote_mgr := NewTestKvManager(t, "remote-"+iter_s+"-")
+		kvclient := NewKvClient(
+			func() (net.Conn, error) { return c_remote, nil },
+			remote_mgr, remote_watcher.W, newLogger())
+		go kvclient.Watcher().Watch(nil)
+		listnr.conns <- c_local
+		remote_stopCh := make(chan struct{})
+		go kvclient.Run(remote_stopCh)
+
+		// remote should get all data and updated
+		tu.WaitFor(t, "Remote "+iter_s+" - Waiting for all items",
+			500*time.Millisecond,
+			func(bool) (bool, error) {
+				return len(remote_watcher.allItems) == expected_all_count, nil
+			})
+		local_mgr.Set("local-ns1", "key4-"+iter_s, "value4")
+		local_mgr.Set("local-ns1", "key5-"+iter_s, "value5")
+		tu.WaitFor(t, "Remote "+iter_s+" - Waiting for actions",
+			500*time.Millisecond,
+			func(bool) (bool, error) {
+				return len(remote_watcher.allActions) == 2, nil
+			})
+
+		// remote disconnects
+		close(remote_stopCh)
+		c_remote.Close()
+		c_local.Close()
+
+		// some intermediate changes
+		local_mgr.Set("local-ns1", "key6-"+iter_s, "value6")
+		local_mgr.Set("local-ns1", "key7-"+iter_s, "value7")
+		expected_all_count += 4
+	}
+}
+
+func TestKvClientRun(t *testing.T) {
+	setupLocalClient := func(c_local net.Conn) *WatcherWrapper {
+		local_wr := NewWatchWrapper("remote-ns1")
+		local_mgr := NewTestKvManager(t, "local-")
+		kvclient := NewKvClient(
+			func() (net.Conn, error) { return c_local, nil },
+			local_mgr, local_wr.W, newLogger())
+		go kvclient.Watcher().Watch(nil)
+		go kvclient.Run(nil)
+		return local_wr
+	}
+	doTestServerClientRun(t, setupLocalClient)
+}
+
+func TestKvServerCancel(t *testing.T) {
+	c_local, _ := net.Pipe()
+	local_mgr := NewTestKvManager(t, "local-")
+	listnr := NewMockListener(c_local)
+	kvserver := NewKvServer(
+		func() (net.Listener, error) { return listnr, nil },
+		local_mgr, nil, newLogger())
+	runEnded := false
+	stopCh := make(chan struct{})
+	go func() {
+		kvserver.Run(stopCh)
+		runEnded = true
+	}()
+	tu.WaitFor(t, "Waiting for server to accept", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(listnr.conns) == 0, nil })
+	close(stopCh)
+	tu.WaitFor(t, "Waiting for server run to end", 500*time.Millisecond,
+		func(bool) (bool, error) { return runEnded == true, nil })
+	_, err := c_local.Write([]byte("a"))
+	assert.Equal(t, io.ErrClosedPipe, err)
+}
+
+func TestKvClientCancel(t *testing.T) {
+	c_local, _ := net.Pipe()
+	local_mgr := NewTestKvManager(t, "local-")
+	connected := false
+	kvclient := NewKvClient(
+		func() (net.Conn, error) {
+			connected = true
+			return c_local, nil
+		},
+		local_mgr, nil, newLogger())
+	runEnded := false
+	stopCh := make(chan struct{})
+	go func() {
+		kvclient.Run(stopCh)
+		runEnded = true
+	}()
+	tu.WaitFor(t, "Waiting for client to connect", 500*time.Millisecond,
+		func(bool) (bool, error) { return connected, nil })
+	close(stopCh)
+	tu.WaitFor(t, "Waiting for client run to end", 500*time.Millisecond,
+		func(bool) (bool, error) { return runEnded == true, nil })
+	_, err := c_local.Write([]byte("a"))
+	assert.Equal(t, io.ErrClosedPipe, err)
+}
+
+func TestKvServerListenLoop(t *testing.T) {
+	local_mgr := NewTestKvManager(t, "local-")
+	listenCount := 0
+	kvserver := NewKvServer(
+		func() (net.Listener, error) {
+			listenCount++
+			return nil, io.EOF
+		},
+		local_mgr, nil, newLogger())
+	kvserver.errDelay = 10 * time.Millisecond
+	go kvserver.Run(nil)
+	tu.WaitFor(t, "Waiting for multiple listens", 500*time.Millisecond,
+		func(bool) (bool, error) { return listenCount > 1, nil })
+}
+
+func TestKvClientConnectLoop(t *testing.T) {
+	local_mgr := NewTestKvManager(t, "local-")
+	connectCount := 0
+	kvclient := NewKvClient(
+		func() (net.Conn, error) {
+			connectCount++
+			return nil, io.EOF
+		},
+		local_mgr, nil, newLogger())
+	kvclient.errDelay = 10 * time.Millisecond
+	go kvclient.Run(nil)
+	tu.WaitFor(t, "Waiting for multiple connects", 500*time.Millisecond,
+		func(bool) (bool, error) { return connectCount > 1, nil })
+}

--- a/pkg/keyvalueservice/watcher.go
+++ b/pkg/keyvalueservice/watcher.go
@@ -1,0 +1,215 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalueservice
+
+import (
+	"fmt"
+	"net"
+	"net/rpc"
+
+	"github.com/Sirupsen/logrus"
+)
+
+type HandleAllFunc func(string, []KvItem)
+type HandleUpdateFunc func(string, []KvAction)
+
+type clientCodecWrapper interface {
+	rpc.ClientCodec
+	Conn() net.Conn
+}
+
+type KvWatcher struct {
+	watchNamespaces []string
+	log             *logrus.Entry
+
+	allHandler    HandleAllFunc
+	updateHandler HandleUpdateFunc
+
+	connChan chan clientCodecWrapper
+	callChan chan *rpc.Call
+	conns    map[*rpc.Client]clientCodecWrapper
+}
+
+func NewKvWatcher(ns []string, l *logrus.Logger, ah HandleAllFunc,
+	uh HandleUpdateFunc) *KvWatcher {
+
+	return &KvWatcher{
+		watchNamespaces: ns,
+		log:             l.WithField("ctx", "KvWatcher"),
+		allHandler:      ah,
+		updateHandler:   uh,
+		connChan:        make(chan clientCodecWrapper),
+		callChan:        make(chan *rpc.Call, 16),
+		conns:           make(map[*rpc.Client]clientCodecWrapper)}
+}
+
+func (w *KvWatcher) AllHandler() HandleAllFunc {
+	return w.allHandler
+}
+
+func (w *KvWatcher) UpdateHandler() HandleUpdateFunc {
+	return w.updateHandler
+}
+
+func (w *KvWatcher) ServeConn(conn clientCodecWrapper) {
+	w.connChan <- conn
+}
+
+func (w *KvWatcher) Watch(stopCh <-chan struct{}) {
+	called := make(map[*rpc.Call]*rpc.Client)
+
+	for {
+		select {
+		case conn := <-w.connChan:
+			client := rpc.NewClientWithCodec(conn)
+			w.conns[client] = conn
+			log := w.connLogger(client)
+
+			for _, ns := range w.watchNamespaces {
+				if ns == "" {
+					continue
+				}
+				log.WithField("ns", ns).Debug("Initializing watch")
+				call := client.Go("KvService.List",
+					&RpcListArgs{Namespace: ns},
+					&RpcListReply{},
+					w.callChan)
+				called[call] = client
+			}
+
+		case call := <-w.callChan:
+			client, ok := called[call]
+			delete(called, call)
+			var nc *rpc.Call
+			var err error
+			if ok {
+				switch call.ServiceMethod {
+				case "KvService.List":
+					nc, err = w.handleListReply(call, client)
+				case "KvService.Watch":
+					nc, err = w.handleWatchReply(call, client)
+				default:
+					w.connLogger(client).Debug("Reply to unknown call ",
+						call.ServiceMethod)
+				}
+				if err != nil {
+					w.closeClientOnError(err, call, client)
+				} else if nc != nil {
+					newCall := client.Go(nc.ServiceMethod,
+						nc.Args, nc.Reply, w.callChan)
+					called[newCall] = client
+				}
+			}
+
+		case <-stopCh:
+			w.log.Debug("Exiting watch loop")
+			for _, client := range called {
+				client.Close()
+			}
+			return
+		}
+	}
+}
+
+func (w *KvWatcher) connLogger(client *rpc.Client) *logrus.Entry {
+	conn := w.conns[client]
+	remote := "<unknown>"
+	if conn != nil {
+		remote = conn.Conn().RemoteAddr().String()
+	}
+	return w.log.WithField("remote", remote)
+}
+
+func (w *KvWatcher) closeClientOnError(err error, call *rpc.Call,
+	client *rpc.Client) {
+
+	if err != nil {
+		w.connLogger(client).Error(
+			fmt.Sprintf("Closing connection on failure of call %s: %v",
+				call.ServiceMethod, err))
+		delete(w.conns, client)
+		client.Close()
+	}
+}
+
+func (w *KvWatcher) handleListReply(call *rpc.Call,
+	client *rpc.Client) (*rpc.Call, error) {
+
+	if call.Error != nil {
+		// all errors are fatal to the connection
+		return nil, call.Error
+	}
+	args := call.Args.(*RpcListArgs)
+	log := w.connLogger(client).WithFields(logrus.Fields{
+		"call": call.ServiceMethod,
+		"ns":   args.Namespace})
+	reply := call.Reply.(*RpcListReply)
+	log.WithFields(logrus.Fields{
+		"count":       len(reply.Items),
+		"new-version": reply.Version}).Debug("Got items")
+	if w.allHandler != nil {
+		w.allHandler(args.Namespace, reply.Items)
+	}
+
+	nc := &rpc.Call{
+		ServiceMethod: "KvService.Watch",
+		Args: &RpcWatchArgs{Namespace: args.Namespace,
+			Version: reply.Version},
+		Reply: &RpcWatchReply{}}
+	return nc, nil
+}
+
+func (w *KvWatcher) handleWatchReply(call *rpc.Call,
+	client *rpc.Client) (*rpc.Call, error) {
+
+	args := call.Args.(*RpcWatchArgs)
+	log := w.connLogger(client).WithFields(logrus.Fields{
+		"call":    call.ServiceMethod,
+		"ns":      args.Namespace,
+		"version": args.Version})
+
+	reinit := false
+	if call.Error != nil {
+		if call.Error.Error() == KvErrorVersionTooOld.Error() {
+			log.Info("Watch returned VERSION_TOO_OLD")
+			reinit = true
+		} else {
+			return nil, call.Error
+		}
+	}
+	var nc *rpc.Call
+	if reinit {
+		log.Debug("Reinitializing watch")
+		nc = &rpc.Call{
+			ServiceMethod: "KvService.List",
+			Args:          &RpcListArgs{Namespace: args.Namespace},
+			Reply:         &RpcListReply{}}
+	} else {
+		reply := call.Reply.(*RpcWatchReply)
+		log.WithFields(logrus.Fields{
+			"count":       len(reply.Actions),
+			"new-version": reply.Version}).Debug("Got actions")
+		if w.updateHandler != nil {
+			w.updateHandler(args.Namespace, reply.Actions)
+		}
+
+		nc = &rpc.Call{
+			ServiceMethod: "KvService.Watch",
+			Args: &RpcWatchArgs{Namespace: args.Namespace,
+				Version: reply.Version},
+			Reply: &RpcWatchReply{}}
+	}
+	return nc, nil
+}

--- a/pkg/keyvalueservice/watcher_test.go
+++ b/pkg/keyvalueservice/watcher_test.go
@@ -1,0 +1,188 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package keyvalueservice
+
+import (
+	"io"
+	"net"
+	"net/rpc"
+	"testing"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+func setupRemote(t *testing.T) (mgr *KvManager, clientConn net.Conn) {
+	mgr = NewKvManager()
+	initWatching(t, mgr, nil)
+	mgr.Set("ns1", "key1", "value1")
+	mgr.Set("ns1", "key2", "value2")
+	mgr.Set("ns2", "key2_1", "value1")
+	mgr.Set("ns2", "key2_2", "value2")
+	mgr.Set("ns3", "key3_1", "value1")
+	mgr.Set("ns3", "key3_2", "value2")
+
+	serverConn, clientConn := net.Pipe()
+
+	server, _, err := NewKvRpcServer(mgr)
+	assert.Nil(t, err)
+	go server.ServeCodec(NewMultiplexCodec(serverConn))
+	return
+}
+
+func TestKvWatcherOps(t *testing.T) {
+	remoteMgr, clientConn := setupRemote(t)
+
+	allItems := make(map[string][]KvItem)
+	allActions := make(map[string][]KvAction)
+	allItems["ns1"] = make([]KvItem, 0)
+	allItems["ns3"] = make([]KvItem, 0)
+	allActions["ns1"] = make([]KvAction, 0)
+	allActions["ns3"] = make([]KvAction, 0)
+
+	allfunc := func(ns string, items []KvItem) {
+		allItems[ns] = items
+	}
+
+	updatefunc := func(ns string, acts []KvAction) {
+		allActions[ns] = append(allActions[ns], acts...)
+	}
+
+	log := logrus.New()
+	log.Level = logrus.DebugLevel
+	w := NewKvWatcher([]string{"ns1", "ns3"}, log, allfunc, updatefunc)
+	go w.Watch(nil)
+	w.ServeConn(NewMultiplexCodec(clientConn))
+
+	tu.WaitFor(t, "Waiting for all ns1 items", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(allItems["ns1"]) == 2, nil })
+	assert.ElementsMatch(t,
+		[]KvItem{{Key: "key1", Value: "value1"},
+			{Key: "key2", Value: "value2"}},
+		allItems["ns1"])
+
+	tu.WaitFor(t, "Waiting for all ns3 items", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(allItems["ns3"]) == 2, nil })
+	assert.ElementsMatch(t,
+		[]KvItem{{Key: "key3_1", Value: "value1"},
+			{Key: "key3_2", Value: "value2"}},
+		allItems["ns3"])
+
+	remoteMgr.Set("ns1", "key2", "value2_1")
+	remoteMgr.Delete("ns1", "key1")
+	remoteMgr.Set("ns1", "key3", "value3")
+	remoteMgr.Set("ns2", "key2_1", "value1_1")
+	remoteMgr.Set("ns3", "key3_2", "value2_1")
+	remoteMgr.Delete("ns3", "key3_1")
+	remoteMgr.Set("ns3", "key3_3", "value3")
+
+	tu.WaitFor(t, "Waiting for updated ns1 items", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(allActions["ns1"]) == 3, nil })
+	assert.ElementsMatch(t,
+		[]KvAction{
+			{Action: OP_SET, Item: KvItem{Key: "key2", Value: "value2_1"}},
+			{Action: OP_SET, Item: KvItem{Key: "key3", Value: "value3"}},
+			{Action: OP_DELETE, Item: KvItem{Key: "key1", Value: "value1"}}},
+		allActions["ns1"])
+
+	tu.WaitFor(t, "Waiting for updated ns3 items", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(allActions["ns3"]) == 3, nil })
+	assert.ElementsMatch(t,
+		[]KvAction{
+			{Action: OP_SET, Item: KvItem{Key: "key3_2", Value: "value2_1"}},
+			{Action: OP_SET, Item: KvItem{Key: "key3_3", Value: "value3"}},
+			{Action: OP_DELETE, Item: KvItem{Key: "key3_1", Value: "value1"}}},
+		allActions["ns3"])
+}
+
+func TestKvWatcherConnError(t *testing.T) {
+	serverConn, clientConn := net.Pipe()
+
+	log := logrus.New()
+	log.Level = logrus.DebugLevel
+	w := NewKvWatcher([]string{"ns1"}, log, nil, nil)
+	go w.Watch(nil)
+	w.ServeConn(NewMultiplexCodec(clientConn))
+
+	tu.WaitFor(t, "Waiting for conn setup", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(w.conns) > 0, nil })
+
+	serverConn.Close()
+	tu.WaitFor(t, "Waiting for conn close", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(w.conns) == 0, nil })
+}
+
+type fakeKvService struct {
+}
+
+func (s *fakeKvService) List(args *RpcListArgs, reply *RpcListReply) error {
+	reply.Items = []KvItem{{Key: "key1", Value: "value1"},
+		{Key: "key2", Value: "value2"}}
+	reply.Version = 1
+	return nil
+}
+
+func (s *fakeKvService) Watch(args *RpcWatchArgs, reply *RpcWatchReply) error {
+	time.Sleep(100 * time.Millisecond)
+	return KvErrorVersionTooOld
+}
+
+func TestKvWatcherReinit(t *testing.T) {
+	rpcServer := rpc.NewServer()
+	err := rpcServer.RegisterName("KvService", &fakeKvService{})
+	assert.Nil(t, err)
+
+	serverConn, clientConn := net.Pipe()
+	go rpcServer.ServeCodec(NewMultiplexCodec(serverConn))
+
+	allcount := 0
+	allfunc := func(ns string, items []KvItem) {
+		allcount = allcount + 1
+	}
+	log := logrus.New()
+	log.Level = logrus.DebugLevel
+	w := NewKvWatcher([]string{"ns1"}, log, allfunc, nil)
+	go w.Watch(nil)
+	w.ServeConn(NewMultiplexCodec(clientConn))
+
+	tu.WaitFor(t, "Waiting for all items", 500*time.Millisecond,
+		func(bool) (bool, error) { return allcount > 1, nil })
+}
+
+func TestKvWatcherCancel(t *testing.T) {
+	_, clientConn := setupRemote(t)
+
+	log := logrus.New()
+	log.Level = logrus.DebugLevel
+	w := NewKvWatcher([]string{"ns1"}, log, nil, nil)
+
+	stopCh := make(chan struct{})
+	watchEnded := false
+	go func() {
+		w.Watch(stopCh)
+		watchEnded = true
+	}()
+	w.ServeConn(NewMultiplexCodec(clientConn))
+	tu.WaitFor(t, "Waiting for watch start", 500*time.Millisecond,
+		func(bool) (bool, error) { return len(w.conns) > 0, nil })
+
+	close(stopCh)
+	tu.WaitFor(t, "Waiting for watch end", 1000*time.Millisecond,
+		func(bool) (bool, error) { return watchEnded, nil })
+	// connection should be closed
+	_, err := clientConn.Write([]byte{})
+	assert.Equal(t, io.ErrClosedPipe, err)
+}


### PR DESCRIPTION
This series of changes adds support for a "key-value service" - a versioned in-memory key-value store accessible remotely. This service will replace the etcd-based communication model between controller and host-agent.