### PR TITLE
Default APIC websocket subscription refresh timeout

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -55,10 +55,7 @@ func main() {
 	if config.ApicPassword == "" {
 		config.ApicPassword = os.Getenv("APIC_PASSWORD")
 	}
-	//If the value not present then set it default, i.e refresh every 30 sec
-	if config.ApicRefreshTimer == 0 {
-		config.ApicRefreshTimer = 30
-	}
+
 	logLevel, err := logrus.ParseLevel(config.LogLevel)
 	if err != nil {
 		panic(err.Error())

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -811,10 +811,18 @@ func (conn *ApicConnection) subscribe(value string, sub *subscription) bool {
 		kind = "class"
 	}
 
+        refresh_interval := ""
+        if conn.RefreshInterval != 0 {
+                refresh_interval = fmt.Sprintf("refresh-timeout=%s&",
+                        conn.RefreshInterval)
+        }
+
 	// properly encoding the URI query parameters breaks APIC
-	uri := fmt.Sprintf("/api/%s/%s.json?subscription=yes&refresh-timeout=%s&%s",
-		kind, value, conn.RefreshInterval, strings.Join(args, "&"))
+	uri := fmt.Sprintf("/api/%s/%s.json?subscription=yes&%s%s",
+		kind, value, refresh_interval, strings.Join(args, "&"))
 	url := fmt.Sprintf("https://%s%s", conn.apic[conn.apicIndex], uri)
+	conn.log.Info("APIC connection URL: ", url)
+
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		conn.log.Error("Could not create request: ", err)

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -62,8 +62,20 @@ type ControllerConfig struct {
 	// The password for connecting to APIC
 	ApicPassword string `json:"apic-password,omitempty"`
 
-	// The refresh timer when connected to APIC
-	ApicRefreshTimer int `json:"apic-refreshtime,omitempty"`
+	// The number of seconds that APIC should wait before timing
+	// out a subscription on a websocket connection. If not
+	// explicitly set, then a default of 900 seconds will
+	// be sent in websocket subscriptions. If it is set to 0,
+	// then a timeout will not be sent in websocket
+	// subscriptions, and APIC will use it's default timeout
+	// of 80 seconds. If set to a non-zero value, then the
+	// timeout value will be provided when we subscribe to
+	// a URL on APIC. NOTE: the subscription timeout is not
+	// supported by APIC versions before 3.2(3), so this
+	// value must not be set when used with APIC versions
+	// older than that release.
+	// Also, note that this is a string.
+	ApicRefreshTimer string `json:"apic-refreshtime,omitempty"`
 
 	// A path for a PEM-encoded private key for client certificate
 	// authentication for APIC API

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -313,10 +314,19 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 			panic(err)
 		}
 	}
+	// If not defined, default is 900
+	if cont.config.ApicRefreshTimer == "" {
+		cont.config.ApicRefreshTimer = "900"
+	}
+	refreshTimeout, err := strconv.Atoi(cont.config.ApicRefreshTimer)
+	if err != nil {
+		panic(err)
+	}
+	cont.log.Info("ApicRefreshTimer conf is set to: ", refreshTimeout)
 	cont.apicConn, err = apicapi.New(cont.log, cont.config.ApicHosts,
 		cont.config.ApicUsername, cont.config.ApicPassword,
 		privKey, apicCert, cont.config.AciPrefix,
-		cont.config.ApicRefreshTimer)
+		refreshTimeout)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The apic-refreshtime configuration was introduced in the commit:
60018bcbab19f9c7550d7fe7b11b5515ab11dff5

The current commit updates the default value of that configuration
to a larger value.

Also clarifying comments added as to what the different values mean
for this configuration, namely:

* not providing this configuration in the configuration file will
default it's value to 900 seconds
* setting it to zero will result in APIC's default being used (which
currently is 80 secs)
* setting to a value greater than 0 will result in that value
being used in the APIC connection.