### PR TITLE
kubernetes 12 nodes come with default taints

### DIFF
--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -281,9 +281,8 @@ spec:
         - name: {{ config.registry.image_pull_secret|yaml_quote }}
       {% endif %}
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       {% if config.kube_config.use_cnideploy_initcontainer %}
       initContainers:
         - name: cnideploy
@@ -435,9 +434,8 @@ spec:
         - name: {{ config.registry.image_pull_secret|yaml_quote }}
       {% endif %}
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: {{ config.registry.image_prefix }}/openvswitch:{{ config.registry.openvswitch_version }}
@@ -519,9 +517,8 @@ spec:
         - name: {{ config.registry.image_pull_secret|yaml_quote }}
       {% endif %}
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: {{ config.registry.image_prefix }}/aci-containers-controller:{{ config.registry.aci_containers_controller_version }}

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -253,9 +253,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -377,9 +376,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -454,9 +452,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -253,9 +253,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -377,9 +376,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -454,9 +452,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -298,9 +298,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       initContainers:
         - name: cnideploy
           image: noiro/cnideploy:1.9r38
@@ -438,9 +437,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -516,9 +514,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -253,9 +253,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -377,9 +376,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -454,9 +452,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -253,9 +253,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -377,9 +376,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -454,9 +452,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -253,9 +253,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -377,9 +376,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -454,9 +452,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -253,9 +253,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -377,9 +376,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -454,9 +452,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -253,9 +253,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -377,9 +376,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -454,9 +452,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -253,9 +253,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -377,9 +376,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -454,9 +452,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -254,9 +254,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -378,9 +377,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -455,9 +453,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -289,9 +289,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -417,9 +416,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -495,9 +493,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -253,9 +253,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-host
           image: noiro/aci-containers-host:1.9r38
@@ -377,9 +376,8 @@ spec:
       hostIPC: true
       serviceAccountName: aci-containers-host-agent
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-openvswitch
           image: noiro/openvswitch:1.7r24
@@ -454,9 +452,8 @@ spec:
       hostNetwork: true
       serviceAccountName: aci-containers-controller
       tolerations:
-        - key: CriticalAddonsOnly
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        - operator: Exists
+          effect: NoSchedule
       containers:
         - name: aci-containers-controller
           image: noiro/aci-containers-controller:1.9r38


### PR DESCRIPTION
Taints:             node-role.kubernetes.io/master:NoSchedule
                    node.kubernetes.io/not-ready:NoSchedule

As a result aci daemonsets cannot start with the current tolerations
- key: CriticalAddonsOnly
- effect: NoSchedule
  key: node-role.kubernetes.io/master

We change this to tolerate any key with effect NoSchedule.

This is the same approach used by weave and other cni plugins.

Signed-off-by: Madhu Challa "challa@noironetworks.com"

Put a "-" in front of effect to keep prov happy.

Signed-off-by: Madhu Challa "challa@noironetworks.com"

Revert previous change "-" and fix test files.

Signed-off-by: Madhu Challa "challa@noironetworks.com"
(cherry picked from commit 1c13e7d6f1f430c7fcda5b00ef9c20e5e005a249)