### PR TITLE
Update docker base images to alpine3.9 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -508,7 +508,7 @@
     ".",
     "nl"
   ]
-  revision = "7c0b5944a3036fc8dc9f4cbf2f5c76dedd29af8b"
+  revision = "f504738125a57f35f87fc30fb69b8df75237ccde"
 
 [[projects]]
   branch = "master"

--- a/docker/Dockerfile-cnideploy
+++ b/docker/Dockerfile-cnideploy
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache && \
   apk add --no-cache wget ca-certificates && update-ca-certificates
 RUN mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar xz -C /opt/cni/bin

--- a/docker/Dockerfile-controller
+++ b/docker/Dockerfile-controller
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache
 COPY dist-static/aci-containers-controller /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/aci-containers-controller", "-config-path", "/usr/local/etc/aci-containers/controller.conf"]

--- a/docker/Dockerfile-host
+++ b/docker/Dockerfile-host
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache
 COPY dist-static/aci-containers-host-agent dist-static/opflex-agent-cni docker/launch-hostagent.sh /usr/local/bin/
 CMD ["/usr/local/bin/launch-hostagent.sh"]

--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -1,7 +1,7 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
   boost-program_options boost-system boost-date_time boost-filesystem \
-  boost-iostreams libnetfilter_conntrack libssl1.0 libcrypto1.0 ca-certificates \
+  boost-iostreams libnetfilter_conntrack libssl1.1 libcrypto1.1 ca-certificates \
   && update-ca-certificates
 COPY bin/* /usr/local/bin/
 COPY lib/* /usr/local/lib/

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 ARG ROOT=/usr/local
 COPY ovs-musl.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \

--- a/docker/Dockerfile-opflex-build-base-debug
+++ b/docker/Dockerfile-opflex-build-base-debug
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 ARG ROOT=/usr/local
 COPY ovs-musl.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \

--- a/docker/Dockerfile-opflexserver
+++ b/docker/Dockerfile-opflexserver
@@ -1,7 +1,7 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
   boost-program_options boost-system boost-date_time boost-filesystem \
-  boost-iostreams libnetfilter_conntrack libssl1.0 libcrypto1.0 ca-certificates \
+  boost-iostreams libnetfilter_conntrack libssl1.1 libcrypto1.1 ca-certificates \
   && update-ca-certificates
 COPY bin/mock_server /usr/local/bin/
 COPY bin/launch-opflexserver.sh /usr/local/bin/


### PR DESCRIPTION
Changed the base image from 3.7 to 3.9 for opflex-build-base, controller, hostagent, cnideploy, opflex, opflexserver, and opflex-build-base.
Also updated the netlink version in Gopkg.lock to the latest commit