### PR TITLE
Refresh WS subscriptions 5seconds earlier than actual refresh-timeout value

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -84,11 +84,12 @@ type ApicConnection struct {
 	password  string
 	prefix    string
 
-	ReconnectInterval time.Duration
-	RefreshInterval   time.Duration
-	RetryInterval     time.Duration
-	UseAPICInstTag    bool // use old-style APIC tags rather than annotations
-	FullSyncHook      func()
+	ReconnectInterval 	time.Duration
+	RefreshInterval   	time.Duration
+	RefreshTickerAdjust 	time.Duration
+	RetryInterval     	time.Duration
+	UseAPICInstTag    	bool // use old-style APIC tags rather than annotations
+	FullSyncHook      	func()
 
 	dialer        *websocket.Dialer
 	connection    *websocket.Conn

--- a/pkg/apicapi/apicapi_test.go
+++ b/pkg/apicapi/apicapi_test.go
@@ -178,7 +178,7 @@ func (server *testServer) testConn(key []byte) (*ApicConnection, error) {
 	})
 
 	n, err := New(log, []string{apic}, "admin", "noir0123", key, cert, "kube",
-		60)
+		60, 5)
 	if err != nil {
 		return nil, err
 	}
@@ -390,6 +390,7 @@ func TestReconnect(t *testing.T) {
 
 	stopCh := make(chan struct{})
 	conn.RefreshInterval = 5 * time.Millisecond
+	conn.RefreshTickerAdjust = 1 * time.Millisecond
 	conn.AddSubscriptionDn("uni/tn-common", []string{"fvBD"})
 	go conn.Run(stopCh)
 

--- a/pkg/controller/cf_common_test.go
+++ b/pkg/controller/cf_common_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 func fakeApicConnection(t *testing.T, log *logrus.Logger) *apic.ApicConnection {
-	conn, _ := apic.New(log, []string{}, "admin", "", nil, nil, "test", 60)
+	conn, _ := apic.New(log, []string{}, "admin", "", nil, nil, "test", 60, 5)
 	assert.NotNil(t, conn)
 	return conn
 }

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -77,6 +77,10 @@ type ControllerConfig struct {
 	// Also, note that this is a string.
 	ApicRefreshTimer string `json:"apic-refreshtime,omitempty"`
 
+	// How early (seconds) the subscriptions to be refreshed than
+	// actual subscription refresh-timeout. Will be defaulted to 5Seconds. 
+	ApicRefreshTickerAdjust string `json:"apic-refreshticker-adjust,omitempty"`
+
 	// A path for a PEM-encoded private key for client certificate
 	// authentication for APIC API
 	ApicPrivateKeyPath string `json:"apic-private-key-path,omitempty"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -303,6 +303,15 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
                 panic(err)
         }
 
+	// If RefreshTickerAdjustInterval is not defined, default to 5Sec. 
+	if cont.config.ApicRefreshTickerAdjust == "" {
+		cont.config.ApicRefreshTickerAdjust = "5"
+	}
+	refreshTickerAdjust, err := strconv.Atoi(cont.config.ApicRefreshTickerAdjust)
+	if err != nil {
+		panic(err)
+	}
+
 	// If not defined, default to 32
 	if cont.config.PodIpPoolChunkSize == 0 {
 		cont.config.PodIpPoolChunkSize = 32
@@ -312,7 +321,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	cont.apicConn, err = apicapi.New(cont.log, cont.config.ApicHosts,
 		cont.config.ApicUsername, cont.config.ApicPassword,
 		privKey, apicCert, cont.config.AciPrefix,
-		refreshTimeout)
+		refreshTimeout, refreshTickerAdjust)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Issue:
Current code refreshes WS subscriptions exactly on the last second of refresh-timeout. Depending on APIC load, its possible that these refresh messages get processed a little late and result in subscription refresh failure.

Fix:
To trigger subscription refreshes 5sec earlier than actual refresh-timeout value that is used as part of initial subscription.

The fix has been tested on a fab setup.