### PR TITLE
Compile opflex with statically linked boost.

### DIFF
--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -1,9 +1,10 @@
 FROM noiro/opflex-build-base
+ARG BUILDOPTS="--with-static-boost --with-boost=/usr/local/boost_1_58_0"
 WORKDIR /opflex
 COPY libopflex /opflex/libopflex
 ARG make_args=-j4
 RUN cd /opflex/libopflex \
-  && ./autogen.sh && ./configure --disable-assert --disable-static \
+  && ./autogen.sh && ./configure --disable-assert $BUILDOPTS \
   && make $make_args && make install
 COPY genie /opflex/genie
 RUN cd /opflex/genie/target/libmodelgbp \
@@ -11,7 +12,7 @@ RUN cd /opflex/genie/target/libmodelgbp \
   && make $make_args && make install
 COPY agent-ovs /opflex/agent-ovs
 RUN cd /opflex/agent-ovs \
-  && ./autogen.sh && ./configure \
+  && ./autogen.sh && ./configure $BUILDOPTS \
   && make $make_args && make install
 RUN for p in `find /usr/local/lib/ /usr/local/bin/ -type f \(\
     -name 'opflex_agent' -o \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -1,9 +1,10 @@
 FROM alpine:3.7
+ARG ROOT=/usr/local
 COPY ovs-musl.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \
     libtool pkgconfig autoconf automake cmake doxygen file py-six \
     linux-headers libuv-dev boost-dev openssl-dev git \
-    libnetfilter_conntrack-dev rapidjson-dev
+    libnetfilter_conntrack-dev rapidjson-dev python-dev bzip2-dev
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'
@@ -13,9 +14,17 @@ RUN git clone https://github.com/openvswitch/ovs.git --branch v2.6.0 --depth 1 \
   && patch -p1 < /ovs-musl.patch \
   && ./boot.sh && ./configure --disable-ssl --disable-libcapng --enable-shared \
   && make $make_args && make install \
-  && ROOT=/usr/local \
   && mkdir -p $ROOT/include/openvswitch/openvswitch \
   && mv $ROOT/include/openvswitch/*.h $ROOT/include/openvswitch/openvswitch \
   && mv $ROOT/include/openflow $ROOT/include/openvswitch \
   && cp include/*.h "$ROOT/include/openvswitch/" \
   && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \;
+RUN wget http://10.30.120.20:8000/boost_1_58_0.tar.gz \
+  && tar zxvf boost_1_58_0.tar.gz \
+  && cd boost_1_58_0 \
+  && ./bootstrap.sh --prefix=$ROOT/boost_1_58_0 \
+  && ./b2 cxxflags=-fPIC cflags=-fPIC -a \
+  && ./b2 install --prefix=$ROOT/boost_1_58_0 \
+  && cd .. \
+  && rm -Rf boost_1_58_0.tar.gz \
+  && rm -Rf boost_1_58_0 \;

--- a/docker/Dockerfile-opflex-build-base-debug
+++ b/docker/Dockerfile-opflex-build-base-debug
@@ -1,9 +1,10 @@
 FROM alpine:3.7
+ARG ROOT=/usr/local
 COPY ovs-musl.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \
     libtool pkgconfig autoconf automake cmake doxygen file py-six \
     linux-headers libuv-dev boost-dev openssl-dev git \
-    libnetfilter_conntrack-dev rapidjson-dev \
+    libnetfilter_conntrack-dev rapidjson-dev python-dev bzip2-dev \
     && apk add --no-cache libexecinfo-dev --repository \
     http://nl.alpinelinux.org/alpine/edge/main
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
@@ -15,9 +16,17 @@ RUN git clone https://github.com/openvswitch/ovs.git --branch v2.6.0 --depth 1 \
   && patch -p1 < /ovs-musl.patch \
   && ./boot.sh && ./configure --disable-ssl --disable-libcapng --enable-shared \
   && make $make_args && make install \
-  && ROOT=/usr/local \
   && mkdir -p $ROOT/include/openvswitch/openvswitch \
   && mv $ROOT/include/openvswitch/*.h $ROOT/include/openvswitch/openvswitch \
   && mv $ROOT/include/openflow $ROOT/include/openvswitch \
   && cp include/*.h "$ROOT/include/openvswitch/" \
   && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \;
+RUN wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz \
+  && tar zxvf boost_1_58_0.tar.gz \
+  && cd boost_1_58_0 \
+  && ./bootstrap.sh --prefix=$ROOT/boost_1_58_0 \
+  && ./b2 cxxflags=-fPIC cflags=-fPIC -a \
+  && ./b2 install --prefix=$ROOT/boost_1_58_0 \
+  && cd .. \
+  && rm -Rf boost_1_58_0.tar.gz \
+  && rm -Rf boost_1_58_0 \;


### PR DESCRIPTION
- opflex-build-base is where boost is built and
  would not change frequently nor is pushed.
- python-dev bzip2-dev are needed to build boost.
- change opflex-build to compile and link
  with static boost.

Signed-off-by: Madhu Challa <challa@gmail.com>