### PR TITLE
Option to enable security-sharing in ext subnets for k8s services

### DIFF
--- a/pkg/controller/cf_update_handlers.go
+++ b/pkg/controller/cf_update_handlers.go
@@ -342,12 +342,9 @@ func (env *CfEnvironment) createAppServiceGraph(appId string, extIps []string) (
 		// 2. Service graph contract and external network
 		serviceObjs = append(serviceObjs,
 			apicExtNet(name, cont.config.AciVrfTenant,
-				cont.config.AciL3Out, extIps))
+				cont.config.AciL3Out, extIps, DefaultServiceExtNetShared))
 
-		contract, err := apicContract(name, cont.config.AciVrfTenant, graphName, DefaultServiceContractScope)
-		if err != nil {
-			return nil, err
-		}
+		contract := apicContract(name, cont.config.AciVrfTenant, graphName, DefaultServiceContractScope)
 		serviceObjs = append(serviceObjs, contract)
 
 		for _, net := range cont.config.AciExtNetworks {

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -37,6 +37,9 @@ import (
 // Default service contract scope value 
 const DefaultServiceContractScope = "context"
 
+// Default service ext subnet scope - enable shared security
+const DefaultServiceExtNetShared = false
+
 func (cont *AciController) initEndpointsInformerFromClient(
 	kubeClient kubernetes.Interface) {
 
@@ -305,17 +308,27 @@ func apicRedirectPol(name string, tenantName string, nodes []string,
 }
 
 func apicExtNet(name string, tenantName string, l3Out string,
-	ingresses []string) apicapi.ApicObject {
+	ingresses []string, sharedSecurity bool) apicapi.ApicObject {
 
 	en := apicapi.NewL3extInstP(tenantName, l3Out, name)
 	enDn := en.GetDn()
 	en.AddChild(apicapi.NewFvRsProv(enDn, name))
+
+	sharedSecurityString := "import-security,shared-security"
 	for _, ingress := range ingresses {
 		ip := net.ParseIP(ingress)
 		if ip != nil && ip.To4() != nil {
-			en.AddChild(apicapi.NewL3extSubnet(enDn, ingress+"/32"))
+			subnet := apicapi.NewL3extSubnet(enDn, ingress+"/32")
+			if sharedSecurity {
+				subnet.SetAttr("scope", sharedSecurityString)
+			}
+			en.AddChild(subnet)
 		} else if ip != nil && ip.To16() != nil {
-			en.AddChild(apicapi.NewL3extSubnet(enDn, ingress+"/128"))
+			subnet := apicapi.NewL3extSubnet(enDn, ingress+"/128")
+			if sharedSecurity {
+				subnet.SetAttr("scope", sharedSecurityString)
+			}
+                        en.AddChild(subnet)
 		}
 	}
 	return en
@@ -344,22 +357,17 @@ func validScope(scope string) bool {
 }
 
 func apicContract(conName string, tenantName string,
-	graphName string, scopeName string) (apicapi.ApicObject, error) {
-	normScopeName := strings.ToLower(scopeName)
-	if !validScope(normScopeName) {
-		errString := "Invalid service contract scope value provided " + scopeName
-		return nil, errors.New(errString)
-	}
+	graphName string, scopeName string) apicapi.ApicObject {
 	con := apicapi.NewVzBrCP(tenantName, conName)
-	if normScopeName != "" && normScopeName != "context" {
-		con.SetAttr("scope", normScopeName)
+	if scopeName != "" && scopeName != "context" {
+		con.SetAttr("scope", scopeName)
 	}
 	cs := apicapi.NewVzSubj(con.GetDn(), "loadbalancedservice")
 	csDn := cs.GetDn()
 	cs.AddChild(apicapi.NewVzRsSubjGraphAtt(csDn, graphName))
 	cs.AddChild(apicapi.NewVzRsSubjFiltAtt(csDn, conName))
 	con.AddChild(cs)
-	return con, nil
+	return con
 }
 
 func apicDevCtx(name string, tenantName string,
@@ -427,10 +435,27 @@ func (cont *AciController) updateServiceDeviceInstance(key string,
 	var conScope string
 	scopeVal, ok := service.ObjectMeta.Annotations[metadata.ServiceContractScopeAnnotation]
 	if ok {
-		conScope = scopeVal
+		normScopeVal := strings.ToLower(scopeVal)
+		if !validScope(normScopeVal) {
+			errString := "Invalid service contract scope value provided " + scopeVal
+			err = errors.New(errString)
+			serviceLogger(cont.log, service).Error("Could not create contract: ", err)
+			return err
+
+		} else {
+			conScope = normScopeVal
+		}
 	} else {
 		conScope = DefaultServiceContractScope
 	}
+
+	var sharedSecurity bool
+	if conScope == "global" {
+		sharedSecurity = true
+	} else {
+		sharedSecurity = DefaultServiceExtNetShared
+	}
+
 	graphName := cont.aciNameForKey("svc", "global")
 	var serviceObjs apicapi.ApicSlice
 	if len(nodes) > 0 {
@@ -466,14 +491,10 @@ func (cont *AciController) updateServiceDeviceInstance(key string,
 			}
 			serviceObjs = append(serviceObjs,
 				apicExtNet(name, cont.config.AciVrfTenant,
-					cont.config.AciL3Out, ingresses))
+					cont.config.AciL3Out, ingresses, sharedSecurity))
 		}
 
-		contract, err := apicContract(name, cont.config.AciVrfTenant, graphName, conScope)
-		if err != nil {
-			serviceLogger(cont.log, service).Error("Could not create contract: ", err)
-			return err
-		}
+		contract := apicContract(name, cont.config.AciVrfTenant, graphName, conScope)
 		serviceObjs = append(serviceObjs, contract)
 
 		for _, net := range cont.config.AciExtNetworks {

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -183,27 +183,6 @@ func TestServiceIp(t *testing.T) {
 	cont.stop()
 }
 
-func TestContractScopeValues(t *testing.T) {
-	name := "testContract"
-	tenant := "testTenant"
-	graphName := "testGraph"
-
-	contract, err := apicContract(name, tenant, graphName, "global")
-	assert.Empty(t, err)
-	assert.Equal(t, contract.GetAttrStr("scope"), "global")
-
-	_, err = apicContract(name, tenant, graphName, "wrong-Name")
-	assert.NotNil(t, err)
-
-	contract, err = apicContract(name, tenant, graphName, "")
-	assert.Empty(t, err)
-	assert.Equal(t, contract.GetAttrStr("scope"), "context")
-
-	contract, err = apicContract(name, tenant, graphName, "GloBal")
-	assert.Empty(t, err)
-	assert.Equal(t, contract.GetAttrStr("scope"), "global")
-}
-
 type seMap map[string]*metadata.ServiceEndpoint
 
 func sgCont() *testAciController {
@@ -305,7 +284,7 @@ func TestServiceAnnotation(t *testing.T) {
 			Ipv4: net.ParseIP("10.6.1.1"),
 		},
 	})
-	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"})
+	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, true)
 	rsCons := apicExtNetCons(name, "common", "l3out", "ext1")
 	filter := apicapi.NewVzFilter("common", name)
 	filterDn := filter.GetDn()
@@ -405,7 +384,7 @@ func TestServiceAnnotation(t *testing.T) {
 	service1.ObjectMeta.Annotations[metadata.ServiceContractScopeAnnotation] = "global"
 	time.Sleep(2 * time.Second)
 	cont.fakeServiceSource.Modify(service1)
-	contract, _ := apicContract(name, "common", graphName, "global")
+	contract := apicContract(name, "common", graphName, "global")
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
@@ -475,8 +454,8 @@ func TestServiceGraph(t *testing.T) {
 		},
 	})
 
-	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"})
-	contract, _ := apicContract(name, "common", graphName, conScope)
+	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, false)
+	contract := apicContract(name, "common", graphName, conScope)
 	rsCons := apicExtNetCons(name, "common", "l3out", "ext1")
 
 	filter := apicapi.NewVzFilter("common", name)


### PR DESCRIPTION
Default value: import-security

If a service contract is defined with the scope value "global", the respective extSubnet is registered with shared-security scope setting as well

This is an addition to https://github.com/noironetworks/aci-containers/pull/186 where we first added option to change service contract scope

Also modified the unit test to verify contract scope to include this code change. TestServiceAnnotation now also checks for the extSubnet's scope value when the service contract scope is set to global