### PR TITLE
Change acc provision to only allow VERSIONS to be set externally

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -51,21 +51,25 @@ flavors:
     default_version: 1.9
     status: null
     hidden: false
+    order: 3
   kubernetes-1.11:
     desc: Kubernetes 1.11
     default_version: 1.9
     status: null
     hidden: false
+    order: 4
   kubernetes-1.10:
     desc: Kubernetes 1.10
     default_version: 1.9
     status: null
     hidden: true
+    order: 5
   kubernetes-1.9:
     desc: Kubernetes 1.9
     default_version: 1.9
     status: null
     hidden: true
+    order: 6
   kubernetes-1.8:
     desc: Kubernetes 1.8
     default_version: 1.7
@@ -75,6 +79,7 @@ flavors:
         use_apps_apigroup: apps
     status: null
     hidden: true
+    order: 7
   kubernetes-1.7:
     desc: Kubernetes 1.7
     default_version: 1.7
@@ -84,7 +89,8 @@ flavors:
         use_apps_api: extensions/v1beta1
         use_apps_apigroup: extensions
     status: null
-    hidden: true  
+    hidden: true
+    order: 8  
   kubernetes-1.6:
     desc: Kubernetes 1.6
     default_version: 1.6
@@ -96,7 +102,8 @@ flavors:
         use_netpol_annotation: True
         use_netpol_apigroup: extensions
     status: null
-    hidden: true  
+    hidden: true
+    order: 9
   openshift-3.11:
     desc: Red Hat OpenShift Container Platform 3.11
     default_version: 1.9
@@ -114,6 +121,7 @@ flavors:
           type: OpenShift
     status: Experimental
     hidden: false
+    order: 11
   openshift-3.9:
     desc: Red Hat OpenShift Container Platform 3.9
     default_version: 1.9
@@ -131,6 +139,7 @@ flavors:
           type: OpenShift
     status: null
     hidden: false
+    order: 1
   openshift-3.6:
     desc: Red Hat OpenShift Container Platform 3.6
     default_version: 1.6
@@ -153,12 +162,14 @@ flavors:
           type: OpenShift
     status: null
     hidden: true
+    order: 2
   # Docker Universal Control Plane (UCP)
   docker-ucp-3.0:
     desc: Docker Universal Control Plane (UCP) 3.0
     default_version: 1.9
     status: Experimental
     hidden: false
+    order: 12
   # CloudFoundry
   cloudfoundry-1.0:
     desc: CloudFoundry cf-deployment 1.x
@@ -170,3 +181,4 @@ flavors:
     options: *anchor
     status: null
     hidden: false
+    order: 10

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -36,9 +36,9 @@ def test_base_case():
 
 
 @in_testdir
-def test_flavors_base_case():
+def test_versions_base_case():
     run_provision(
-        "flavor_wrong_url.inp.yaml",
+        "version_wrong_url.inp.yaml",
         "base_case.kube.yaml",
         "base_case.apic.txt"
     )

--- a/provision/testdata/version_wrong_url.inp.yaml
+++ b/provision/testdata/version_wrong_url.inp.yaml
@@ -49,5 +49,5 @@ logging:
   opflexagent_log_level: info
 
 #could be a URL address or a local path
-flavors_url:
+versions_url:
   path: https://random-wrong-url


### PR DESCRIPTION
1. Instead of FLAVORS and VERSIONS both being set using a URL/filepath, now FLAVORS is imported from flavors.yaml.

  The user can provide path to the VERSIONS by adding to their config:
  versions_url:
      path: <required_path>

2. Change to ensure all "Experimental" flavors come later in the output of acc-provision --list-flavors

3. Running acc-provision without any arguments returns help

(cherry picked from commit 0d2e159625bd4e50fd998f1c50e34510ab715810)