### PR TITLE
Two minor enhancements

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -590,6 +590,11 @@ def config_validate(flavor_opts, config):
                                        required),
     }
 
+    # Allow deletion of resources without isname check
+    if get(("provision", "prov_apic")) is False:
+        checks["aci_config/system_id"] = \
+            (get(("aci_config", "system_id")), required)
+
     if flavor_opts.get("apic", {}).get("use_kubeapi_vlan", True):
         checks["net_config/kubeapi_vlan"] = (
             get(("net_config", "kubeapi_vlan")), required)

--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -10,6 +10,7 @@ import ipaddress
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 apic_debug = False
+apic_cookies = {}
 apic_default_timeout = (15, 90)
 
 
@@ -60,12 +61,16 @@ class Apic(object):
         self.ssl = ssl
         self.username = username
         self.password = password
-        self.cookies = None
+        self.cookies = apic_cookies.get((addr, username, ssl))
         self.errors = 0
         self.verify = verify
         self.timeout = timeout if timeout else apic_default_timeout
         self.debug = debug
-        self.login()
+
+        if self.cookies is None:
+            self.login()
+            if self.cookies is not None:
+                apic_cookies[(addr, username, ssl)] = self.cookies
 
     def url(self, path):
         if self.ssl:


### PR DESCRIPTION
1. Reduce logins during acc-provision session to one
2. Allow '-' in names when deleting old VMMs on APIC