### PR TITLE
Add functionality to get release info from acikubectl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,13 @@ BUILD_CMD ?= go build -v
 TEST_CMD ?= go test -cover
 TEST_ARGS ?=
 INSTALL_CMD ?= go install -v
+GIT_COMMIT=$(shell scripts/getGitCommit.sh)
+PKG_NAME=github.com/noironetworks/aci-containers/pkg/controller
 STATIC_BUILD_CMD ?= CGO_ENABLED=0 GOOS=linux ${BUILD_CMD} \
-	-ldflags="-s -w" -a -installsuffix cgo
+        -ldflags="\
+        -X ${PKG_NAME}.buildTime=$(shell date -u +%m-%d-%Y.%H:%M:%S.UTC) \
+        -X ${PKG_NAME}.gitCommit=${GIT_COMMIT} \
+         -s -w" -a -installsuffix cgo
 DOCKER_BUILD_CMD ?= docker build
 VENDOR_BUILD_CMD ?= dep ensure -v
 

--- a/cmd/acikubectl/cmd/default.go
+++ b/cmd/acikubectl/cmd/default.go
@@ -28,14 +28,8 @@ import (
 
 func updateObjectAnnot(annot string, newValue string, cmd *cobra.Command,
 	args []string) {
-	kubeClient, err := initClient()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Could not initialize kubernetes client:")
-		fmt.Fprintln(os.Stderr, err)
-		if kubeconfig == "" {
-			fmt.Fprintln(os.Stderr,
-				"You may need to specify a kubeconfig file with --kubeconfig.")
-		}
+	kubeClient := initClientPrintError()
+	if kubeClient == nil {
 		return
 	}
 
@@ -131,14 +125,8 @@ func updateObjectAnnot(annot string, newValue string, cmd *cobra.Command,
 
 func getObjectAnnot(annot string, format func(string),
 	cmd *cobra.Command, args []string) {
-	kubeClient, err := initClient()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Could not initialize kubernetes client:")
-		fmt.Fprintln(os.Stderr, err)
-		if kubeconfig == "" {
-			fmt.Fprintln(os.Stderr,
-				"You may need to specify a kubeconfig file with --kubeconfig.")
-		}
+	kubeClient := initClientPrintError()
+	if kubeClient == nil {
 		return
 	}
 

--- a/cmd/acikubectl/cmd/version.go
+++ b/cmd/acikubectl/cmd/version.go
@@ -1,0 +1,66 @@
+// Copyright © 2019 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"strings"
+)
+
+func getVersion(cmd *cobra.Command, args []string) {
+	if len(args) != 0 {
+		fmt.Fprintln(os.Stderr, "More arguments than required")
+		return
+	}
+	kubeClient := initClientPrintError()
+	if kubeClient == nil {
+		return
+	}
+	systemNamespace, err := findSystemNamespace(kubeClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Could not find aci-containers system namespace:", err)
+		return
+	}
+	systemNamespacePods, err1 := kubeClient.CoreV1().Pods(systemNamespace).List(metav1.ListOptions{})
+	if err1 != nil {
+		fmt.Fprintln(os.Stderr, "Could not list pods:", err1)
+	}
+	for _, pod := range systemNamespacePods.Items {
+		if strings.Contains(pod.Name, "aci-containers-controller") {
+			buffer := new(bytes.Buffer)
+			mylist := []string{"exec", "-n" + systemNamespace, pod.Name, "--", "/bin/sh", "-c", "aci-containers-controller -version"}
+			execKubectl(mylist, buffer)
+			trimString := strings.TrimSpace(buffer.String())
+			fmt.Println(trimString)
+			break
+		}
+	}
+}
+
+var versionCmd = &cobra.Command{
+	Use:     "version",
+	Short:   "Print the client and server versions for the current context acikubectl version",
+	Example: `acikubectl version`,
+	Run:     getVersion,
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -15,9 +15,11 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -35,7 +37,18 @@ func main() {
 	controller.InitFlags(config)
 	configPath := flag.String("config-path", "",
 		"Absolute path to a host agent configuration file")
+	version := flag.Bool("version", false, "prints github commit ID and build time")
 	flag.Parse()
+
+	if *version {
+		if controller.GetVersion().GitCommit != "" {
+			buffer := bytes.NewBufferString(controller.VersionString())
+			fmt.Println(buffer.String())
+		} else {
+			fmt.Println("Information missing in current build")
+		}
+		os.Exit(0)
+	}
 
 	if configPath != nil && *configPath != "" {
 		log.Info("Loading configuration from ", *configPath)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -274,6 +274,11 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	var err error
 	var privKey []byte
 	var apicCert []byte
+
+	if gitCommit != "" {
+		cont.log.Info("Running controller built from git commit ID " + gitCommit + "at build time " + buildTime)
+	}
+
 	if cont.config.ApicPrivateKeyPath != "" {
 		privKey, err = ioutil.ReadFile(cont.config.ApicPrivateKeyPath)
 		if err != nil {

--- a/pkg/controller/version.go
+++ b/pkg/controller/version.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import "fmt"
+
+// Variables set during build time for release info
+var (
+	gitCommit string
+	buildTime string
+)
+
+// Info enlists version and build information
+type VersionInfo struct {
+	GitCommit string
+	BuildTime string
+}
+
+// Get gets the version information
+func GetVersion() *VersionInfo {
+	ver := VersionInfo{}
+	ver.GitCommit = gitCommit
+	ver.BuildTime = buildTime
+
+	return &ver
+}
+
+// String returns printable version string
+func VersionString() string {
+	ver := GetVersion()
+	return StringFromInfo(ver)
+}
+
+// StringFromInfo prints the versioning details
+func StringFromInfo(ver *VersionInfo) string {
+	return fmt.Sprintf("GitCommit: %s\n", ver.GitCommit) +
+		fmt.Sprintf("BuildTime: %s\n", ver.BuildTime)
+}

--- a/scripts/getGitCommit.sh
+++ b/scripts/getGitCommit.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if command -v git &>/dev/null && git rev-parse &>/dev/null; then
+    GIT_COMMIT=$(git rev-parse HEAD)
+    echo $GIT_COMMIT
+    exit 0
+fi
+echo >&2 'error: unable to determine the git revision'
+exit 1


### PR DESCRIPTION
To get the git commit ID and build time, run on any host:
acikubectl version
or
acikubectl version --kubeconfig=<path>

Git commit info is saved inside the aci-containers-controller container and can be accessed by running "aci-containers-controller --version"

Also, replaced redundant code for initClient() with existing func initClientPrintError()

(cherry picked from commit ea022de6d30a0e4c101a496f3fe36b876efe3fc8)