### PR TITLE
Removing cluster-info dump command from acikubectl cluster-report

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -120,10 +120,6 @@ func clusterReport(cmd *cobra.Command, args []string) {
 			name: "cluster-report/status/cluster-info.log",
 			args: []string{"cluster-info"},
 		},
-		{
-			name: "cluster-report/status/cluster-dump.log",
-			args: []string{"cluster-info", "dump"},
-		},
 	}
 
 	nodes, err :=


### PR DESCRIPTION
(cherry picked from commit 99078b16d8442e7a1a245682bf880fd9b174f1d6)