### PR TITLE
[CloudFoundry] Put key-value service port in acc_provision output

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -503,6 +503,7 @@ def config_adjust(args, config, prov_apic, no_random):
                 node_svc_subnet,
             ],
             "api_port": 9900,
+            "key_value_port": 9902,
         },
         "registry": {
             "configuration_version": token,

--- a/provision/acc_provision/templates/aci-cf-containers.yaml
+++ b/provision/acc_provision/templates/aci-cf-containers.yaml
@@ -29,4 +29,5 @@ network_app_static_ext_ip_pool: {{config.cf_config.static_ext_ip_pool|yaml_list_
 network_node_service_ip_pool: {{config.cf_config.node_service_ip_pool|yaml_list_dict}}
 network_node_service_subnets: {{config.cf_config.node_service_gw_subnets}}
 networking_aci_api_port: {{config.cf_config.api_port}}
+key_value_port: {{config.cf_config.key_value_port}}
 

--- a/provision/testdata/flavor_cf_10.cf.yaml
+++ b/provision/testdata/flavor_cf_10.cf.yaml
@@ -61,3 +61,4 @@ network_node_service_ip_pool:
 
 network_node_service_subnets: ['10.5.0.1/24']
 networking_aci_api_port: 9900
+key_value_port: 9902


### PR DESCRIPTION
Signed-off-by: Amit Bose <amitbose@gmail.com>