### PR TITLE
CSCvi20583 Changing TagInst to TagAnnotation

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -78,12 +78,14 @@ type pendingChange struct {
 }
 
 type ApicConnection struct {
-	apic      []string
-	apicIndex int
-	user      string
-	password  string
-	prefix    string
+	apic      			[]string
+	apicIndex 			int
+	user      			string
+	password  			string
+	prefix    			string
+	version   			float64 // APIC version
 
+    CachedVersion 		float64
 	ReconnectInterval 	time.Duration
 	RefreshInterval   	time.Duration
 	RefreshTickerAdjust 	time.Duration

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -89,9 +89,6 @@ type ControllerConfig struct {
 	// enable secure TLS server verifification
 	ApicCertPath string `json:"apic-cert-path,omitempty"`
 
-	// use old-style APIC tags rather than annotations, for pre-Fraser
-	ApicUseInstTag bool `json:"apic-use-inst-tag,omitempty"`
-
 	// The type of the ACI VMM domain: either "kubernetes",
 	// "openshift" or "cloudfoundry"
 	AciVmmDomainType string `json:"aci-vmm-type,omitempty"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -354,7 +354,23 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	if err != nil {
 		panic(err)
 	}
-	cont.apicConn.UseAPICInstTag = cont.config.ApicUseInstTag
+
+	if len(cont.config.ApicHosts) != 0 {
+		version, err := cont.apicConn.GetVersion()
+		if err != nil {
+			cont.log.Error("Could not get APIC version")
+			panic(err)
+		}
+		cont.apicConn.CachedVersion = version
+		// APIC version 3.2 introduced tagAnnotation support for better scalability.
+		if version >= 3.2 {
+			cont.apicConn.UseAPICInstTag = false
+		} else {
+			cont.apicConn.UseAPICInstTag = true
+		}
+	}
+
+	cont.log.Debug("UseAPICInstTag set to:", cont.apicConn.UseAPICInstTag)
 
 	cont.initStaticObjs()
 


### PR DESCRIPTION
APIC version 3.2 introduced tagAnnotation for scalability reasons.
With this change:
1) Upon ACC start, in very initial stage, APIC will be queried to get current version and based on the version it determines whether to use tagInst or tagAnnotation.
2) While APIC is running with >=3.2, if ACC is upgraded, all the subscriptions will move on to use tagAnnotation. Also, existing tagInst will get removed as part of fullSync/Reconcile logic.
3) While APIC is running with <=3.1, if ACC is upgraded, there shouldn't be any change and ACC shall continue to use tagInst.
4) If APIC is downgraded from >=3.2 to <=3.1, ACC will exit and K8S will restart the container after which things will fall in place.

Testing:
1) Verified the behavior of moving over to tagAnnotation and removal of tagInst by updating ACC.
2) Triggered os.Exit based on websocket connection failure to make sure os.Exit will cause container to exit and K8S restarting it back.
3) Upon each APIC connection restart, ACC fetches the version compares it against CachedVersion to determine whether to restart ACC.