### PR TITLE
Update opflex device subscription in controller

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -377,12 +377,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 			"vmmInjectedOrg", "vmmInjectedOrgUnit"})
 
 	cont.apicConn.AddSubscriptionClass("opflexODev",
-		[]string{"opflexODev"},
-		fmt.Sprintf("and(eq(opflexODev.devType,\"%s\"),"+
-			"eq(opflexODev.domName,\"%s\"),"+
-			"eq(opflexODev.ctrlrName,\"%s\"))",
-			cont.env.OpFlexDeviceType(), cont.config.AciVmmDomain,
-			cont.config.AciVmmController))
+		[]string{"opflexODev"}, "")
 
 	cont.apicConn.SetSubscriptionHooks("opflexODev",
 		func(obj apicapi.ApicObject) bool {

--- a/pkg/controller/nodes_test.go
+++ b/pkg/controller/nodes_test.go
@@ -69,11 +69,16 @@ func setupODev(cont *testAciController, nodeName string, hasMac bool) {
 	}
 	oDev.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/33]")
+	oDev.SetAttr("devType", "k8s")
+        oDev.SetAttr("domName", "kube")
+        oDev.SetAttr("ctrlrName", "kube")
 	cont.opflexDeviceChanged(oDev)
 }
 
 func TestServiceEpAnnotationV4(t *testing.T) {
 	cont := testController()
+	cont.config.AciVmmDomain = "kube"
+        cont.config.AciVmmController = "kube"
 	cont.config.NodeServiceIpPool = []ipam.IpRange{
 		{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.1.3")},
 	}
@@ -104,6 +109,8 @@ func TestServiceEpAnnotationV4(t *testing.T) {
 
 func TestServiceEpAnnotationV6(t *testing.T) {
 	cont := testController()
+	cont.config.AciVmmDomain = "kube"
+	cont.config.AciVmmController = "kube"
 	cont.config.NodeServiceIpPool = []ipam.IpRange{
 		{Start: net.ParseIP("fd43:85d7:bcf2:9ad2::2"), End: net.ParseIP("fd43:85d7:bcf2:9ad2::3")},
 	}
@@ -132,6 +139,8 @@ func TestServiceEpAnnotationV6(t *testing.T) {
 
 func TestServiceEpAnnotationExisting(t *testing.T) {
 	cont := testController()
+	cont.config.AciVmmDomain = "kube"
+        cont.config.AciVmmController = "kube"
 	cont.config.NodeServiceIpPool = []ipam.IpRange{
 		{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.1.4")},
 		{Start: net.ParseIP("fd43:85d7:bcf2:9ad2::2"), End: net.ParseIP("fd43:85d7:bcf2:9ad2::4")},
@@ -222,6 +231,8 @@ func TestPodNetV6Annotation(t *testing.T) {
 
 func TestPodNetAnnotation(t *testing.T) {
 	cont := testController()
+	cont.config.AciVmmDomain = "kube"
+        cont.config.AciVmmController = "kube"
 	cont.config.PodIpPoolChunkSize = 2
 	cont.config.PodIpPool = []ipam.IpRange{
 		{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.1.13")},

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -337,13 +337,21 @@ func TestServiceAnnotation(t *testing.T) {
 	opflexDevice1.SetAttr("hostName", "node1")
 	opflexDevice1.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/33]")
+	opflexDevice1.SetAttr("devType", "k8s")
+	opflexDevice1.SetAttr("domName", "kube")
+	opflexDevice1.SetAttr("ctrlrName", "kube")
 
 	opflexDevice2 := apicapi.EmptyApicObject("opflexODev", "dev2")
 	opflexDevice2.SetAttr("hostName", "node2")
 	opflexDevice2.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/34]")
+	opflexDevice2.SetAttr("devType", "k8s")
+        opflexDevice2.SetAttr("domName", "kube")
+        opflexDevice2.SetAttr("ctrlrName", "kube")
 
 	cont := sgCont()
+	cont.config.AciVmmDomain = "kube"
+	cont.config.AciVmmController = "kube"
 	cont.fakeNodeSource.Add(node1)
 	cont.fakeNodeSource.Add(node2)
 	cont.fakeServiceSource.Add(service2)
@@ -509,26 +517,41 @@ func TestServiceGraph(t *testing.T) {
 	opflexDevice1.SetAttr("hostName", "node1")
 	opflexDevice1.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/33]")
+	opflexDevice1.SetAttr("devType", "k8s")
+        opflexDevice1.SetAttr("domName", "kube")
+        opflexDevice1.SetAttr("ctrlrName", "kube")
 
 	opflexDevice2 := apicapi.EmptyApicObject("opflexODev", "dev2")
 	opflexDevice2.SetAttr("hostName", "node2")
 	opflexDevice2.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/34]")
+	opflexDevice2.SetAttr("devType", "k8s")
+        opflexDevice2.SetAttr("domName", "kube")
+        opflexDevice2.SetAttr("ctrlrName", "kube")
 
 	opflexDevice3 := apicapi.EmptyApicObject("opflexODev", "dev1")
 	opflexDevice3.SetAttr("hostName", "node3")
 	opflexDevice3.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/50]")
+	opflexDevice3.SetAttr("devType", "k8s")
+        opflexDevice3.SetAttr("domName", "kube")
+        opflexDevice3.SetAttr("ctrlrName", "kube")
 
 	opflexDevice4 := apicapi.EmptyApicObject("opflexODev", "dev2")
 	opflexDevice4.SetAttr("hostName", "node4")
 	opflexDevice4.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/51]")
+	opflexDevice4.SetAttr("devType", "k8s")
+        opflexDevice4.SetAttr("domName", "kube")
+        opflexDevice4.SetAttr("ctrlrName", "kube")
 
 	opflexDevice1_alt := apicapi.EmptyApicObject("opflexODev", "dev1")
 	opflexDevice1_alt.SetAttr("hostName", "node1")
 	opflexDevice1_alt.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/100]")
+	opflexDevice1_alt.SetAttr("devType", "k8s")
+        opflexDevice1_alt.SetAttr("domName", "kube")
+        opflexDevice1_alt.SetAttr("ctrlrName", "kube")
 
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
@@ -556,6 +579,8 @@ func TestServiceGraph(t *testing.T) {
 	}
 
 	cont := sgCont()
+	cont.config.AciVmmDomain = "kube"
+        cont.config.AciVmmController = "kube"
 	cont.fakeNodeSource.Add(node1)
 	cont.fakeNodeSource.Add(node2)
 	cont.fakeServiceSource.Add(service2)


### PR DESCRIPTION
Remove the filters on class subscription in controller for opflex devices. Implement these filters inside the functions for the subscription hook (opflexDeviceChanged and opflexDeviceDeleted) instead.

This is to make sure we don't filter out updates from APIC for opflex device deletions, as these notifications come with the above filter values set as defaults.

This is fix to http://cdets.cisco.com/apps/dumpcr?identifier=CSCvo58994&content=summary&format=html