### PR TITLE
CSCvp26247 Ignore headless service processing

### DIFF
--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -243,6 +243,12 @@ func (agent *HostAgent) syncServices() bool {
 // Must have index lock
 func (agent *HostAgent) updateServiceDesc(external bool, as *v1.Service,
 	endpoints *v1.Endpoints) bool {
+
+       if as.Spec.ClusterIP == "None" {
+	   agent.log.Debug("ClusterIP is set to None")
+           return true
+       }
+
 	ofas := &opflexService{
 		Uuid:              string(as.ObjectMeta.UID),
 		DomainPolicySpace: agent.config.AciVrfTenant,


### PR DESCRIPTION
Added a check in hostagent to not process headless service (ClusterIP: None)