### PR TITLE
Option to pass flavors.yaml as a URL or a filepath

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -1,4 +1,4 @@
-default_flavor: kubernetes-1.10
+default_flavor: kubernetes-1.12
 
 versions: 
   1.6: 

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -36,6 +36,15 @@ def test_base_case():
 
 
 @in_testdir
+def test_flavors_base_case():
+    run_provision(
+        "flavor_wrong_url.inp.yaml",
+        "base_case.kube.yaml",
+        "base_case.apic.txt"
+    )
+
+
+@in_testdir
 def test_base_case_ipv6():
     run_provision(
         "base_case_ipv6.inp.yaml",

--- a/provision/testdata/devnull.stderr.txt
+++ b/provision/testdata/devnull.stderr.txt
@@ -1,4 +1,4 @@
-INFO: Using configuration flavor kubernetes-1.10
+INFO: Using configuration flavor kubernetes-1.12
 ERR:  Invalid configuration for aci_config/aep: Missing option
 ERR:  Invalid configuration for aci_config/apic_host: Missing option
 ERR:  Invalid configuration for aci_config/l3out/external-networks: Missing option

--- a/provision/testdata/flavor_wrong_url.inp.yaml
+++ b/provision/testdata/flavor_wrong_url.inp.yaml
@@ -1,0 +1,53 @@
+aci_config:
+  system_id: kube
+  apic_hosts:
+    - 10.30.120.100
+  apic_login:
+    username: admin
+    password: noir0123
+  aep: kube-aep
+  vrf:
+    name: kube
+    tenant: common
+  l3out:
+    name: l3out
+    external_networks:
+    - default
+  sync_login:
+    certfile: user.crt
+    keyfile: user.key
+  vmm_domain:
+    encap_type: vxlan
+    mcast_range:
+        start: 225.2.1.1
+        end: 225.2.255.255
+  custom_epgs:
+    - group1
+    - group2
+
+net_config:
+  node_subnet: 10.1.0.1/16
+  pod_subnet: 10.2.0.1/16
+  extern_dynamic: 10.3.0.1/24
+  extern_static: 10.4.0.1/24
+  node_svc_subnet: 10.5.0.1/24
+  kubeapi_vlan: 4001
+  service_vlan: 4003
+  infra_vlan: 4093
+
+kube_config:
+  controller: 1.1.1.1
+  use_cluster_role: true
+  use_ds_rolling_update: true
+
+registry:
+  image_prefix: noiro
+
+logging:
+  controller_log_level: info
+  hostagent_log_level: info
+  opflexagent_log_level: info
+
+#could be a URL address or a local path
+flavors_url:
+  path: https://random-wrong-url


### PR DESCRIPTION
- Add option to pass flavors.yaml (for acc_provision.py) as a URL or a filepath

  The path/URL can be added to the user config input file as:
  flavors_url:
    path: respective_path/url

  The filepath/URL is handled in this sequence:

  1. Check if it's a valid URL with valid yaml format. Simple check added: if the yaml has the 'default_flavor' field -- suggestions welcome
  2. If 1. fails, do a similar check assuming flavors_url is a local filepath.
  3. If both fail, default to the acc_provision/flavors.yaml saved in our repo.

- Change the default flavor from kubernetes-1.10 to kubernetes-1.12

- Add a testdata/flavors_url.inp.yaml with an illegal URL address as flavors_url.
  In future, when we do have a hosted yaml online, can add a test with the correct URL too.

- Add function to safely load YAMLs in acc_provision.py
  Overriding the default PyYAML handling of strings to always output unicode