### PR TITLE
[CloudFoundry] Retry iptables update failures in host agent

### DIFF
--- a/pkg/hostagent/cf_kv_client.go
+++ b/pkg/hostagent/cf_kv_client.go
@@ -70,6 +70,7 @@ func (env *CfEnvironment) handleKvItems(ns string, items []rkv.KvItem) {
 	if env.appsSynced && env.cellSynced {
 		env.agent.EnableSync()
 		env.agent.cleanupSetup()
+		env.agent.ScheduleSync("iptables")
 	}
 }
 

--- a/pkg/hostagent/cf_kv_client_test.go
+++ b/pkg/hostagent/cf_kv_client_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	rkv "github.com/noironetworks/aci-containers/pkg/keyvalueservice"
 	"github.com/noironetworks/aci-containers/pkg/ipam"
+	rkv "github.com/noironetworks/aci-containers/pkg/keyvalueservice"
 	md "github.com/noironetworks/aci-containers/pkg/metadata"
 	tu "github.com/noironetworks/aci-containers/pkg/testutil"
 )

--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -23,7 +23,7 @@ import (
 const nodename = "test-node"
 
 type testHostAgent struct {
-	HostAgent
+	*HostAgent
 	stopCh chan struct{}
 
 	fakeNodeSource      *framework.FakeControllerSource
@@ -37,11 +37,11 @@ func testAgent() *testHostAgent {
 	log.Level = logrus.DebugLevel
 
 	agent := &testHostAgent{
-		HostAgent: *NewHostAgent(&HostAgentConfig{
+		HostAgent: NewHostAgent(&HostAgentConfig{
 			NodeName: nodename,
 		}, &K8sEnvironment{}, log),
 	}
-	agent.env.(*K8sEnvironment).agent = &agent.HostAgent
+	agent.env.(*K8sEnvironment).agent = agent.HostAgent
 
 	agent.fakeNodeSource = framework.NewFakeControllerSource()
 	agent.initNodeInformerBase(


### PR DESCRIPTION
iptables changes needed to support legacy CF networking
now uses a sync-to-desired-state model that retries on
failures.

Signed-off-by: Amit Bose <amitbose@gmail.com>