### PR TITLE
Revert dot to dash in build dir names

### DIFF
--- a/provision/debian/build-deb.sh
+++ b/provision/debian/build-deb.sh
@@ -3,16 +3,16 @@
 # Set env var REVISION to overwrite the 'revision' field in version string
 
 set -e -x
-BUILD_DIR=${BUILD_DIR:.`pwd`/debbuild}
+BUILD_DIR=${BUILD_DIR:-`pwd`/debbuild}
 mkdir -p $BUILD_DIR
 rm -rf $BUILD_DIR/*
 NAME=`python setup.py --name`
 VERSION=`python setup.py --version`
 REVISION=${REVISION:-1}
 python setup.py sdist --dist-dir $BUILD_DIR
-SOURCE_FILE=${NAME}.${VERSION}.tar.gz
+SOURCE_FILE=${NAME}-${VERSION}.tar.gz
 tar -C $BUILD_DIR -xf $BUILD_DIR/$SOURCE_FILE
-SOURCE_DIR=$BUILD_DIR/${NAME}.${VERSION}
+SOURCE_DIR=$BUILD_DIR/${NAME}-${VERSION}
 
 sed -e "s/@VERSION@/$VERSION/" -e "s/@REVISION@/$REVISION/" ${SOURCE_DIR}/debian/changelog.in > ${SOURCE_DIR}/debian/changelog
 

--- a/provision/rpm/build-rpm.sh
+++ b/provision/rpm/build-rpm.sh
@@ -2,7 +2,7 @@
 # Should be run from the root of the source tree
 
 set -e -x
-BUILD_DIR=${BUILD_DIR:.`pwd`/rpmbuild}
+BUILD_DIR=${BUILD_DIR:-`pwd`/rpmbuild}
 mkdir -p $BUILD_DIR/BUILD $BUILD_DIR/SOURCES $BUILD_DIR/SPECS $BUILD_DIR/RPMS $BUILD_DIR/SRPMS
 RELEASE=${RELEASE:-1}
 VERSION=`python setup.py --version`


### PR DESCRIPTION
Turns out the earlier changes from dash to dot were not needed.