### PR TITLE
Added missing RBAC policies for host-agent

### DIFF
--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -58,14 +58,14 @@ with open(VERSIONS_PATH, 'r') as stream:
     VERSIONS = doc['versions']
 
 with open(FLAVORS_PATH, 'r') as stream:
-        try:
-            doc = yaml.safe_load(stream)
-        except yaml.YAMLError as exc:
-            print(exc)
-        DEFAULT_FLAVOR = doc['default_flavor']
-        DEFAULT_FLAVOR_OPTIONS = doc['kubeFlavorOptions']
-        CfFlavorOptions = doc['cfFlavorOptions']
-        FLAVORS = doc['flavors']
+    try:
+        doc = yaml.safe_load(stream)
+    except yaml.YAMLError as exc:
+        print(exc)
+    DEFAULT_FLAVOR = doc['default_flavor']
+    DEFAULT_FLAVOR_OPTIONS = doc['kubeFlavorOptions']
+    CfFlavorOptions = doc['cfFlavorOptions']
+    FLAVORS = doc['flavors']
 
 
 def info(msg):
@@ -856,23 +856,23 @@ def parse_args(show_help):
 
 
 def get_versions(versions_url):
-        global VERSIONS
-        try:
-            # try as a URL
-            res = requests.get(versions_url)
-            versions_yaml = yaml.safe_load(res)
-            info("Loading versions from URL: " + versions_url)
-            VERSIONS = versions_yaml['versions']
+    global VERSIONS
+    try:
+        # try as a URL
+        res = requests.get(versions_url)
+        versions_yaml = yaml.safe_load(res)
+        info("Loading versions from URL: " + versions_url)
+        VERSIONS = versions_yaml['versions']
 
+    except Exception:
+        try:
+            # try as a local file
+            with open(versions_url, 'r') as res:
+                versions_yaml = yaml.safe_load(res)
+                info("Loading versions from local file: " + versions_url)
+                VERSIONS = versions_yaml['versions']
         except Exception:
-            try:
-                # try as a local file
-                with open(versions_url, 'r') as res:
-                    versions_yaml = yaml.safe_load(res)
-                    info("Loading versions from local file: " + versions_url)
-                    VERSIONS = versions_yaml['versions']
-            except Exception:
-                info("Unable to load versions from path: " + versions_url)
+            info("Unable to load versions from path: " + versions_url)
 
 
 def provision(args, apic_file, no_random):

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -188,9 +188,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/acc_provision/templates/aci-containers.yaml
+++ b/provision/acc_provision/templates/aci-containers.yaml
@@ -167,14 +167,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: {{ config.kube_config.use_rbac_api }}
 kind: ClusterRole

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/base_case.kube.yaml
+++ b/provision/testdata/base_case.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/base_case_ipv6.kube.yaml
+++ b/provision/testdata/base_case_ipv6.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -210,9 +210,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/flavor_openshift.kube.yaml
+++ b/provision/testdata/flavor_openshift.kube.yaml
@@ -189,14 +189,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -219,7 +211,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -227,7 +219,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/nested-portgroup.kube.yaml
+++ b/provision/testdata/nested-portgroup.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/nested-vlan.kube.yaml
+++ b/provision/testdata/nested-vlan.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/nested-vxlan.kube.yaml
+++ b/provision/testdata/nested-vxlan.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/pod_ext_access.kube.yaml
+++ b/provision/testdata/pod_ext_access.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/sample.kube.yaml
+++ b/provision/testdata/sample.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/vlan_case.kube.yaml
+++ b/provision/testdata/vlan_case.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/with_comments.kube.yaml
+++ b/provision/testdata/with_comments.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -179,14 +179,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -209,7 +201,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -217,7 +209,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/with_interface_mtu.kube.yaml
+++ b/provision/testdata/with_interface_mtu.kube.yaml
@@ -200,9 +200,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -180,14 +180,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -210,7 +202,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -218,7 +210,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/with_overrides.kube.yaml
+++ b/provision/testdata/with_overrides.kube.yaml
@@ -201,9 +201,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -178,14 +178,6 @@ rules:
   - list
   - watch
   - get
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - nodes
-  - services/status
-  verbs:
-  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -208,7 +200,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_netpol_apigroup }}"
+  - "networking.k8s.io"
   resources:
   - networkpolicies
   verbs:
@@ -216,7 +208,7 @@ rules:
   - watch
   - get
 - apiGroups:
-  - "{{ config.kube_config.use_apps_apigroup }}"
+  - "apps"
   resources:
   - deployments
   - replicasets

--- a/provision/testdata/with_tenant_l3out.kube.yaml
+++ b/provision/testdata/with_tenant_l3out.kube.yaml
@@ -199,9 +199,27 @@ rules:
   - ""
   resources:
   - nodes
+  - namespaces
   - pods
   - endpoints
   - services
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_netpol_apigroup }}"
+  resources:
+  - networkpolicies
+  verbs:
+  - list
+  - watch
+  - get
+- apiGroups:
+  - "{{ config.kube_config.use_apps_apigroup }}"
+  resources:
+  - deployments
+  - replicasets
   verbs:
   - list
   - watch


### PR DESCRIPTION
Found during OCP-3.11 install
- aci-containers-host-agent could not access the following
  resources: namespace, networkpolicies and deployments
- Added RBAC policies for the above resources