### PR TITLE
Multiple fixes related to agent IPAM plus an integration test.

### DIFF
--- a/cmd/opflexagentcni/main.go
+++ b/cmd/opflexagentcni/main.go
@@ -230,6 +230,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
+	defer eprpc.Close()
 
 	result, err = eprpc.Register(&metadata)
 	if err != nil {
@@ -274,6 +275,8 @@ func cmdDel(args *skel.CmdArgs) error {
 	if err != nil {
 		return err
 	}
+	defer eprpc.Close()
+
 	_, err = eprpc.Unregister(cid)
 	if err != nil {
 		return err

--- a/pkg/eprpcclient/eprpcclient.go
+++ b/pkg/eprpcclient/eprpcclient.go
@@ -57,3 +57,7 @@ func (c *Client) Resync() (bool, error) {
 	err := c.connection.Call("EpRPC.Resync", ResyncArgs{}, &result)
 	return result, err
 }
+
+func (c *Client) Close() {
+	c.connection.Close()
+}

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -179,7 +179,9 @@ func (agent *HostAgent) Run(stopCh <-chan struct{}) {
 	}
 
 	agent.log.Debug("Building IP address management database")
+	agent.indexMutex.Lock()
 	agent.rebuildIpam()
+	agent.indexMutex.Unlock()
 
 	if agent.config.OpFlexEndpointDir == "" ||
 		agent.config.OpFlexServiceDir == "" {

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -35,6 +35,7 @@ type HostAgent struct {
 	env    Environment
 
 	indexMutex sync.Mutex
+	ipamMutex  sync.Mutex
 
 	opflexEps      map[string][]*opflexEndpoint
 	opflexServices map[string]*opflexService

--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -16,8 +16,10 @@ package hostagent
 
 import (
 	"github.com/Sirupsen/logrus"
+	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	framework "k8s.io/client-go/tools/cache/testing"
+	"net"
 )
 
 const nodename = "test-node"
@@ -36,9 +38,13 @@ func testAgent() *testHostAgent {
 	log := logrus.New()
 	log.Level = logrus.DebugLevel
 
+	ncf := cniNetConfig{Subnet: cnitypes.IPNet{IP: net.ParseIP("10.128.2.0"), Mask: net.CIDRMask(24, 32)}}
 	agent := &testHostAgent{
 		HostAgent: NewHostAgent(&HostAgentConfig{
-			NodeName: nodename,
+			NodeName:       nodename,
+			EpRpcSock:      "/tmp/aci-containers-ep-rpc.sock",
+			CniMetadataDir: "/tmp/cnimeta",
+			NetConfig:      []cniNetConfig{ncf},
 		}, &K8sEnvironment{}, log),
 	}
 	agent.env.(*K8sEnvironment).agent = agent.HostAgent

--- a/pkg/hostagent/integ_test.go
+++ b/pkg/hostagent/integ_test.go
@@ -1,0 +1,205 @@
+// Copyright 2018 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/noironetworks/aci-containers/pkg/eprpcclient"
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+	"github.com/noironetworks/aci-containers/pkg/metadata"
+	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+)
+
+const (
+	testPodNS = "itPodNS"
+	testNetNS = "/var/run/netns/integns"
+	rpcSock   = "/tmp/aci-containers-ep-rpc.sock"
+)
+
+type buildIpam struct {
+	annotation  string
+	existingEps []metadata.ContainerMetadata
+	freeListV4  []ipam.IpRange
+	freeListV6  []ipam.IpRange
+	desc        string
+}
+
+var buildIpams = []buildIpam{
+	{
+		"{\"V4\":[{\"start\":\"10.1.0.2\",\"end\":\"10.1.1.1\"}],\"V6\":null}",
+		[]metadata.ContainerMetadata{},
+		[]ipam.IpRange{
+			{Start: net.ParseIP("10.1.0.2"), End: net.ParseIP("10.1.1.1")},
+		},
+		[]ipam.IpRange{},
+		"simple v4",
+	},
+	{
+		"{\"V4\":[{\"start\":\"10.128.2.130\",\"end\":\"10.128.3.1\"},{\"start\":\"10.128.3.2\",\"end\":\"10.128.3.129\"},{\"start\":\"10.128.3.130\",\"end\":\"10.128.4.1\"},{\"start\":\"10.128.4.2\",\"end\":\"10.128.4.129\"},{\"start\":\"10.128.4.130\",\"end\":\"10.128.5.1\"},{\"start\":\"10.128.6.130\",\"end\":\"10.128.7.1\"},{\"start\":\"10.128.5.2\",\"end\":\"10.128.5.129\"},{\"start\":\"10.128.2.2\",\"end\":\"10.128.2.129\"},{\"start\":\"10.128.5.130\",\"end\":\"10.128.6.129\"},{\"start\":\"10.128.5.130\",\"end\":\"10.128.6.129\"},{\"start\":\"10.128.7.2\",\"end\":\"10.128.9.1\"},{\"start\":\"10.128.7.2\",\"end\":\"10.128.8.129\"} ],\"V6\":null}",
+		[]metadata.ContainerMetadata{},
+		[]ipam.IpRange{
+			{Start: net.ParseIP("10.128.2.2"), End: net.ParseIP("10.128.9.1")},
+		},
+		[]ipam.IpRange{},
+		"v4 with duplicates",
+	},
+}
+
+func TestInteg(t *testing.T) {
+	node := func(podNetAnnotation string) *v1.Node {
+		return &v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodename,
+				Annotations: map[string]string{
+					metadata.PodNetworkRangeAnnotation: podNetAnnotation,
+				},
+			},
+		}
+	}
+
+	PluginCloner.Stub = true
+	agent := testAgent()
+	agent.run()
+
+	for _, test := range buildIpams {
+		agent.indexMutex.Lock()
+		agent.epMetadata =
+			make(map[string]map[string]*metadata.ContainerMetadata)
+		agent.podNetAnnotation = ""
+		for _, ep := range test.existingEps {
+			podid := "ns/pod" + ep.Id.ContId
+			if _, ok := agent.epMetadata[podid]; !ok {
+				agent.epMetadata[podid] =
+					make(map[string]*metadata.ContainerMetadata)
+			}
+			agent.epMetadata[podid][ep.Id.ContId] = &ep
+		}
+		agent.indexMutex.Unlock()
+		agent.fakeNodeSource.Add(node(test.annotation))
+
+		tu.WaitFor(t, test.desc, 100*time.Millisecond,
+			func(last bool) (bool, error) {
+				agent.indexMutex.Lock()
+				defer agent.indexMutex.Unlock()
+				return tu.WaitEqual(t, last, test.freeListV4,
+					agent.podIps.CombineV4(), test.desc) &&
+					tu.WaitEqual(t, last, test.freeListV4,
+						agent.podIps.CombineV4(), test.desc), nil
+			})
+
+	}
+
+	for jx := 0; jx < 2000; jx++ {
+		log.Infof("=>Iteration %d<=", jx)
+		var wg sync.WaitGroup
+		count := 16
+
+		wg.Add(count)
+		for ix := 0; ix < count; ix++ {
+			go func(id int) {
+				defer wg.Done()
+				name := fmt.Sprintf("pod%d", id)
+				cid := fmt.Sprintf("%d8ec72deca647bfa60a4b815aa735c87de859b47e87", id)
+				err := cniAdd(name, cid, "testeth1")
+				if err != nil {
+					t.Error(err)
+				}
+			}(ix)
+		}
+
+		log.Infof("Waiting for Adds to finish")
+		wg.Wait()
+		log.Infof("Adds finished")
+
+		err := metadata.CheckMetadata("/tmp/cnimeta", "")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Infof("Starting deletes")
+		var wgdel sync.WaitGroup
+		wgdel.Add(count)
+		for ix := 0; ix < count; ix++ {
+			go func(id int) {
+				defer wgdel.Done()
+				name := fmt.Sprintf("pod%d", id)
+				cid := fmt.Sprintf("%d8ec72deca647bfa60a4b815aa735c87de859b47e87", id)
+				err := cniDel(name, cid)
+				if err != nil {
+					t.Error(err)
+				}
+			}(ix)
+		}
+
+		log.Infof("Waiting for deletes")
+		wgdel.Wait()
+		log.Infof("Deletes done")
+
+	}
+	agent.stop()
+}
+
+func cniAdd(podName, cid, ifname string) error {
+
+	md := metadata.ContainerMetadata{
+		Id: metadata.ContainerId{
+			ContId:    cid,
+			Namespace: testPodNS,
+			Pod:       podName,
+		},
+		Ifaces: []*metadata.ContainerIfaceMd{
+			{
+				Name:    ifname,
+				Sandbox: testNetNS,
+			},
+		},
+	}
+
+	eprpc, err := eprpcclient.NewClient(rpcSock, time.Millisecond*500)
+	if err != nil {
+		return err
+	}
+	defer eprpc.Close()
+
+	result, err := eprpc.Register(&md)
+	log.Infof("Result: %+v", result)
+	return err
+}
+
+func cniDel(podName, cid string) error {
+	eprpc, err := eprpcclient.NewClient(rpcSock, time.Millisecond*500)
+	if err != nil {
+		return err
+	}
+
+	defer eprpc.Close()
+	md := metadata.ContainerId{
+		ContId:    cid,
+		Namespace: testPodNS,
+		Pod:       podName,
+	}
+
+	_, err = eprpc.Unregister(&md)
+	return err
+}

--- a/pkg/hostagent/ipam.go
+++ b/pkg/hostagent/ipam.go
@@ -68,6 +68,8 @@ func (agent *HostAgent) updateIpamAnnotation(newPodNetAnnotation string) {
 		return
 	}
 
+	agent.ipamMutex.Lock()
+	defer agent.ipamMutex.Unlock()
 	agent.podIps = ipam.NewIpCache()
 	if newRanges.V4 != nil {
 		agent.podIps.LoadRanges(newRanges.V4)

--- a/pkg/hostagent/ipam.go
+++ b/pkg/hostagent/ipam.go
@@ -123,6 +123,8 @@ func deallocateIp(ip net.IP, free []*ipam.IpAlloc) {
 func (agent *HostAgent) allocateIps(iface *metadata.ContainerIfaceMd) error {
 	var result error
 	var err error
+	agent.ipamMutex.Lock()
+	defer agent.ipamMutex.Unlock()
 
 	for _, nc := range agent.config.NetConfig {
 		if nc.Subnet.IP != nil {
@@ -161,6 +163,8 @@ func (agent *HostAgent) allocateIps(iface *metadata.ContainerIfaceMd) error {
 }
 
 func (agent *HostAgent) deallocateIps(iface *metadata.ContainerIfaceMd) {
+	agent.ipamMutex.Lock()
+	defer agent.ipamMutex.Unlock()
 	for _, ip := range iface.IPs {
 		if ip.Address.IP == nil {
 			continue
@@ -180,6 +184,9 @@ func (agent *HostAgent) deallocateMdIps(md *metadata.ContainerMetadata) {
 		// using external ipam
 		return
 	}
+
+	agent.ipamMutex.Lock()
+	defer agent.ipamMutex.Unlock()
 	for _, iface := range md.Ifaces {
 		for _, ip := range iface.IPs {
 			if ip.Address.IP == nil {

--- a/pkg/metadata/cnimetadata.go
+++ b/pkg/metadata/cnimetadata.go
@@ -83,13 +83,13 @@ func LoadMetadata(datadir string, network string,
 	return nil
 }
 
-func CheckMetadata(datadir string, network string) error {
+func CheckMetadata(datadir string, network string) (int64, error) {
 
 	ipMap := make(map[string]string)
 	dir := filepath.Join(datadir, network)
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	for _, file := range files {
@@ -100,7 +100,7 @@ func CheckMetadata(datadir string, network string) error {
 				for _, ip := range ifc.IPs {
 					curr, ok := ipMap[ip.Address.String()]
 					if ok {
-						return fmt.Errorf("pod: %s alreay has IP: %s, clashes with pod: %s", curr, ip.Address.String(), podId)
+						return 0, fmt.Errorf("pod: %s alreay has IP: %s, clashes with pod: %s", curr, ip.Address.String(), podId)
 					}
 
 					ipMap[ip.Address.String()] = podId
@@ -109,7 +109,7 @@ func CheckMetadata(datadir string, network string) error {
 		}
 	}
 
-	return nil
+	return int64(len(ipMap)), nil
 }
 
 func GetMetadata(datadir string, network string, id string) (*ContainerMetadata, error) {


### PR DESCRIPTION
Addresses duplicate IP addresses and other issues related to agent IPAM.

1. Race conditions due to lack of locking in the IPAM
2. Boundary conditions in the IPAM
3. RPC client close to free fds.

Added an integration test to exercise the interactions between CNI and the agent.