### PR TITLE
Update build-rpm.sh

### DIFF
--- a/provision/rpm/build-rpm.sh
+++ b/provision/rpm/build-rpm.sh
@@ -2,7 +2,7 @@
 # Should be run from the root of the source tree
 
 set -e -x
-BUILD_DIR=${BUILD_DIR:-`pwd`/rpmbuild}
+BUILD_DIR=${BUILD_DIR:.`pwd`/rpmbuild}
 mkdir -p $BUILD_DIR/BUILD $BUILD_DIR/SOURCES $BUILD_DIR/SPECS $BUILD_DIR/RPMS $BUILD_DIR/SRPMS
 RELEASE=${RELEASE:-1}
 VERSION=`python setup.py --version`


### PR DESCRIPTION
To use '.' instead of '-' for creating built artifacts.