### PR TITLE
Option to enable security-sharing in ext subnets for k8s services

### DIFF
--- a/pkg/controller/cf_update_handlers.go
+++ b/pkg/controller/cf_update_handlers.go
@@ -342,7 +342,7 @@ func (env *CfEnvironment) createAppServiceGraph(appId string, extIps []string) (
 		// 2. Service graph contract and external network
 		serviceObjs = append(serviceObjs,
 			apicExtNet(name, cont.config.AciVrfTenant,
-				cont.config.AciL3Out, extIps))
+				cont.config.AciL3Out, extIps, DefaultServiceExtNetShared))
 
 		contract, err := apicContract(name, cont.config.AciVrfTenant, graphName, DefaultServiceContractScope)
 		if err != nil {

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -305,7 +305,7 @@ func TestServiceAnnotation(t *testing.T) {
 			Ipv4: net.ParseIP("10.6.1.1"),
 		},
 	})
-	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"})
+	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, false)
 	rsCons := apicExtNetCons(name, "common", "l3out", "ext1")
 	filter := apicapi.NewVzFilter("common", name)
 	filterDn := filter.GetDn()
@@ -475,7 +475,7 @@ func TestServiceGraph(t *testing.T) {
 		},
 	})
 
-	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"})
+	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, false)
 	contract, _ := apicContract(name, "common", graphName, conScope)
 	rsCons := apicExtNetCons(name, "common", "l3out", "ext1")
 

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -49,6 +49,10 @@ const ServiceEpAnnotation = "opflex.cisco.com/service-endpoint"
 // Annotation to set service contract scope values. If unset or "", defaults to "context"(VRF). Other valid values: "context", "tenant", and "global"
 const ServiceContractScopeAnnotation = "opflex.cisco.com/ext_service_contract_scope"
 
+// True or False -- will enable the shared security option in addition
+// to import security
+const ServiceExtNetSharedAnnotation = "opflex.cisco.com/ext_service_shared_security"
+
 // List of IP address ranges for use by the pod network
 const PodNetworkRangeAnnotation = "opflex.cisco.com/pod-network-ranges"
 


### PR DESCRIPTION
Default value: import-security

In your service definition, add annotation:
opflex.cisco.com/ext_service_shared_security : "True"
This will result in the external subnet's scope being set to "import-security,shared-security"

Valid values: true, false. Empty value defaults to false

If a new service is deployed with invalid value, it wont register with APIC
If an existing service is updated with invalid value, the service wont be updated in APIC