### PR TITLE
Fix handling of podnet annotation update, by using consistent data

### DIFF
--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -49,6 +49,7 @@ type HostAgent struct {
 
 	podNetAnnotation string
 	podIps           *ipam.IpCache
+	usedIPs          map[string]bool
 
 	syncEnabled         bool
 	opflexConfigWritten bool
@@ -93,6 +94,7 @@ func (agent *HostAgent) Init() {
 		panic(err.Error())
 	}
 	agent.log.Info("Loaded cached endpoint CNI metadata: ", len(agent.epMetadata))
+	agent.buildUsedIPs()
 
 	err = agent.env.Init(agent)
 	if err != nil {
@@ -177,11 +179,6 @@ func (agent *HostAgent) Run(stopCh <-chan struct{}) {
 	if err != nil {
 		panic(err.Error())
 	}
-
-	agent.log.Debug("Building IP address management database")
-	agent.indexMutex.Lock()
-	agent.rebuildIpam()
-	agent.indexMutex.Unlock()
 
 	if agent.config.OpFlexEndpointDir == "" ||
 		agent.config.OpFlexServiceDir == "" {

--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -76,6 +76,7 @@ func testAgent() *testHostAgent {
 			ListFunc:  agent.fakeServiceSource.List,
 			WatchFunc: agent.fakeServiceSource.Watch,
 		})
+	agent.usedIPs = make(map[string]bool)
 
 	return agent
 }

--- a/pkg/hostagent/nodes_test.go
+++ b/pkg/hostagent/nodes_test.go
@@ -144,6 +144,7 @@ func TestBuildIpam(t *testing.T) {
 			}
 			agent.epMetadata[podid][ep.Id.ContId] = &ep
 		}
+		agent.buildUsedIPs()
 		agent.indexMutex.Unlock()
 		agent.fakeNodeSource.Add(node(test.annotation))
 

--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -325,7 +325,9 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 		logger.Debug("Configuring network for ", iface.Name, ": ", *result)
 		err = runSetupNetwork(logger, iface.Sandbox, iface.Name, result)
 		if err != nil {
-			agent.deallocateIps(iface)
+			agent.ipamMutex.Lock()
+			agent.deallocateIpsLocked(iface)
+			agent.ipamMutex.Unlock()
 			return nil, err
 		}
 	}

--- a/pkg/ipam/ipcache.go
+++ b/pkg/ipam/ipcache.go
@@ -93,17 +93,24 @@ func (iplists *IpCache) LoadRanges(ipranges []IpRange) {
 	}
 }
 
-//Removes the IP from the respective IpCache
-func (iplists *IpCache) RemoveIp(ip net.IP) {
+// Removes the IP from the respective IpCache
+// Returns true if successful
+func (iplists *IpCache) RemoveIp(ip net.IP) bool {
 	if ip.To4() != nil {
 		for _, ipa := range iplists.cacheIpsV4 {
-			ipa.RemoveIp(ip)
+			if ipa.RemoveIp(ip) {
+				return true
+			}
 		}
 	} else if ip.To16() != nil {
 		for _, ipa := range iplists.cacheIpsV6 {
-			ipa.RemoveIp(ip)
+			if ipa.RemoveIp(ip) {
+				return true
+			}
 		}
 	}
+
+	return false
 }
 
 //Combines the 2 V4 lists into 1 list


### PR DESCRIPTION
Podnet annotation update causes IPAM cache to be messed up because there is in-flight data. Fix it by using local data under lock protection.