### PR TITLE
Supress InsecureRequestWarning (part deux)

### DIFF
--- a/provision/acc_provision/apic_provision.py
+++ b/provision/acc_provision/apic_provision.py
@@ -9,6 +9,11 @@ import urllib3
 import ipaddress
 
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+try:
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+except Exception:
+    pass
 apic_debug = False
 apic_cookies = {}
 apic_default_timeout = (15, 90)


### PR DESCRIPTION
An earlier commit tried to do this, but it doesn't work for
versions of Requests which have their own reference to urllib3.
This commit attempts to fix that.

(cherry picked from commit 2c49b82fd1322f4d87d9c27126b2dc7c49e38da3)