### PR TITLE
Add DOCKER_HUB_ID and DOCKER_TAG to makefiles.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ OVSRESYNC_DEPS=${METADATA_SRC} ${OVSRESYNC_SRC} vendor
 SIMPLESERVICE_DEPS=${SIMPLESERVICE_SRC} vendor
 DIST_FILE=aci-containers.tgz
 
+DOCKER_HUB_ID ?= noiro
+DOCKER_TAG ?=
 BUILD_CMD ?= go build -v
 TEST_CMD ?= go test -cover
 TEST_ARGS ?=
@@ -138,17 +140,17 @@ dist-static/simpleservice: ${SIMPLESERVICE_DEPS}
 	${STATIC_BUILD_CMD} -o $@ ${BASE}/cmd/simpleservice
 
 container-host: dist-static/aci-containers-host-agent dist-static/opflex-agent-cni
-	${DOCKER_BUILD_CMD} -t noiro/aci-containers-host -f ./docker/Dockerfile-host .
+	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/aci-containers-host${DOCKER_TAG} -f ./docker/Dockerfile-host .
 container-controller: dist-static/aci-containers-controller
-	${DOCKER_BUILD_CMD} -t noiro/aci-containers-controller -f ./docker/Dockerfile-controller .
+	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/aci-containers-controller${DOCKER_TAG} -f ./docker/Dockerfile-controller .
 container-opflex-build-base:
-	${DOCKER_BUILD_CMD} -t noiro/opflex-build-base -f ./docker/Dockerfile-opflex-build-base docker
+	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/opflex-build-base${DOCKER_TAG} -f ./docker/Dockerfile-opflex-build-base docker
 container-openvswitch: dist-static/ovsresync
-	${DOCKER_BUILD_CMD} -t noiro/openvswitch -f ./docker/Dockerfile-openvswitch .
+	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/openvswitch${DOCKER_TAG} -f ./docker/Dockerfile-openvswitch .
 container-cnideploy:
-	${DOCKER_BUILD_CMD} -t noiro/cnideploy -f ./docker/Dockerfile-cnideploy docker
+	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/cnideploy${DOCKER_TAG} -f ./docker/Dockerfile-cnideploy docker
 container-simpleservice: dist-static/simpleservice
-	${DOCKER_BUILD_CMD} -t noiro/simpleservice -f ./docker/Dockerfile-simpleservice .
+	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/simpleservice${DOCKER_TAG} -f ./docker/Dockerfile-simpleservice .
 
 check: check-ipam check-index check-apicapi check-controller check-hostagent check-keyvalueservice
 check-ipam:

--- a/build-priv.sh
+++ b/build-priv.sh
@@ -3,19 +3,25 @@
 # 1. go get github.com/noironetworks/aci-containers
 # 2. mkdir -p $HOME/work && cd $HOME/work
 # 3. git clone https://github.com/noironetworks/opflex opflex-noiro
-# 4. Modify docker/Dockerfile-* and Makefile to reflect DOCKER_USER
-# 5. docker login as DOCKER_USER
-# usage: build.sh <opflex-dir> <aci-containers-dir> <docker-user>
-# example: ./build-priv.sh challa
+# 4. Modify docker/Dockerfile-* and Makefile to reflect DOCKER_HUB_ID
+# 5. docker login as DOCKER_HUB_ID
+# usage: build.sh <docker-user> :<tag>
+# example: ./build-priv.sh challa :demo
+set -x
 
-DOCKER_USER=$1
+DOCKER_HUB_ID=$1
+DOCKER_TAG=$2
 
 [ -z "$GOPATH" ] && GOPATH=$HOME/go
 export GOPATH
-ACICONTAINERS_DIR=$GOPATH/src/github.com/noironetworks/aci-containers
+ACICONTAINERS_DIR=.
 
 [ -z "$OPFLEX_DIR" ] && OPFLEX_DIR=$HOME/work/opflex-noiro
 export OPFLEX_DIR
+
+[ -z "$DOCKER_TAG" ] && DOCKER_TAG=
+export DOCKER_HUB_ID
+export DOCKER_TAG
 
 set -Eeuxo pipefail
 
@@ -23,21 +29,20 @@ echo "starting opflex build"
 
 pushd $ACICONTAINERS_DIR
 rm -Rf build
-make container-opflex-build-base
-docker build -t $DOCKER_USER/opflex-build-base -f docker/Dockerfile-opflex-build-base-debug docker
-docker push $DOCKER_USER/opflex-build-base
+docker build -t $DOCKER_HUB_ID/opflex-build-base$DOCKER_TAG -f docker/Dockerfile-opflex-build-base docker
+docker push $DOCKER_HUB_ID/opflex-build-base$DOCKER_TAG
 
 pushd $OPFLEX_DIR/genie
 mvn compile exec:java
 popd
-docker build -t $DOCKER_USER/opflex-build -f docker/Dockerfile-opflex-build $OPFLEX_DIR
-docker push $DOCKER_USER/opflex-build
+docker build -t $DOCKER_HUB_ID/opflex-build$DOCKER_TAG -f docker/Dockerfile-opflex-build $OPFLEX_DIR
+docker push $DOCKER_HUB_ID/opflex-build$DOCKER_TAG
 
 mkdir -p build/opflex/dist
-docker run $DOCKER_USER/opflex-build tar -c -C /usr/local \
+docker run $DOCKER_HUB_ID/opflex-build$DOCKER_TAG tar -c -C /usr/local \
 	bin/opflex_agent bin/gbp_inspect bin/mcast_daemon bin/mock_server \
 	| tar -x -C build/opflex/dist
-docker run -w /usr/local $DOCKER_USER/opflex-build /bin/sh -c 'find lib \(\
+docker run -w /usr/local $DOCKER_HUB_ID/opflex-build$DOCKER_TAG /bin/sh -c 'find lib \(\
 	 -name '\''libopflex*.so*'\'' -o \
 	 -name '\''libmodelgbp*so*'\'' -o \
 	 -name '\''libopenvswitch*so*'\'' -o \
@@ -46,7 +51,7 @@ docker run -w /usr/local $DOCKER_USER/opflex-build /bin/sh -c 'find lib \(\
            \) ! -name '\''*debug'\'' \
            | xargs tar -c ' \
 	  | tar -x -C build/opflex/dist
-docker run -w /usr/local $DOCKER_USER/opflex-build /bin/sh -c \
+docker run -w /usr/local $DOCKER_HUB_ID/opflex-build$DOCKER_TAG /bin/sh -c \
 	'find lib bin -name '\''*.debug'\'' | xargs tar -cz' \
 	 > opflex-debuginfo.tar.gz
 cp docker/launch-opflexagent.sh build/opflex/dist/bin/
@@ -55,25 +60,25 @@ cp docker/launch-opflexserver.sh build/opflex/dist/bin/
 cp docker/Dockerfile-opflex build/opflex/dist/
 cp docker/Dockerfile-opflexserver build/opflex/dist/
 
-docker build -t $DOCKER_USER/opflex -f ./build/opflex/dist/Dockerfile-opflex build/opflex/dist
-docker push $DOCKER_USER/opflex
-docker build -t $DOCKER_USER/opflexserver -f ./build/opflex/dist/Dockerfile-opflexserver build/opflex/dist
-docker push $DOCKER_USER/opflexserver
+docker build -t $DOCKER_HUB_ID/opflex$DOCKER_TAG -f ./build/opflex/dist/Dockerfile-opflex build/opflex/dist
+docker push $DOCKER_HUB_ID/opflex$DOCKER_TAG
+docker build -t $DOCKER_HUB_ID/opflexserver$DOCKER_TAG -f ./build/opflex/dist/Dockerfile-opflexserver build/opflex/dist
+docker push $DOCKER_HUB_ID/opflexserver$DOCKER_TAG
 
 echo "starting aci-containers build"
 make all-static
 
-docker build -t $DOCKER_USER/aci-containers-controller -f docker/Dockerfile-controller .
-docker push $DOCKER_USER/aci-containers-controller
+docker build -t $DOCKER_HUB_ID/aci-containers-controller$DOCKER_TAG -f docker/Dockerfile-controller .
+docker push $DOCKER_HUB_ID/aci-containers-controller$DOCKER_TAG
 
-docker build -t $DOCKER_USER/aci-containers-host -f docker/Dockerfile-host .
-docker push $DOCKER_USER/aci-containers-host
+docker build -t $DOCKER_HUB_ID/aci-containers-host$DOCKER_TAG -f docker/Dockerfile-host .
+docker push $DOCKER_HUB_ID/aci-containers-host$DOCKER_TAG
 
-docker build -t $DOCKER_USER/cnideploy -f docker/Dockerfile-cnideploy docker
-docker push $DOCKER_USER/cnideploy
+docker build -t $DOCKER_HUB_ID/cnideploy$DOCKER_TAG -f docker/Dockerfile-cnideploy docker
+docker push $DOCKER_HUB_ID/cnideploy$DOCKER_TAG
 
 echo "starting openvswitch build"
-docker build -t $DOCKER_USER/openvswitch -f docker/Dockerfile-openvswitch .
-docker push $DOCKER_USER/openvswitch
+docker build -t $DOCKER_HUB_ID/openvswitch$DOCKER_TAG -f docker/Dockerfile-openvswitch .
+docker push $DOCKER_HUB_ID/openvswitchi$DOCKER_TAG
 
 popd


### PR DESCRIPTION
- Export same from build_priv.sh
- This would make private builds lot simpler.
- Default would be noiro with no tag (i.e latest)
  (same as what it is before this change)

Signed-off-by: Madhu Challa <challa@gmail.com>