### PR TITLE
Reordering APIC json, part 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
     - language: python
       python: 3.6
       install:
-        - pip install flake8        
+        - pip install flake8
         - python provision/setup.py install
       script:
         - make -C provision test

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -719,7 +719,7 @@ def generate_cert(username, cert_file, key_file):
         cert.gmtime_adj_notAfter(10 * 365 * 24 * 60 * 60)
         cert.set_issuer(cert.get_subject())
         cert.set_pubkey(k)
-        cert.sign(k, 'sha1')
+        cert.sign(k, b'sha1')
 
         cert_data = crypto.dump_certificate(crypto.FILETYPE_PEM, cert)
         key_data = crypto.dump_privatekey(crypto.FILETYPE_PEM, k)

--- a/provision/testdata/base_case.apic.txt
+++ b/provision/testdata/base_case.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "kube-pool"
+            "name": "kube-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -31,8 +31,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-kube-mpool",
-            "name": "kube-mpool"
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool"
         },
         "children": [
             {
@@ -68,21 +68,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vxlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "k8s",
             "name": "kube",
-            "prefEncapMode": "vxlan"
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "k8s",
                         "name": "kube",
-                        "scope": "kubernetes"
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -151,8 +151,8 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "encap": "vlan-4001",
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes"
+                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "encap": "vlan-4001"
                                 }
                             }
                         }
@@ -181,8 +181,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-common",
-            "name": "common"
+            "name": "common",
+            "dn": "uni/tn-common"
         },
         "children": [
             {
@@ -210,8 +210,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -239,8 +239,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-kube",
-            "name": "kube"
+            "name": "kube",
+            "dn": "uni/tn-kube"
         },
         "children": [
             {
@@ -532,8 +532,8 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "arpFlood": "yes",
-                        "name": "kube-node-bd"
+                        "name": "kube-node-bd",
+                        "arpFlood": "yes"
                     },
                     "children": [
                         {
@@ -593,8 +593,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv4",
                                     "name": "icmp",
+                                    "etherT": "ipv4",
                                     "prot": "icmp"
                                 }
                             }
@@ -602,8 +602,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv6",
                                     "name": "icmp6",
+                                    "etherT": "ipv6",
                                     "prot": "icmpv6"
                                 }
                             }
@@ -620,8 +620,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
@@ -640,8 +640,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": "est"
@@ -660,22 +660,22 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
                                     "name": "dns-udp",
-                                    "prot": "udp"
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns"
                                 }
                             }
                         },
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "dns-tcp",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -693,11 +693,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
-                                    "etherT": "ip",
-                                    "name": "kube-api",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -706,11 +706,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
-                                    "etherT": "ip",
-                                    "name": "kube-api2",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -728,8 +728,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "kube-api-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -755,10 +755,10 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "health-check-subj",
-                                    "provMatchT": "AtleastOne",
-                                    "revFltPorts": "yes"
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
                                 },
                                 "children": [
                                     {
@@ -808,8 +808,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -835,8 +835,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -871,8 +871,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "kube",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -906,8 +906,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "kube.crt"
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }

--- a/provision/testdata/base_case_ipv6.apic.txt
+++ b/provision/testdata/base_case_ipv6.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "kube-pool"
+            "name": "kube-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -31,8 +31,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-kube-mpool",
-            "name": "kube-mpool"
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool"
         },
         "children": [
             {
@@ -68,21 +68,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vxlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "k8s",
             "name": "kube",
-            "prefEncapMode": "vxlan"
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "k8s",
                         "name": "kube",
-                        "scope": "kubernetes"
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -151,8 +151,8 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "encap": "vlan-4001",
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes"
+                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "encap": "vlan-4001"
                                 }
                             }
                         }
@@ -181,8 +181,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-common",
-            "name": "common"
+            "name": "common",
+            "dn": "uni/tn-common"
         },
         "children": [
             {
@@ -210,8 +210,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -239,8 +239,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-kube",
-            "name": "kube"
+            "name": "kube",
+            "dn": "uni/tn-kube"
         },
         "children": [
             {
@@ -430,16 +430,16 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "arpFlood": "yes",
-                        "name": "kube-node-bd"
+                        "name": "kube-node-bd",
+                        "arpFlood": "yes"
                     },
                     "children": [
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ctrl": "nd",
                                     "ip": "1:1:1:1::1/64",
-                                    "scope": "public"
+                                    "scope": "public",
+                                    "ctrl": "nd"
                                 },
                                 "children": [
                                     {
@@ -478,8 +478,8 @@ None
                         {
                             "fvSubnet": {
                                 "attributes": {
-                                    "ctrl": "nd",
-                                    "ip": "1:2:1:1::1/64"
+                                    "ip": "1:2:1:1::1/64",
+                                    "ctrl": "nd"
                                 },
                                 "children": [
                                     {
@@ -511,8 +511,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv4",
                                     "name": "icmp",
+                                    "etherT": "ipv4",
                                     "prot": "icmp"
                                 }
                             }
@@ -520,8 +520,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv6",
                                     "name": "icmp6",
+                                    "etherT": "ipv6",
                                     "prot": "icmpv6"
                                 }
                             }
@@ -538,8 +538,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
@@ -558,8 +558,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": "est"
@@ -578,22 +578,22 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
                                     "name": "dns-udp",
-                                    "prot": "udp"
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns"
                                 }
                             }
                         },
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "dns-tcp",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -611,11 +611,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
-                                    "etherT": "ip",
-                                    "name": "kube-api",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -624,11 +624,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
-                                    "etherT": "ip",
-                                    "name": "kube-api2",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -646,8 +646,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "kube-api-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -673,10 +673,10 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "health-check-subj",
-                                    "provMatchT": "AtleastOne",
-                                    "revFltPorts": "yes"
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
                                 },
                                 "children": [
                                     {
@@ -726,8 +726,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -753,8 +753,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -799,8 +799,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "kube",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -834,8 +834,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "kube.crt"
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }

--- a/provision/testdata/flavor_cf_10.apic.txt
+++ b/provision/testdata/flavor_cf_10.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "mycf0-pool"
+            "name": "mycf0-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -22,8 +22,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-mycf0-mpool",
-            "name": "mycf0-mpool"
+            "name": "mycf0-mpool",
+            "dn": "uni/infra/maddrns-mycf0-mpool"
         },
         "children": [
             {
@@ -59,21 +59,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vxlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "cf",
             "name": "mycf0",
-            "prefEncapMode": "vxlan"
+            "mode": "cf",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "cf",
                         "name": "mycf0",
-                        "scope": "cloudfoundry"
+                        "mode": "cf",
+                        "scope": "cloudfoundry",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -189,8 +189,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-common",
-            "name": "common"
+            "name": "common",
+            "dn": "uni/tn-common"
         },
         "children": [
             {
@@ -218,8 +218,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -247,8 +247,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-mycf0",
-            "name": "mycf0"
+            "name": "mycf0",
+            "dn": "uni/tn-mycf0"
         },
         "children": [
             {
@@ -273,21 +273,21 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "gorouter"
+                                                "tnVzBrCPNamc": "gorouter"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "is-node"
+                                                "tnVzBrCPNamc": "is-node"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "mycf0-l3out-allow-all"
+                                                "tnVzBrCPNamc": "mycf0-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -331,21 +331,21 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "gorouter-is1"
+                                                "tnVzBrCPNamc": "gorouter-is1"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "is-node"
+                                                "tnVzBrCPNamc": "is-node"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "mycf0-l3out-allow-all"
+                                                "tnVzBrCPNamc": "mycf0-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -382,21 +382,21 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "gorouter-is2"
+                                                "tnVzBrCPNamc": "gorouter-is2"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "is-node"
+                                                "tnVzBrCPNamc": "is-node"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "mycf0-l3out-allow-all"
+                                                "tnVzBrCPNamc": "mycf0-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -433,14 +433,14 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPNamc": "dns"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "mycf0-l3out-allow-all"
+                                                "tnVzBrCPNamc": "mycf0-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -477,14 +477,14 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPNamc": "dns"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "mycf0-l3out-allow-all"
+                                                "tnVzBrCPNamc": "mycf0-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -521,14 +521,14 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPNamc": "dns"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "mycf0-l3out-allow-all"
+                                                "tnVzBrCPNamc": "mycf0-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -565,14 +565,14 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPNamc": "dns"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "mycf0-l3out-allow-all"
+                                                "tnVzBrCPNamc": "mycf0-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -609,14 +609,14 @@ None
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "dns"
+                                                "tnVzBrCPNamc": "dns"
                                             }
                                         }
                                     },
                                     {
                                         "fvRsCons": {
                                             "attributes": {
-                                                "tnVzBrCPName": "mycf0-l3out-allow-all"
+                                                "tnVzBrCPNamc": "mycf0-l3out-allow-all"
                                             }
                                         }
                                     },
@@ -727,8 +727,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "tcp",
+                                    "etherT": "ip",
                                     "prot": "tcp"
                                 }
                             }
@@ -736,37 +736,39 @@ None
                     ]
                 }
             },
-            {
-                "vzFilter": {
-                    "attributes": {
-                        "name": "dns"
-                    },
-                    "children": [
-                        {
-                            "vzEntry": {
-                                "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "udp",
-                                    "prot": "udp"
-                                }
-                            }
+            [
+                {
+                    "vzFilter": {
+                        "attributes": {
+                            "name": "dns"
                         },
-                        {
-                            "vzEntry": {
-                                "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "tcp",
-                                    "prot": "tcp"
+                        "children": [
+                            {
+                                "vzEntry": {
+                                    "attributes": {
+                                        "name": "udp",
+                                        "etherT": "ip",
+                                        "prot": "udp",
+                                        "dFromProt": "dns",
+                                        "dToPort": "dns"
+                                    }
+                                }
+                            },
+                            {
+                                "vzEntry": {
+                                    "attributes": {
+                                        "name": "tcp",
+                                        "etherT": "ip",
+                                        "prot": "tcp",
+                                        "dFromProt": "dns",
+                                        "dToPort": "dns"
+                                    }
                                 }
                             }
-                        }
-                    ]
+                        ]
+                    }
                 }
-            },
+            ],
             {
                 "vzFilter": {
                     "attributes": {
@@ -792,8 +794,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "is-node-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -819,8 +821,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -846,8 +848,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "gorouter-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -873,8 +875,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "gorouter-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -900,8 +902,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "gorouter-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -936,8 +938,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "mycf0",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -971,8 +973,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "mycf0.crt"
+                        "name": "mycf0.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }

--- a/provision/testdata/flavor_openshift.apic.txt
+++ b/provision/testdata/flavor_openshift.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "kube-pool"
+            "name": "kube-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -31,8 +31,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-kube-mpool",
-            "name": "kube-mpool"
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool"
         },
         "children": [
             {
@@ -68,21 +68,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vxlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "openshift",
             "name": "kube",
-            "prefEncapMode": "vxlan"
+            "mode": "openshift",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "openshift",
                         "name": "kube",
-                        "scope": "openshift"
+                        "mode": "openshift",
+                        "scope": "openshift",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -151,8 +151,8 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "encap": "vlan-4001",
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes"
+                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "encap": "vlan-4001"
                                 }
                             }
                         }
@@ -181,8 +181,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-common",
-            "name": "common"
+            "name": "common",
+            "dn": "uni/tn-common"
         },
         "children": [
             {
@@ -210,8 +210,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -239,8 +239,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-kube",
-            "name": "kube"
+            "name": "kube",
+            "dn": "uni/tn-kube"
         },
         "children": [
             {
@@ -553,8 +553,8 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "arpFlood": "yes",
-                        "name": "kube-node-bd"
+                        "name": "kube-node-bd",
+                        "arpFlood": "yes"
                     },
                     "children": [
                         {
@@ -614,8 +614,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv4",
                                     "name": "icmp",
+                                    "etherT": "ipv4",
                                     "prot": "icmp"
                                 }
                             }
@@ -623,8 +623,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv6",
                                     "name": "icmp6",
+                                    "etherT": "ipv6",
                                     "prot": "icmpv6"
                                 }
                             }
@@ -641,8 +641,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
@@ -661,8 +661,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": "est"
@@ -681,22 +681,22 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
                                     "name": "dns-udp",
-                                    "prot": "udp"
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns"
                                 }
                             }
                         },
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "dns-tcp",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -714,11 +714,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
-                                    "etherT": "ip",
-                                    "name": "kube-api",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -727,11 +727,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
-                                    "etherT": "ip",
-                                    "name": "kube-api2",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -749,8 +749,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "kube-api-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -776,10 +776,10 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "health-check-subj",
-                                    "provMatchT": "AtleastOne",
-                                    "revFltPorts": "yes"
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
                                 },
                                 "children": [
                                     {
@@ -829,8 +829,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -856,8 +856,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -892,8 +892,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "kube",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -927,8 +927,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "kube.crt"
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }

--- a/provision/testdata/nested-vlan.apic.txt
+++ b/provision/testdata/nested-vlan.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "kube-pool"
+            "name": "kube-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -31,8 +31,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "dynamic",
-            "name": "kube-vpool"
+            "name": "kube-vpool",
+            "allocMode": "dynamic"
         },
         "children": [
             {
@@ -51,8 +51,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-kube-mpool",
-            "name": "kube-mpool"
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool"
         },
         "children": [
             {
@@ -88,21 +88,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "k8s",
             "name": "kube",
-            "prefEncapMode": "vlan"
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vlan",
+            "prefEncapMode": "vlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "k8s",
                         "name": "kube",
-                        "scope": "kubernetes"
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -221,8 +221,8 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "encap": "vlan-4001",
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes"
+                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "encap": "vlan-4001"
                                 }
                             }
                         }
@@ -251,8 +251,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-common",
-            "name": "common"
+            "name": "common",
+            "dn": "uni/tn-common"
         },
         "children": [
             {
@@ -280,8 +280,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -309,8 +309,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-kube",
-            "name": "kube"
+            "name": "kube",
+            "dn": "uni/tn-kube"
         },
         "children": [
             {
@@ -500,8 +500,8 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "arpFlood": "yes",
-                        "name": "kube-node-bd"
+                        "name": "kube-node-bd",
+                        "arpFlood": "yes"
                     },
                     "children": [
                         {
@@ -561,8 +561,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv4",
                                     "name": "icmp",
+                                    "etherT": "ipv4",
                                     "prot": "icmp"
                                 }
                             }
@@ -570,8 +570,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv6",
                                     "name": "icmp6",
+                                    "etherT": "ipv6",
                                     "prot": "icmpv6"
                                 }
                             }
@@ -588,8 +588,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
@@ -608,8 +608,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": "est"
@@ -628,22 +628,22 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
                                     "name": "dns-udp",
-                                    "prot": "udp"
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns"
                                 }
                             }
                         },
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "dns-tcp",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -661,11 +661,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
-                                    "etherT": "ip",
-                                    "name": "kube-api",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -674,11 +674,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
-                                    "etherT": "ip",
-                                    "name": "kube-api2",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -696,8 +696,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "kube-api-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -723,10 +723,10 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "health-check-subj",
-                                    "provMatchT": "AtleastOne",
-                                    "revFltPorts": "yes"
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
                                 },
                                 "children": [
                                     {
@@ -776,8 +776,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -803,8 +803,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -839,8 +839,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "kube",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -874,8 +874,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "kube.crt"
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }

--- a/provision/testdata/nested-vxlan.apic.txt
+++ b/provision/testdata/nested-vxlan.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "kube-pool"
+            "name": "kube-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -31,8 +31,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-kube-mpool",
-            "name": "kube-mpool"
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool"
         },
         "children": [
             {
@@ -68,21 +68,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vxlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "k8s",
             "name": "kube",
-            "prefEncapMode": "vxlan"
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "k8s",
                         "name": "kube",
-                        "scope": "kubernetes"
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -186,8 +186,8 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "encap": "vlan-4001",
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes"
+                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "encap": "vlan-4001"
                                 }
                             }
                         }
@@ -216,8 +216,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-common",
-            "name": "common"
+            "name": "common",
+            "dn": "uni/tn-common"
         },
         "children": [
             {
@@ -245,8 +245,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -274,8 +274,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-kube",
-            "name": "kube"
+            "name": "kube",
+            "dn": "uni/tn-kube"
         },
         "children": [
             {
@@ -465,8 +465,8 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "arpFlood": "yes",
-                        "name": "kube-node-bd"
+                        "name": "kube-node-bd",
+                        "arpFlood": "yes"
                     },
                     "children": [
                         {
@@ -526,8 +526,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv4",
                                     "name": "icmp",
+                                    "etherT": "ipv4",
                                     "prot": "icmp"
                                 }
                             }
@@ -535,8 +535,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv6",
                                     "name": "icmp6",
+                                    "etherT": "ipv6",
                                     "prot": "icmpv6"
                                 }
                             }
@@ -553,8 +553,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
@@ -573,8 +573,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": "est"
@@ -593,22 +593,22 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
                                     "name": "dns-udp",
-                                    "prot": "udp"
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns"
                                 }
                             }
                         },
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "dns-tcp",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -626,11 +626,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
-                                    "etherT": "ip",
-                                    "name": "kube-api",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -639,11 +639,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
-                                    "etherT": "ip",
-                                    "name": "kube-api2",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -661,8 +661,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "kube-api-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -688,10 +688,10 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "health-check-subj",
-                                    "provMatchT": "AtleastOne",
-                                    "revFltPorts": "yes"
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
                                 },
                                 "children": [
                                     {
@@ -741,8 +741,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -768,8 +768,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -804,8 +804,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "kube",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -839,8 +839,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "kube.crt"
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }

--- a/provision/testdata/vlan_case.apic.txt
+++ b/provision/testdata/vlan_case.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "kube-pool"
+            "name": "kube-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -31,8 +31,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "dynamic",
-            "name": "kube-vpool"
+            "name": "kube-vpool",
+            "allocMode": "dynamic"
         },
         "children": [
             {
@@ -51,8 +51,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-kube-mpool",
-            "name": "kube-mpool"
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool"
         },
         "children": [
             {
@@ -88,21 +88,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "k8s",
             "name": "kube",
-            "prefEncapMode": "vlan"
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vlan",
+            "prefEncapMode": "vlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "k8s",
                         "name": "kube",
-                        "scope": "kubernetes"
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -178,8 +178,8 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "encap": "vlan-4001",
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes"
+                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "encap": "vlan-4001"
                                 }
                             }
                         }
@@ -208,8 +208,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-common",
-            "name": "common"
+            "name": "common",
+            "dn": "uni/tn-common"
         },
         "children": [
             {
@@ -237,8 +237,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -266,8 +266,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-kube",
-            "name": "kube"
+            "name": "kube",
+            "dn": "uni/tn-kube"
         },
         "children": [
             {
@@ -457,8 +457,8 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "arpFlood": "yes",
-                        "name": "kube-node-bd"
+                        "name": "kube-node-bd",
+                        "arpFlood": "yes"
                     },
                     "children": [
                         {
@@ -518,8 +518,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv4",
                                     "name": "icmp",
+                                    "etherT": "ipv4",
                                     "prot": "icmp"
                                 }
                             }
@@ -527,8 +527,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv6",
                                     "name": "icmp6",
+                                    "etherT": "ipv6",
                                     "prot": "icmpv6"
                                 }
                             }
@@ -545,8 +545,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
@@ -565,8 +565,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": "est"
@@ -585,22 +585,22 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
                                     "name": "dns-udp",
-                                    "prot": "udp"
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns"
                                 }
                             }
                         },
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "dns-tcp",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -618,11 +618,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
-                                    "etherT": "ip",
-                                    "name": "kube-api",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -631,11 +631,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
-                                    "etherT": "ip",
-                                    "name": "kube-api2",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -653,8 +653,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "kube-api-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -680,10 +680,10 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "health-check-subj",
-                                    "provMatchT": "AtleastOne",
-                                    "revFltPorts": "yes"
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
                                 },
                                 "children": [
                                     {
@@ -733,8 +733,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -760,8 +760,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -796,8 +796,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "kube",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -831,8 +831,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "kube.crt"
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }

--- a/provision/testdata/with_comments.apic.txt
+++ b/provision/testdata/with_comments.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "kube-pool"
+            "name": "kube-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -31,8 +31,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-kube-mpool",
-            "name": "kube-mpool"
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool"
         },
         "children": [
             {
@@ -68,21 +68,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vxlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "k8s",
             "name": "kube",
-            "prefEncapMode": "vxlan"
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "k8s",
                         "name": "kube",
-                        "scope": "kubernetes"
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -151,8 +151,8 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "encap": "vlan-4001",
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes"
+                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "encap": "vlan-4001"
                                 }
                             }
                         }
@@ -181,8 +181,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-common",
-            "name": "common"
+            "name": "common",
+            "dn": "uni/tn-common"
         },
         "children": [
             {
@@ -210,8 +210,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -239,8 +239,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-kube",
-            "name": "kube"
+            "name": "kube",
+            "dn": "uni/tn-kube"
         },
         "children": [
             {
@@ -430,8 +430,8 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "arpFlood": "yes",
-                        "name": "kube-node-bd"
+                        "name": "kube-node-bd",
+                        "arpFlood": "yes"
                     },
                     "children": [
                         {
@@ -491,8 +491,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv4",
                                     "name": "icmp",
+                                    "etherT": "ipv4",
                                     "prot": "icmp"
                                 }
                             }
@@ -500,8 +500,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv6",
                                     "name": "icmp6",
+                                    "etherT": "ipv6",
                                     "prot": "icmpv6"
                                 }
                             }
@@ -518,8 +518,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
@@ -538,8 +538,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": "est"
@@ -558,22 +558,22 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
                                     "name": "dns-udp",
-                                    "prot": "udp"
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns"
                                 }
                             }
                         },
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "dns-tcp",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -591,11 +591,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
-                                    "etherT": "ip",
-                                    "name": "kube-api",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -604,11 +604,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
-                                    "etherT": "ip",
-                                    "name": "kube-api2",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -626,8 +626,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "kube-api-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -653,10 +653,10 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "health-check-subj",
-                                    "provMatchT": "AtleastOne",
-                                    "revFltPorts": "yes"
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
                                 },
                                 "children": [
                                     {
@@ -706,8 +706,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -733,8 +733,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -769,8 +769,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "kube",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -804,8 +804,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "kube.crt"
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }

--- a/provision/testdata/with_overrides.apic.txt
+++ b/provision/testdata/with_overrides.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "kube-pool"
+            "name": "kube-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -31,8 +31,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-kube-mpool",
-            "name": "kube-mpool"
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool"
         },
         "children": [
             {
@@ -68,21 +68,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vxlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "k8s",
             "name": "kubernetes1",
-            "prefEncapMode": "vxlan"
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "k8s",
                         "name": "kubernetes1",
-                        "scope": "kubernetes"
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -151,8 +151,8 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "encap": "vlan-4001",
-                                    "tDn": "uni/tn-demo/ap-kubernetes/epg-kube-nodes"
+                                    "tDn": "uni/tn-demo/ap-kubernetes/epg-kube-nodes",
+                                    "encap": "vlan-4001"
                                 }
                             }
                         }
@@ -181,8 +181,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-common",
-            "name": "common"
+            "name": "common",
+            "dn": "uni/tn-common"
         },
         "children": [
             {
@@ -210,8 +210,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -239,8 +239,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-demo",
-            "name": "demo"
+            "name": "demo",
+            "dn": "uni/tn-demo"
         },
         "children": [
             {
@@ -437,8 +437,8 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "arpFlood": "yes",
-                        "name": "kube-node-bd"
+                        "name": "kube-node-bd",
+                        "arpFlood": "yes"
                     },
                     "children": [
                         {
@@ -498,8 +498,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv4",
                                     "name": "icmp",
+                                    "etherT": "ipv4",
                                     "prot": "icmp"
                                 }
                             }
@@ -507,8 +507,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv6",
                                     "name": "icmp6",
+                                    "etherT": "ipv6",
                                     "prot": "icmpv6"
                                 }
                             }
@@ -525,8 +525,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
@@ -545,8 +545,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": "est"
@@ -565,22 +565,22 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
                                     "name": "dns-udp",
-                                    "prot": "udp"
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns"
                                 }
                             }
                         },
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "dns-tcp",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -598,11 +598,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
-                                    "etherT": "ip",
-                                    "name": "kube-api",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -611,11 +611,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
-                                    "etherT": "ip",
-                                    "name": "kube-api2",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -633,8 +633,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "kube-api-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -660,10 +660,10 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "health-check-subj",
-                                    "provMatchT": "AtleastOne",
-                                    "revFltPorts": "yes"
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
                                 },
                                 "children": [
                                     {
@@ -713,8 +713,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -740,8 +740,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -776,8 +776,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "kube",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -811,8 +811,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "kube.crt"
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }

--- a/provision/testdata/with_tenant_l3out.apic.txt
+++ b/provision/testdata/with_tenant_l3out.apic.txt
@@ -2,8 +2,8 @@
 {
     "fvnsVlanInstP": {
         "attributes": {
-            "allocMode": "static",
-            "name": "kube-pool"
+            "name": "kube-pool",
+            "allocMode": "static"
         },
         "children": [
             {
@@ -31,8 +31,8 @@
 {
     "fvnsMcastAddrInstP": {
         "attributes": {
-            "dn": "uni/infra/maddrns-kube-mpool",
-            "name": "kube-mpool"
+            "name": "kube-mpool",
+            "dn": "uni/infra/maddrns-kube-mpool"
         },
         "children": [
             {
@@ -68,21 +68,21 @@
 {
     "vmmDomP": {
         "attributes": {
-            "encapMode": "vxlan",
-            "enfPref": "sw",
-            "mcastAddr": "225.1.2.3",
-            "mode": "k8s",
             "name": "kube",
-            "prefEncapMode": "vxlan"
+            "mode": "k8s",
+            "enfPref": "sw",
+            "encapMode": "vxlan",
+            "prefEncapMode": "vxlan",
+            "mcastAddr": "225.1.2.3"
         },
         "children": [
             {
                 "vmmCtrlrP": {
                     "attributes": {
-                        "hostOrIp": "1.1.1.1",
-                        "mode": "k8s",
                         "name": "kube",
-                        "scope": "kubernetes"
+                        "mode": "k8s",
+                        "scope": "kubernetes",
+                        "hostOrIp": "1.1.1.1"
                     }
                 }
             },
@@ -151,8 +151,8 @@
                         {
                             "infraRsFuncToEpg": {
                                 "attributes": {
-                                    "encap": "vlan-4001",
-                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes"
+                                    "tDn": "uni/tn-kube/ap-kubernetes/epg-kube-nodes",
+                                    "encap": "vlan-4001"
                                 }
                             }
                         }
@@ -181,8 +181,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-kube",
-            "name": "kube"
+            "name": "kube",
+            "dn": "uni/tn-kube"
         },
         "children": [
             {
@@ -210,8 +210,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "allow-all-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -239,8 +239,8 @@ None
 {
     "fvTenant": {
         "attributes": {
-            "dn": "uni/tn-kube",
-            "name": "kube"
+            "name": "kube",
+            "dn": "uni/tn-kube"
         },
         "children": [
             {
@@ -430,8 +430,8 @@ None
             {
                 "fvBD": {
                     "attributes": {
-                        "arpFlood": "yes",
-                        "name": "kube-node-bd"
+                        "name": "kube-node-bd",
+                        "arpFlood": "yes"
                     },
                     "children": [
                         {
@@ -491,8 +491,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv4",
                                     "name": "icmp",
+                                    "etherT": "ipv4",
                                     "prot": "icmp"
                                 }
                             }
@@ -500,8 +500,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ipv6",
                                     "name": "icmp6",
+                                    "etherT": "ipv6",
                                     "prot": "icmpv6"
                                 }
                             }
@@ -518,8 +518,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
@@ -538,8 +538,8 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "etherT": "ip",
                                     "name": "health-check",
+                                    "etherT": "ip",
                                     "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": "est"
@@ -558,22 +558,22 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
-                                    "dFromPort": "dns",
-                                    "dToPort": "dns",
-                                    "etherT": "ip",
                                     "name": "dns-udp",
-                                    "prot": "udp"
+                                    "etherT": "ip",
+                                    "prot": "udp",
+                                    "dFromPort": "dns",
+                                    "dToPort": "dns"
                                 }
                             }
                         },
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "dns-tcp",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "dns",
                                     "dToPort": "dns",
-                                    "etherT": "ip",
-                                    "name": "dns-tcp",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -591,11 +591,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "6443",
                                     "dToPort": "6443",
-                                    "etherT": "ip",
-                                    "name": "kube-api",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -604,11 +604,11 @@ None
                         {
                             "vzEntry": {
                                 "attributes": {
+                                    "name": "kube-api2",
+                                    "etherT": "ip",
+                                    "prot": "tcp",
                                     "dFromPort": "8443",
                                     "dToPort": "8443",
-                                    "etherT": "ip",
-                                    "name": "kube-api2",
-                                    "prot": "tcp",
                                     "stateful": "no",
                                     "tcpRules": ""
                                 }
@@ -626,8 +626,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "kube-api-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -653,10 +653,10 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "health-check-subj",
-                                    "provMatchT": "AtleastOne",
-                                    "revFltPorts": "yes"
+                                    "revFltPorts": "yes",
+                                    "consMatchT": "AtleastOne",
+                                    "provMatchT": "AtleastOne"
                                 },
                                 "children": [
                                     {
@@ -706,8 +706,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "dns-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -733,8 +733,8 @@ None
                         {
                             "vzSubj": {
                                 "attributes": {
-                                    "consMatchT": "AtleastOne",
                                     "name": "icmp-subj",
+                                    "consMatchT": "AtleastOne",
                                     "provMatchT": "AtleastOne"
                                 },
                                 "children": [
@@ -769,8 +769,8 @@ None
 {
     "aaaUser": {
         "attributes": {
-            "accountStatus": "active",
             "name": "kube",
+            "accountStatus": "active",
             "pwd": "NotRandom!"
         },
         "children": [
@@ -804,8 +804,8 @@ None
             {
                 "aaaUserCert": {
                     "attributes": {
-                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n",
-                        "name": "kube.crt"
+                        "name": "kube.crt",
+                        "data": "-----BEGIN CERTIFICATE-----\nMIIB6DCCAVECAgPoMA0GCSqGSIb3DQEBBQUAMDwxCzAJBgNVBAYTAlVTMRYwFAYD\nVQQKDA1DaXNjbyBTeXN0ZW1zMRUwEwYDVQQDDAxVc2VyIG1hbmRlZXAwHhcNMTcw\nNTE2MjEyOTMwWhcNMjcwNTE0MjEyOTMwWjA8MQswCQYDVQQGEwJVUzEWMBQGA1UE\nCgwNQ2lzY28gU3lzdGVtczEVMBMGA1UEAwwMVXNlciBtYW5kZWVwMIGfMA0GCSqG\nSIb3DQEBAQUAA4GNADCBiQKBgQDa/gPoDimwFVaybG9/mVm3J1V6P4HbsSE5L5tP\nZHohQp/lKf0hnar+gIfo5SXxe7r/hYAibQsQ/O6mMNKuQ3BlSyHHxeGVG/QfKyVi\ngSOsCX8bTHxblDWNuHIMEKSaqzFKgA8/zFvsK2XobEpxbMnsF0d/PHkexCow1noH\nScj3FwIDAQABMA0GCSqGSIb3DQEBBQUAA4GBAHX+kLTe6LCABewmCTvMsjusHdpZ\nki01+nQ7KhnERbBm/tZ5scZE4ctIqch3ny1EITHNtYWKBN4CdUKcjvDW2h2vkHeg\nrtYbV+AaEsq0m4vGF9Emvt1cp9Y41IyMBZYqw8c/V1AtmRQcRTYQA8H3OFDchyB2\n0JHSDnBoS7ffSbBx\n-----END CERTIFICATE-----\n"
                     }
                 }
             }


### PR DESCRIPTION
The first pull request I made was the safer version, where I *didn't* replace `sort_keys=True` in `json.dumps` in `apic_provision.py` so (despite the ordered dicts) the keys should have been in the exact same order for all the apic.txt test files as they were before.  This is the less-safe version, where I copied the generated apic.txt test files over the originals because there were too many changes for me to manually review, unlike for the acc_provision.py changes.  I had to fix one bug that Amit found because pyOpenSSL requires that the hash algorithm name be a bytestring, that's in a separate commit, not sure if it's worth adding a test for.  The other changes all come from keyword arguments in Python <3.6 being unordered: if you take an ordered mapping and pass it to a function with **, the resulting dict has no guaranteed order.