### PR TITLE
Cherrypick: update netlink, alpine images and mock-server code

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -526,7 +526,7 @@
     ".",
     "nl"
   ]
-  revision = "aa0edbe0c96fbff58fc45342d4df938c74405036"
+  revision = "f504738125a57f35f87fc30fb69b8df75237ccde"
 
 [[projects]]
   branch = "master"

--- a/docker/Dockerfile-cnideploy
+++ b/docker/Dockerfile-cnideploy
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache && \
   apk add --no-cache wget ca-certificates && update-ca-certificates
 RUN mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | tar xz -C /opt/cni/bin

--- a/docker/Dockerfile-controller
+++ b/docker/Dockerfile-controller
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache
 COPY dist-static/aci-containers-controller /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/aci-containers-controller", "-config-path", "/usr/local/etc/aci-containers/controller.conf"]

--- a/docker/Dockerfile-host
+++ b/docker/Dockerfile-host
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache
 COPY dist-static/aci-containers-host-agent dist-static/opflex-agent-cni docker/launch-hostagent.sh /usr/local/bin/
 CMD ["/usr/local/bin/launch-hostagent.sh"]

--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -1,7 +1,7 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
   boost-program_options boost-system boost-date_time boost-filesystem \
-  boost-iostreams libnetfilter_conntrack libssl1.0 libcrypto1.0 ca-certificates \
+  boost-iostreams libnetfilter_conntrack libssl1.1 libcrypto1.1 ca-certificates \
   && update-ca-certificates
 COPY bin/* /usr/local/bin/
 COPY lib/* /usr/local/lib/

--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -18,6 +18,7 @@ RUN for p in `find /usr/local/lib/ /usr/local/bin/ -type f \(\
     -name 'opflex_agent' -o \
     -name 'gbp_inspect' -o \
     -name 'mcast_daemon' -o \
+    -name 'mock_server' -o \
     -name 'libopflex*so*' -o \
     -name 'libmodelgbp*so*' -o \
     -name 'libopenvswitch*so*' -o \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 ARG ROOT=/usr/local
 COPY ovs-musl.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \

--- a/docker/Dockerfile-opflex-build-base-debug
+++ b/docker/Dockerfile-opflex-build-base-debug
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 ARG ROOT=/usr/local
 COPY ovs-musl.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \

--- a/docker/Dockerfile-opflexserver
+++ b/docker/Dockerfile-opflexserver
@@ -1,7 +1,7 @@
-FROM alpine:3.7
+FROM alpine:3.9
 RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
   boost-program_options boost-system boost-date_time boost-filesystem \
-  boost-iostreams libnetfilter_conntrack libssl1.0 libcrypto1.0 ca-certificates \
+  boost-iostreams libnetfilter_conntrack libssl1.1 libcrypto1.1 ca-certificates \
   && update-ca-certificates
 COPY bin/mock_server /usr/local/bin/
 COPY bin/launch-opflexserver.sh /usr/local/bin/

--- a/docker/Dockerfile-opflexserver
+++ b/docker/Dockerfile-opflexserver
@@ -1,0 +1,9 @@
+FROM alpine:3.7
+RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
+  boost-program_options boost-system boost-date_time boost-filesystem \
+  boost-iostreams libnetfilter_conntrack libssl1.0 libcrypto1.0 ca-certificates \
+  && update-ca-certificates
+COPY bin/mock_server /usr/local/bin/
+COPY bin/launch-opflexserver.sh /usr/local/bin/
+COPY lib/* /usr/local/lib/
+CMD ["/usr/local/bin/launch-opflexserver.sh"]

--- a/docker/launch-opflexserver.sh
+++ b/docker/launch-opflexserver.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -e
+set -x
+
+PREFIX=/usr/local
+OPFLEXSERVER=${PREFIX}/bin/mock_server
+OPFLEXSERVER_CONF_PATH=/usr/local/etc/opflex-server
+OPFLEXSERVER_CONF=${OPFLEXSERVER_CONF_PATH}/policy.json
+mkdir -p ${OPFLEXSERVER_CONF_PATH}
+
+if [ ! -f ${OPFLEXSERVER_CONF} ]; then
+    cat <<EOF > ${OPFLEXSERVER_CONF}
+[
+    {
+    }
+]
+EOF
+fi
+
+exec ${OPFLEXSERVER} --policy=${OPFLEXSERVER_CONF}


### PR DESCRIPTION
Update the netlink revision

(cherry picked from commit 401e742)
Update Dockerfile base images to alpine:3.9

Changed the base images for controller, hostagent, opflex, opflex-build-base, opflex-build-base-debug and opflexserver from alpine:3.7 to alpine:3.9
Also updated the libssl and libcrypto images from 1.0 to 1.1

(cherry picked from commit 1ef7668)

Add mock-server to the build

Signed-off-by: Madhu Challa <challa@gmail.com>

Invoke opflex-server via launch script.

Copy launch-opflexserver.sh to /usr/local/bin

(cherry picked from commit 7edc248)