### PR TITLE
Bump acc-provision to 1.9.9 and images to 43 and 80

### DIFF
--- a/provision/acc_provision/flavors.yaml
+++ b/provision/acc_provision/flavors.yaml
@@ -14,10 +14,10 @@ versions:
     opflex_agent_version: 1.7r70
     openvswitch_version: 1.7r24
   1.9:
-    cnideploy_version: 1.9r38
-    aci_containers_host_version: 1.9r38
-    aci_containers_controller_version: 1.9r38
-    opflex_agent_version: 1.9r69
+    cnideploy_version: 1.9r43
+    aci_containers_host_version: 1.9r43
+    aci_containers_controller_version: 1.9r43
+    opflex_agent_version: 1.9r80
     openvswitch_version: 1.7r24
 
 # Known Flavor options:

--- a/provision/setup.py
+++ b/provision/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='acc_provision',
-    version='1.9.8',
+    version='1.9.9',
     description='Tool to provision ACI for ACI Containers Controller',
     author="Cisco Systems, Inc.",
     author_email="apicapi@noironetworks.com",

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -303,7 +303,7 @@ spec:
           effect: NoSchedule
       initContainers:
         - name: cnideploy
-          image: noiro/cnideploy:1.9r38
+          image: noiro/cnideploy:1.9r43
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -315,7 +315,7 @@ spec:
               mountPath: /mnt/cni-bin
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -348,7 +348,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -367,7 +367,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -519,7 +519,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -259,7 +259,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -291,7 +291,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -309,7 +309,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -458,7 +458,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -294,7 +294,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -327,7 +327,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             privileged: true
@@ -346,7 +346,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -498,7 +498,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -258,7 +258,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-host
-          image: noiro/aci-containers-host:1.9r38
+          image: noiro/aci-containers-host:1.9r43
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -290,7 +290,7 @@ spec:
               path: /status
               port: 8090
         - name: opflex-agent
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           imagePullPolicy: Always
           securityContext:
             capabilities:
@@ -308,7 +308,7 @@ spec:
             - name: opflex-config-volume
               mountPath: /usr/local/etc/opflex-agent-ovs/conf.d
         - name: mcast-daemon
-          image: noiro/opflex:1.9r69
+          image: noiro/opflex:1.9r80
           command: ["/bin/sh"]
           args: ["/usr/local/bin/launch-mcastdaemon.sh"]
           imagePullPolicy: Always
@@ -457,7 +457,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: aci-containers-controller
-          image: noiro/aci-containers-controller:1.9r38
+          image: noiro/aci-containers-controller:1.9r43
           imagePullPolicy: Always
           volumeMounts:
             - name: controller-config-volume


### PR DESCRIPTION
More specifically:

image: noiro/aci-containers-controller:1.9r43
image: noiro/aci-containers-host:1.9r43
image: noiro/openvswitch:1.7r24
image: noiro/opflex:1.9r80
(cherry picked from commit 07f46ad327c5cdd34cf63a674359ecbd68be1962)