### PR TITLE
Delete epfile when cni device is deleted

### DIFF
--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -41,6 +41,7 @@ type HostAgent struct {
 	opflexEps      map[string][]*opflexEndpoint
 	opflexServices map[string]*opflexService
 	epMetadata     map[string]map[string]*md.ContainerMetadata
+	cniToPodID     map[string]string
 	serviceEp      md.ServiceEndpoint
 
 	podInformer       cache.SharedIndexInformer
@@ -75,6 +76,7 @@ func NewHostAgent(config *HostAgentConfig, env Environment, log *logrus.Logger) 
 		opflexEps:      make(map[string][]*opflexEndpoint),
 		opflexServices: make(map[string]*opflexService),
 		epMetadata:     make(map[string]map[string]*md.ContainerMetadata),
+		cniToPodID:     make(map[string]string),
 
 		podIps: ipam.NewIpCache(),
 

--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -392,6 +392,7 @@ func (agent *HostAgent) unconfigureContainerIfaces(id *md.ContainerId) error {
 		return err
 	}
 
+	agent.cniEpDelete(podid)
 	logger.Debug("Deallocating IP address(es)")
 	agent.deallocateMdIps(metadata)
 


### PR DESCRIPTION
Even after cni delete was performed (and the IP address was released), the epfile was not deleted until we received a pod delete event from the API server. This PR ensures that the epfile is deleted when the CNI interface is removed.