### PR TITLE
Added code to support PodIpPoolChunkSize configuration in controller and acc-provision

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -134,7 +134,7 @@ type ControllerConfig struct {
 	PodIpPool []ipam.IpRange `json:"pod-ip-pool,omitempty"`
 
 	// The number of IP addresses to allocate when a pod starts to run low
-	PodIpPoolChunkSize int `json:"pod-ip-pool-chunk-size,omitempty"`
+	PodIpPoolChunkSize int `json:"pod-subnet-chunk-size,omitempty"`
 
 	// Pod subnet CIDRs in the form <gateway-address>/<prefix-length> that
 	// cover all pod-ip-pools
@@ -180,7 +180,6 @@ func NewConfig() *ControllerConfig {
 		AciVmmDomainType:   "Kubernetes",
 		AciPolicyTenant:    "kubernetes",
 		AciPrefix:          "kube",
-		PodIpPoolChunkSize: 32,
 		AllocateServiceIps: &t,
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -323,6 +323,13 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		panic(err)
 	}
 	cont.log.Info("ApicRefreshTimer conf is set to: ", refreshTimeout)
+
+	// If not defined, default to 32
+	if cont.config.PodIpPoolChunkSize == 0 {
+		cont.config.PodIpPoolChunkSize = 32
+	}
+	cont.log.Info("PodIpPoolChunkSize conf is set to: ", cont.config.PodIpPoolChunkSize)
+
 	cont.apicConn, err = apicapi.New(cont.log, cont.config.ApicHosts,
 		cont.config.ApicUsername, cont.config.ApicPassword,
 		privKey, apicCert, cont.config.AciPrefix,

--- a/pkg/controller/nodes_test.go
+++ b/pkg/controller/nodes_test.go
@@ -320,7 +320,6 @@ func TestNodeNetPol(t *testing.T) {
 
 func TestPodNetAnnotUpgrade(t *testing.T) {
 	cont := testController()
-	cont.config.PodIpPoolChunkSize = 32
 	cont.config.PodIpPool = []ipam.IpRange{
 		{Start: net.ParseIP("10.128.2.2"), End: net.ParseIP("10.128.16.1")},
 	}

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -126,6 +126,7 @@ def config_default():
         "net_config": {
             "node_subnet": None,
             "pod_subnet": None,
+            "pod_subnet_chunk_size": 32,
             "extern_dynamic": None,
             "extern_static": None,
             "node_svc_subnet": None,

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -57,6 +57,7 @@ data:
         "allocate-service-ips": false,
         {% endif %}
         "pod-ip-pool": {{ config.kube_config.pod_ip_pool|json|indent(width=8) }},
+        "pod-subnet-chunk-size": {{ config.net_config.pod_subnet_chunk_size|json }},
         "node-service-ip-pool": {{ config.kube_config.node_service_ip_pool|json|indent(width=8) }},
         "node-service-subnets": {{ config.kube_config.node_service_gw_subnets|json|indent(width=8) }}
     }

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "1:2:1:1::2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "1:5:1:1::ffff:fffe",

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -70,6 +70,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",

--- a/provision/testdata/with_overrides.inp.yaml
+++ b/provision/testdata/with_overrides.inp.yaml
@@ -31,6 +31,7 @@ aci_config:
 net_config:
   node_subnet: 10.1.0.1/16
   pod_subnet: 10.1.0.1/16
+  pod_subnet_chunk_size: 24
   extern_dynamic: 10.4.0.1/16
   extern_static: 10.3.0.1/24
   node_svc_subnet: 10.6.0.1/24

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -60,6 +60,7 @@ data:
                 "start": "10.1.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 24,
         "node-service-ip-pool": [
             {
                 "end": "10.6.0.254",

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -59,6 +59,7 @@ data:
                 "start": "10.2.0.2"
             }
         ],
+        "pod-subnet-chunk-size": 32,
         "node-service-ip-pool": [
             {
                 "end": "10.5.0.254",


### PR DESCRIPTION
To enable, add the "pod_subnet_chunk_size" field in the input acc provisioning file. Default value: 32

If the PodIpPoolChunkSize is changed:
1. Existing annotations for the pod IP pool on the nodes will not change.
2. The new pod IP pool size will reflect only when a new annotation is applied by the controller after the pool defined by the existing annotation is exhausted.

(cherry picked from commit 6eee85780930841a1291a9c05579d3028b4c6bbe)