### PR TITLE
Fixing the format of refresh-timeout in APIC subscription request.

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -821,8 +821,8 @@ func (conn *ApicConnection) subscribe(value string, sub *subscription) bool {
 
 	refresh_interval := ""
 	if conn.RefreshInterval != 0 {
-		refresh_interval = fmt.Sprintf("refresh-timeout=%s&",
-			conn.RefreshInterval)
+		refresh_interval = fmt.Sprintf("refresh-timeout=%v&",
+			conn.RefreshInterval.Seconds())
 	}
 
 	// properly encoding the URI query parameters breaks APIC

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -297,6 +297,12 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	}
 	cont.log.Info("ApicRefreshTimer conf is set to: ", refreshTimeout)
 
+        // Bailout if the refreshTimeout is more than 12Hours
+        if refreshTimeout > (12*60*60) {
+                cont.log.Info("ApicRefreshTimer can't be more than 12Hrs")
+                panic(err)
+        }
+
 	// If not defined, default to 32
 	if cont.config.PodIpPoolChunkSize == 0 {
 		cont.config.PodIpPoolChunkSize = 32


### PR DESCRIPTION
Also added a check to make sure the specified timeout is less than 12Hrs

Before:
URL: https://127.0.0.1:33211/api/mo/uni/tn-common.json?subscription=yes&refresh-time
out=1m0s&query-target=subtree&rsp-subtree=full&
After:
URL: https://127.0.0.1:33211/api/mo/uni/tn-common.json?subscription=yes&refresh-time
out=60&query-target=subtree&rsp-subtree=full&

(cherry picked from commit 1cfc168f81a2a6d3e12f544f94590bfc31bd099b)