### PR TITLE
Removing custom description from setup.py for acc_provision module

### DIFF
--- a/provision/setup.py
+++ b/provision/setup.py
@@ -1,10 +1,9 @@
 from setuptools import setup, find_packages
-from git_version import get_git_version
 
 setup(
     name='acc_provision',
     version='1.9.9',
-    description='Tool to provision ACI for ACI Containers Controller\n\nBuild info: \n' + get_git_version(),
+    description='Tool to provision ACI for ACI Containers Controller',
     author="Cisco Systems, Inc.",
     author_email="apicapi@noironetworks.com",
     url='http://github.com/noironetworks/aci-containers/',


### PR DESCRIPTION
Its not recommended to put custom function calls to the description
https://docs.python.org/3/distutils/setupscript.html#additional-meta-data
as it goes on to pypi home page of that module.