### PR TITLE
Fix net namespace configuration for non-root Pods

### DIFF
--- a/cmd/hostagent/main.go
+++ b/cmd/hostagent/main.go
@@ -54,7 +54,7 @@ func main() {
 	}
 	log.Level = logLevel
 	if config.ChildMode {
-		hostagent.StartPlugin(log)
+		hostagent.StartPlugin(log, config)
 		return
 	}
 

--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -54,6 +54,9 @@ type HostAgentConfig struct {
 	// separate process.
 	ChildMode bool `json:"child-mode,omitempty"`
 
+	// FsUid to use for the child-mode process
+	ChildModeFsUid int `json:"child-mode-fsuid,omitempty"`
+
 	// Log level
 	LogLevel string `json:"log-level,omitempty"`
 
@@ -140,6 +143,7 @@ type HostAgentConfig struct {
 
 func (config *HostAgentConfig) InitFlags() {
 	flag.BoolVar(&config.ChildMode, "child-mode", false, "Child Mode")
+	flag.IntVar(&config.ChildModeFsUid, "child-mode-fsuid", 0, "Child Mode FS Uid")
 
 	flag.StringVar(&config.LogLevel, "log-level", "info", "Log level")
 

--- a/pkg/hostagent/setup_test.go
+++ b/pkg/hostagent/setup_test.go
@@ -1,0 +1,34 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSandboxUserId(t *testing.T) {
+	log := testAgent().log.WithField("test", "TestGetSandboxUserId")
+
+	exp_uid := fmt.Sprintf("%d", os.Getuid())
+	assert.Equal(t,
+		exp_uid,
+		getSandboxUserId(log, fmt.Sprintf("/proc/%d/ns/net", os.Getpid())))
+
+	assert.Equal(t, "", getSandboxUserId(log, "/var/vcap/data/1234"))
+}


### PR DESCRIPTION
When K8S pods are configured to run as non-root
users, the host-agent is denied access to that
pods network namespace (even though the agent is
runnng as root). This fix switches the file-system
user-id of the child-mode host-agent to the pod's
user-id as a work-around.

Signed-off-by: Amit Bose <amitbose@gmail.com>