### PR TITLE
Functionality to get release info from acc-provision

### DIFF
--- a/pkg/hostagent/version.go
+++ b/pkg/hostagent/version.go
@@ -1,0 +1,51 @@
+// Copyright 2019 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import "fmt"
+
+// Variables set during build time for release info
+var (
+	gitCommit string
+	buildTime string
+)
+
+// Info enlists version and build information
+type VersionInfo struct {
+	GitCommit string
+	BuildTime string
+}
+
+// Get gets the version information
+func GetVersion() *VersionInfo {
+	ver := VersionInfo{}
+	ver.GitCommit = gitCommit
+	ver.BuildTime = buildTime
+
+	return &ver
+}
+
+// String returns printable version string
+func VersionString() string {
+	ver := GetVersion()
+	return StringFromInfo(ver)
+}
+
+// StringFromInfo prints the versioning details
+func StringFromInfo(ver *VersionInfo) string {
+	return fmt.Sprintf("GitCommit: %s\n", ver.GitCommit) +
+		fmt.Sprintf("BuildTime: %s\n", ver.BuildTime)
+}

--- a/provision/.gitignore
+++ b/provision/.gitignore
@@ -3,3 +3,4 @@
 /*.egg
 /*.egg-info
 /dist/
+RELEASE-VERSION

--- a/provision/MANIFEST.in
+++ b/provision/MANIFEST.in
@@ -5,3 +5,4 @@ include bin/acikubectl
 include debian/*
 include debian/source/*
 include rpm/*
+include acc_provision/RELEASE-VERSION

--- a/provision/acc_provision/acc_provision.py
+++ b/provision/acc_provision/acc_provision.py
@@ -811,6 +811,8 @@ def parse_args(show_help):
     parser.add_argument(
         '-v', '--version', action='version', version=version)
     parser.add_argument(
+        '--release', action='store_true', default=False, help='print git release info')
+    parser.add_argument(
         '--debug', action='store_true', default=False,
         help='enable debug')
     parser.add_argument(
@@ -1001,6 +1003,15 @@ def main(args=None, apic_file=None, no_random=False):
     # len(sys.argv) == 1 when acc-provision is called w/o arguments
     if args is None:
         args = parse_args(len(sys.argv) == 1)
+
+    if args.release:
+        try:
+            release_file_path = os.path.dirname(os.path.realpath(__file__)) + '/RELEASE-VERSION'
+            release = open(release_file_path, "r").read().rstrip()
+            print(release, file=sys.stderr)
+        except Exception:
+            info("Release info not present in this package")
+        return
 
     if args.list_flavors:
         info("Available configuration flavors:")

--- a/provision/acc_provision/test_main.py
+++ b/provision/acc_provision/test_main.py
@@ -234,6 +234,7 @@ def get_args(**overrides):
         "list_flavors": False,
         "flavor": None,
         "version_token": "dummy",
+        "release": False,
     }
     argc = collections.namedtuple('argc', list(arg.keys()))
     args = argc(**arg)

--- a/provision/git_version.py
+++ b/provision/git_version.py
@@ -1,0 +1,72 @@
+__all__ = ("get_git_version")
+
+from subprocess import Popen, PIPE
+import os
+
+
+def call_git_rev_parse():
+
+	try:
+		p = Popen(['git', 'rev-parse', 'HEAD'], stdout=PIPE, stderr=PIPE)
+		p.stderr.close()
+		line = "Git commit ID: " + p.stdout.readlines()[0]
+		p = Popen(['date', '-u', '+%m-%d-%Y.%H:%M:%S.UTC'], stdout=PIPE, stderr=PIPE)
+		p.stderr.close()
+		line = line + "Build time: " + p.stdout.readlines()[0]
+		return line.strip()
+
+	except:
+		return None
+
+
+def read_release_version():
+	try:
+		script_dir = os.path.dirname(__file__)
+		with open(script_dir + "/acc_provision/RELEASE-VERSION", "r") as f:
+			version = f.readlines()[0]
+			f.close()
+			return version.strip()
+
+	except:
+		return None
+
+
+def write_release_version(version):
+	script_dir = os.path.dirname(__file__)
+	with open(script_dir + "/acc_provision/RELEASE-VERSION", "w") as f:
+		f.write("%s\n" % version)
+		f.close()
+
+
+def get_git_version():
+	# Read in the version that's currently in RELEASE-VERSION.
+	release_version = read_release_version()
+
+	version = call_git_rev_parse()
+
+	# If that doesn't work, fall back on the value that's in
+	# RELEASE-VERSION.
+
+	if version is None:
+		version = release_version
+
+	# If we still don't have anything:
+
+	if version is None:
+		version = "Release info not in the current build."
+		return version
+
+
+	# If the current version is different from what's in the
+	# RELEASE-VERSION file, update the file to be current.
+
+	if version != release_version:
+		write_release_version(version)
+
+	# Finally, return the current version.
+
+	return version
+
+
+if __name__ == "__main__":
+	print(get_git_version())

--- a/provision/setup.py
+++ b/provision/setup.py
@@ -1,9 +1,10 @@
 from setuptools import setup, find_packages
+from git_version import get_git_version
 
 setup(
     name='acc_provision',
     version='1.9.9',
-    description='Tool to provision ACI for ACI Containers Controller',
+    description='Tool to provision ACI for ACI Containers Controller\n\nBuild info: \n' + get_git_version(),
     author="Cisco Systems, Inc.",
     author_email="apicapi@noironetworks.com",
     url='http://github.com/noironetworks/aci-containers/',

--- a/provision/testdata/help.stdout.txt
+++ b/provision/testdata/help.stdout.txt
@@ -1,5 +1,5 @@
-usage: acc_provision.py [-h] [-v] [--debug] [--sample] [-c file] [-o file]
-                        [-a] [-d] [-u name] [-p pass] [-w timeout]
+usage: acc_provision.py [-h] [-v] [--release] [--debug] [--sample] [-c file]
+                        [-o file] [-a] [-d] [-u name] [-p pass] [-w timeout]
                         [--list-flavors] [-f flavor] [-t token]
 
 Provision an ACI/Kubernetes installation
@@ -7,6 +7,7 @@ Provision an ACI/Kubernetes installation
 optional arguments:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
+  --release             print git release info
   --debug               enable debug
   --sample              print a sample input file with fabric configuration
   -c, --config file     input file with your fabric configuration


### PR DESCRIPTION
A file called RELEASE-VERSION contains package release info, the git commit ID and the build time.

To get release info, run
acc-provision --release