### PR TITLE
Cherrypick: Move libexecinfo deps into its own dockerfile and  Compile opflex with statically linked boost

### DIFF
--- a/build-priv.sh
+++ b/build-priv.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Build opflex and aci-containers private images in non jenkins environment
+# 1. go get github.com/noironetworks/aci-containers
+# 2. mkdir -p $HOME/work && cd $HOME/work
+# 3. git clone https://github.com/noironetworks/opflex opflex-noiro
+# 4. Modify docker/Dockerfile-* and Makefile to reflect DOCKER_USER
+# 5. docker login as DOCKER_USER
+# usage: build.sh <opflex-dir> <aci-containers-dir> <docker-user>
+# example: ./build-priv.sh challa
+
+DOCKER_USER=$1
+
+[ -z "$GOPATH" ] && GOPATH=$HOME/go
+export GOPATH
+ACICONTAINERS_DIR=$GOPATH/src/github.com/noironetworks/aci-containers
+
+[ -z "$OPFLEX_DIR" ] && OPFLEX_DIR=$HOME/work/opflex-noiro
+export OPFLEX_DIR
+
+set -Eeuxo pipefail
+
+echo "starting opflex build"
+
+pushd $ACICONTAINERS_DIR
+rm -Rf build
+make container-opflex-build-base
+docker build -t $DOCKER_USER/opflex-build-base -f docker/Dockerfile-opflex-build-base-debug docker
+docker push $DOCKER_USER/opflex-build-base
+
+pushd $OPFLEX_DIR/genie
+mvn compile exec:java
+popd
+docker build -t $DOCKER_USER/opflex-build -f docker/Dockerfile-opflex-build $OPFLEX_DIR
+docker push $DOCKER_USER/opflex-build
+
+mkdir -p build/opflex/dist
+docker run $DOCKER_USER/opflex-build tar -c -C /usr/local \
+	bin/opflex_agent bin/gbp_inspect bin/mcast_daemon bin/mock_server \
+	| tar -x -C build/opflex/dist
+docker run -w /usr/local $DOCKER_USER/opflex-build /bin/sh -c 'find lib \(\
+	 -name '\''libopflex*.so*'\'' -o \
+	 -name '\''libmodelgbp*so*'\'' -o \
+	 -name '\''libopenvswitch*so*'\'' -o \
+	  -name '\''libsflow*so*'\'' -o \
+	  -name '\''libofproto*so*'\'' \
+           \) ! -name '\''*debug'\'' \
+           | xargs tar -c ' \
+	  | tar -x -C build/opflex/dist
+docker run -w /usr/local $DOCKER_USER/opflex-build /bin/sh -c \
+	'find lib bin -name '\''*.debug'\'' | xargs tar -cz' \
+	 > opflex-debuginfo.tar.gz
+cp docker/launch-opflexagent.sh build/opflex/dist/bin/
+cp docker/launch-mcastdaemon.sh build/opflex/dist/bin/
+cp docker/launch-opflexserver.sh build/opflex/dist/bin/
+cp docker/Dockerfile-opflex build/opflex/dist/
+cp docker/Dockerfile-opflexserver build/opflex/dist/
+
+docker build -t $DOCKER_USER/opflex -f ./build/opflex/dist/Dockerfile-opflex build/opflex/dist
+docker push $DOCKER_USER/opflex
+docker build -t $DOCKER_USER/opflexserver -f ./build/opflex/dist/Dockerfile-opflexserver build/opflex/dist
+docker push $DOCKER_USER/opflexserver
+
+echo "starting aci-containers build"
+make all-static
+
+docker build -t $DOCKER_USER/aci-containers-controller -f docker/Dockerfile-controller .
+docker push $DOCKER_USER/aci-containers-controller
+
+docker build -t $DOCKER_USER/aci-containers-host -f docker/Dockerfile-host .
+docker push $DOCKER_USER/aci-containers-host
+
+docker build -t $DOCKER_USER/cnideploy -f docker/Dockerfile-cnideploy docker
+docker push $DOCKER_USER/cnideploy
+
+echo "starting openvswitch build"
+docker build -t $DOCKER_USER/openvswitch -f docker/Dockerfile-openvswitch .
+docker push $DOCKER_USER/openvswitch
+
+popd

--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -1,9 +1,10 @@
 FROM noiro/opflex-build-base
+ARG BUILDOPTS="--with-static-boost --with-boost=/usr/local/boost_1_58_0"
 WORKDIR /opflex
 COPY libopflex /opflex/libopflex
 ARG make_args=-j4
 RUN cd /opflex/libopflex \
-  && ./autogen.sh && ./configure --disable-assert --disable-static \
+  && ./autogen.sh && ./configure --disable-assert $BUILDOPTS \
   && make $make_args && make install
 COPY genie /opflex/genie
 RUN cd /opflex/genie/target/libmodelgbp \
@@ -11,7 +12,7 @@ RUN cd /opflex/genie/target/libmodelgbp \
   && make $make_args && make install
 COPY agent-ovs /opflex/agent-ovs
 RUN cd /opflex/agent-ovs \
-  && ./autogen.sh && ./configure \
+  && ./autogen.sh && ./configure $BUILDOPTS \
   && make $make_args && make install
 RUN for p in `find /usr/local/lib/ /usr/local/bin/ -type f \(\
     -name 'opflex_agent' -o \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -1,9 +1,10 @@
 FROM alpine:3.7
+ARG ROOT=/usr/local
 COPY ovs-musl.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \
     libtool pkgconfig autoconf automake cmake doxygen file py-six \
     linux-headers libuv-dev boost-dev openssl-dev git \
-    libnetfilter_conntrack-dev rapidjson-dev
+    libnetfilter_conntrack-dev rapidjson-dev python-dev bzip2-dev
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'
@@ -13,9 +14,17 @@ RUN git clone https://github.com/openvswitch/ovs.git --branch v2.6.0 --depth 1 \
   && patch -p1 < /ovs-musl.patch \
   && ./boot.sh && ./configure --disable-ssl --disable-libcapng --enable-shared \
   && make $make_args && make install \
-  && ROOT=/usr/local \
   && mkdir -p $ROOT/include/openvswitch/openvswitch \
   && mv $ROOT/include/openvswitch/*.h $ROOT/include/openvswitch/openvswitch \
   && mv $ROOT/include/openflow $ROOT/include/openvswitch \
   && cp include/*.h "$ROOT/include/openvswitch/" \
   && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \;
+RUN wget http://10.30.120.20:8000/boost_1_58_0.tar.gz \
+  && tar zxvf boost_1_58_0.tar.gz \
+  && cd boost_1_58_0 \
+  && ./bootstrap.sh --prefix=$ROOT/boost_1_58_0 \
+  && ./b2 cxxflags=-fPIC cflags=-fPIC -a \
+  && ./b2 install --prefix=$ROOT/boost_1_58_0 \
+  && cd .. \
+  && rm -Rf boost_1_58_0.tar.gz \
+  && rm -Rf boost_1_58_0 \;

--- a/docker/Dockerfile-opflex-build-base-debug
+++ b/docker/Dockerfile-opflex-build-base-debug
@@ -1,9 +1,10 @@
 FROM alpine:3.7
+ARG ROOT=/usr/local
 COPY ovs-musl.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \
     libtool pkgconfig autoconf automake cmake doxygen file py-six \
     linux-headers libuv-dev boost-dev openssl-dev git \
-    libnetfilter_conntrack-dev rapidjson-dev \
+    libnetfilter_conntrack-dev rapidjson-dev python-dev bzip2-dev \
     && apk add --no-cache libexecinfo-dev --repository \
     http://nl.alpinelinux.org/alpine/edge/main
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
@@ -15,9 +16,17 @@ RUN git clone https://github.com/openvswitch/ovs.git --branch v2.6.0 --depth 1 \
   && patch -p1 < /ovs-musl.patch \
   && ./boot.sh && ./configure --disable-ssl --disable-libcapng --enable-shared \
   && make $make_args && make install \
-  && ROOT=/usr/local \
   && mkdir -p $ROOT/include/openvswitch/openvswitch \
   && mv $ROOT/include/openvswitch/*.h $ROOT/include/openvswitch/openvswitch \
   && mv $ROOT/include/openflow $ROOT/include/openvswitch \
   && cp include/*.h "$ROOT/include/openvswitch/" \
   && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \;
+RUN wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz \
+  && tar zxvf boost_1_58_0.tar.gz \
+  && cd boost_1_58_0 \
+  && ./bootstrap.sh --prefix=$ROOT/boost_1_58_0 \
+  && ./b2 cxxflags=-fPIC cflags=-fPIC -a \
+  && ./b2 install --prefix=$ROOT/boost_1_58_0 \
+  && cd .. \
+  && rm -Rf boost_1_58_0.tar.gz \
+  && rm -Rf boost_1_58_0 \;

--- a/docker/Dockerfile-opflex-build-base-debug
+++ b/docker/Dockerfile-opflex-build-base-debug
@@ -1,0 +1,23 @@
+FROM alpine:3.7
+COPY ovs-musl.patch /
+RUN apk upgrade --no-cache && apk add --no-cache build-base \
+    libtool pkgconfig autoconf automake cmake doxygen file py-six \
+    linux-headers libuv-dev boost-dev openssl-dev git \
+    libnetfilter_conntrack-dev rapidjson-dev \
+    && apk add --no-cache libexecinfo-dev --repository \
+    http://nl.alpinelinux.org/alpine/edge/main
+ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
+ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
+ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'
+ARG make_args=-j4
+RUN git clone https://github.com/openvswitch/ovs.git --branch v2.6.0 --depth 1 \
+  && cd ovs \
+  && patch -p1 < /ovs-musl.patch \
+  && ./boot.sh && ./configure --disable-ssl --disable-libcapng --enable-shared \
+  && make $make_args && make install \
+  && ROOT=/usr/local \
+  && mkdir -p $ROOT/include/openvswitch/openvswitch \
+  && mv $ROOT/include/openvswitch/*.h $ROOT/include/openvswitch/openvswitch \
+  && mv $ROOT/include/openflow $ROOT/include/openvswitch \
+  && cp include/*.h "$ROOT/include/openvswitch/" \
+  && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \;


### PR DESCRIPTION
Move libexecinfo deps into its own dockerfile.

    - based on code review comments from Sumit.

    Add set -Eeuxo pipefail.

    - based on feedback from Gaurav.

    (cherry picked from commit 875f4e5ef7f976689c9602127d2ccb77a62aa10f)

Compile opflex with statically linked boost.

    - opflex-build-base is where boost is built and
      would not change frequently nor is pushed.
    - python-dev bzip2-dev are needed to build boost.
    - change opflex-build to compile and link
      with static boost.

    Signed-off-by: Madhu Challa <challa@gmail.com>

    Change boost url for lab environment.

    Signed-off-by: Madhu Challa <challa@gmail.com>
    (cherry picked from commit aeeaf3cf071892ab87ceebecbfa09f78582ba800)