### PR TITLE
Option to pass flavors.yaml as a URL or a filepath 

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 from __future__ import print_function, unicode_literals
 
 import argparse
@@ -7,6 +6,7 @@ import base64
 import copy
 import functools
 import ipaddress
+import requests
 import json
 import os
 import os.path
@@ -18,31 +18,12 @@ import uuid
 import pkg_resources
 import pkgutil
 import yaml
+from yaml import SafeLoader
 
 from OpenSSL import crypto
 from .apic_provision import Apic, ApicKubeConfig
 from jinja2 import Environment, PackageLoader
 from os.path import exists
-
-
-VERSION_FIELDS = [
-    "cnideploy_version",
-    "aci_containers_host_version",
-    "opflex_agent_version",
-    "aci_containers_controller_version",
-    "openvswitch_version",
-]
-
-with open("acc_provision/flavors.yaml", 'r') as stream:
-        try:
-                doc = yaml.load(stream)
-        except yaml.YAMLError as exc:
-                print(exc)
-        DEFAULT_FLAVOR = doc['default_flavor']
-        VERSIONS = doc['versions']
-        DEFAULT_FLAVOR_OPTIONS = doc['kubeFlavorOptions']
-        CfFlavorOptions = doc['cfFlavorOptions']
-        FLAVORS = doc['flavors']
 
 
 def info(msg):
@@ -155,8 +136,21 @@ def config_default():
             "hostagent_log_level": "info",
             "opflexagent_log_level": "info",
         },
+        "flavors_url": {
+            "path": "",
+        },
     }
     return default_config
+
+
+# Adding a constructor to yaml SafeLoader so that it always overrides
+# the PyYAML handling of strings. For eg, strings like '10.0.0.0/24'
+# in our user input YAML files which contain masks. 
+def construct_yaml_str(self, node):
+    return self.construct_scalar(node)
+
+
+SafeLoader.add_constructor(u'tag:yaml.org,2002:str', construct_yaml_str)
 
 
 def config_user(config_file):
@@ -164,7 +158,7 @@ def config_user(config_file):
     if config_file:
         if config_file == "-":
             info("Loading configuration from \"STDIN\"")
-            config = yaml.load(sys.stdin)
+            config = yaml.safe_load(sys.stdin)
         else:
             info("Loading configuration from \"%s\"" % config_file)
 
@@ -177,7 +171,7 @@ def config_user(config_file):
                 return self.construct_scalar(node)
             yaml.Loader.add_constructor(u'tag:yaml.org,2002:str', construct_yaml_str)
             with open(config_file, 'r') as file:
-                config = yaml.load(file)
+                config = yaml.safe_load(file)
     if config is None:
         config = {}
     return config
@@ -723,9 +717,6 @@ networks:
     return config
 
 
-CfFlavorOptions['template_generator'] = generate_cf_yaml
-
-
 def generate_apic_config(flavor_opts, config, prov_apic, apic_file):
     configurator = ApicKubeConfig(config)
     for k, v in flavor_opts.get("apic", {}).items():
@@ -838,8 +829,8 @@ def parse_args():
 def provision(args, apic_file, no_random):
     config_file = args.config
     output_file = args.output
-
     prov_apic = None
+
     if args.apic:
         prov_apic = True
     if args.delete:
@@ -950,10 +941,86 @@ def provision(args, apic_file, no_random):
     return ret
 
 
+DEFAULT_FLAVORS_PATH = os.path.dirname(os.path.realpath(__file__)) + "/flavors.yaml"
+VERSION_FIELDS = [
+    "cnideploy_version",
+    "aci_containers_host_version",
+    "opflex_agent_version",
+    "aci_containers_controller_version",
+    "openvswitch_version",
+]
+
+
+def check_yaml(text_to_verify):
+    try:
+        flavors_yaml = yaml.safe_load(text_to_verify)
+        if 'default_flavor' in flavors_yaml:
+            return flavors_yaml
+    except yaml.YAMLError as exc:
+        print(exc)
+        raise Exception
+
+
+def default_flavors_path():
+    with open(DEFAULT_FLAVORS_PATH, 'r') as res:
+        info("Loading flavors from default flavors.yaml: " + DEFAULT_FLAVORS_PATH)
+        valid_yaml = check_yaml(res)
+        if valid_yaml:
+            set_flavors(valid_yaml)
+    return
+
+
+def get_flavors(flavors_url):
+    if flavors_url == 'blah':
+        return default_flavors_path()
+    flag = False
+    try:
+        # try as a URL
+        res = requests.get(flavors_url)
+        valid_yaml = check_yaml(res.text)
+        info("Loading flavors from URL: " + flavors_url)
+        set_flavors(valid_yaml)
+        flag = True
+
+    except Exception:
+        try:
+            # try as a local file
+            with open(flavors_url, 'r') as res:
+                valid_yaml = check_yaml(res)
+                info("Loading flavors from local file: " + flavors_url)
+                set_flavors(valid_yaml)
+                flag = True
+        except Exception:
+            info("Unable to load flavors from path: " + flavors_url)
+
+    finally:
+        # try the static file in repo
+        if not flag:
+            return default_flavors_path()
+
+
+def set_flavors(doc):
+    global DEFAULT_FLAVOR, VERSIONS, DEFAULT_FLAVOR_OPTIONS, CfFlavorOptions, FLAVORS
+    DEFAULT_FLAVOR = doc['default_flavor']
+    VERSIONS = doc['versions']
+    DEFAULT_FLAVOR_OPTIONS = doc['kubeFlavorOptions']
+    CfFlavorOptions = doc['cfFlavorOptions']
+    CfFlavorOptions['template_generator'] = generate_cf_yaml
+    FLAVORS = doc['flavors']
+
+
 def main(args=None, apic_file=None, no_random=False):
     # apic_file and no_random are used by the test functions
     if args is None:
         args = parse_args()
+
+    config = config_user(args.config)
+    if config:
+        if 'flavors_url' not in config:
+            config['flavors_url'] = {}
+            config['flavors_url']['path'] = "blah"
+        flavors_url = config['flavors_url']['path']
+        get_flavors(flavors_url)
 
     if args.list_flavors:
         info("Available configuration flavors:")

--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -1,4 +1,4 @@
-default_flavor: kubernetes-1.10
+default_flavor: kubernetes-1.12
 
 versions: 
   1.6: 

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -27,6 +27,15 @@ def in_testdir(f):
 
 
 @in_testdir
+def test_flavors_base_case():
+    run_provision(
+        "flavor_wrong_url.inp.yaml",
+        "base_case.kube.yaml",
+        "base_case.apic.txt"
+    )
+
+
+@in_testdir
 def test_base_case():
     run_provision(
         "base_case.inp.yaml",

--- a/provision/testdata/devnull.stderr.txt
+++ b/provision/testdata/devnull.stderr.txt
@@ -1,4 +1,4 @@
-INFO: Using configuration flavor kubernetes-1.10
+INFO: Using configuration flavor kubernetes-1.12
 ERR:  Invalid configuration for aci_config/aep: Missing option
 ERR:  Invalid configuration for aci_config/apic_host: Missing option
 ERR:  Invalid configuration for aci_config/l3out/external-networks: Missing option

--- a/provision/testdata/flavor_wrong_url.inp.yaml
+++ b/provision/testdata/flavor_wrong_url.inp.yaml
@@ -1,0 +1,53 @@
+aci_config:
+  system_id: kube
+  apic_hosts:
+    - 10.30.120.100
+  apic_login:
+    username: admin
+    password: noir0123
+  aep: kube-aep
+  vrf:
+    name: kube
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+kube_config:
+  controller: 1.1.1.1
+  use_cluster_role: true
+  use_ds_rolling_update: true
+
+registry:
+  image_prefix: noiro
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+#could be a URL address or a local path
+flavors_url:
+  path: https://random-wrong-url


### PR DESCRIPTION
Adding option to pass flavors.yaml (for acc_provision.py) as a URL or a filepath 

The path/URL can be added to the user config input file as:
flavors_url:
   path: respective_path/url

The filepath/URL is handled in this sequence:
1. Check if it's a valid URL with valid yaml format. Simple check added: if the yaml has the 'default_flavor' field -- suggestions welcome
2. If 1. fails, do a similar check assuming flavors_url is a local filepath.
3. If both fail, default to the acc_provision/flavors.yaml saved in our repo.

Also, added a testdata/flavors_url.inp.yaml with an illegal URL address as flavors_url. 
In future, when we do have a hosted yaml online, can add a test with the correct URL too. 