### PR TITLE
Option to add contract scope for k8s services as an annotation

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -446,6 +446,7 @@ var metadata = map[string]*apicMeta{
 	"vzBrCP": {
 		attributes: map[string]interface{}{
 			"name": "",
+			"scope": "context",
 		},
 		children: []string{
 			"vzSubj",

--- a/pkg/controller/cf_environment.go
+++ b/pkg/controller/cf_environment.go
@@ -45,9 +45,9 @@ import (
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/noironetworks/aci-containers/pkg/apicapi"
-	rkv "github.com/noironetworks/aci-containers/pkg/keyvalueservice"
 	"github.com/noironetworks/aci-containers/pkg/cfapi"
 	"github.com/noironetworks/aci-containers/pkg/ipam"
+	rkv "github.com/noironetworks/aci-containers/pkg/keyvalueservice"
 	"github.com/noironetworks/aci-containers/pkg/metadata"
 )
 

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -46,6 +46,9 @@ type NetIps struct {
 // Service endpoint annotation
 const ServiceEpAnnotation = "opflex.cisco.com/service-endpoint"
 
+// Annotation to set service contract scope values. If unset or "", defaults to "context"(VRF). Other valid values: "context", "tenant", and "global"
+const ServiceContractScopeAnnotation = "opflex.cisco.com/ext_service_contract_scope"
+
 // List of IP address ranges for use by the pod network
 const PodNetworkRangeAnnotation = "opflex.cisco.com/pod-network-ranges"
 


### PR DESCRIPTION
Default value: context

For example, add in the service definition:
"metadata": {
  "annotations": {
    "opflex.cisco.com/ext_service_scope" : "tenant"
  }
}

Valid scope values: context, tenant, global. An empty entry defaults to context(VRF only)

If a new service is deployed with invalid scope, it wont register with APIC
If an existing service is updated with invalid scope, the service wont be updated in APIC

Added unit and functional tests to check the contract scope values and service annotations.
Also formatted the committed files with go fmt