### PR TITLE
Handle cases where SNAT is used with external service IP

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -43,6 +43,7 @@ import (
 type podUpdateFunc func(*v1.Pod) (*v1.Pod, error)
 type nodeUpdateFunc func(*v1.Node) (*v1.Node, error)
 type serviceUpdateFunc func(*v1.Service) (*v1.Service, error)
+type serviceListFunc func(string) (*v1.ServiceList, error)
 
 type AciController struct {
 	log    *logrus.Logger
@@ -76,9 +77,10 @@ type AciController struct {
 	snatIndexer           cache.Indexer
 	snatInformer          cache.Controller
 
-	updatePod           podUpdateFunc
-	updateNode          nodeUpdateFunc
-	updateServiceStatus serviceUpdateFunc
+	updatePod              podUpdateFunc
+	updateNode             nodeUpdateFunc
+	updateServiceStatus    serviceUpdateFunc
+	listServicesBySelector serviceListFunc
 
 	indexMutex sync.Mutex
 
@@ -110,6 +112,7 @@ type AciController struct {
 	nodePodNetCache      map[string]*nodePodNetMeta
 	serviceMetaCache     map[string]*serviceMeta
 	snatPolicyCache      map[string]*ContSnatPolicy
+	snatServices         map[string]bool
 
 	nodeSyncEnabled    bool
 	serviceSyncEnabled bool
@@ -200,6 +203,7 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 		nodePodNetCache:      make(map[string]*nodePodNetMeta),
 		serviceMetaCache:     make(map[string]*serviceMeta),
 		snatPolicyCache:      make(map[string]*ContSnatPolicy),
+		snatServices:         make(map[string]bool),
 	}
 }
 

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/yl2chen/cidranger"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/api/core/v1"
 	v1net "k8s.io/api/networking/v1"
 	"k8s.io/client-go/kubernetes"
@@ -114,6 +114,10 @@ func (env *K8sEnvironment) Init(cont *AciController) error {
 	cont.updateServiceStatus = func(service *v1.Service) (*v1.Service, error) {
 		return kubeClient.CoreV1().
 			Services(service.ObjectMeta.Namespace).UpdateStatus(service)
+	}
+
+	cont.listServicesBySelector = func(selector string) (*v1.ServiceList, error) {
+		return kubeClient.CoreV1().Services("").List(metav1.ListOptions{LabelSelector: selector,})
 	}
 
 	cont.log.Debug("Initializing informers")

--- a/pkg/controller/snats_test.go
+++ b/pkg/controller/snats_test.go
@@ -51,7 +51,7 @@ func testsnatpolicy(name string, namespace string, deploy string,
 }
 
 func TestSnatGraph(t *testing.T) {
-	name := "kube_snat_MYSNAT"
+	name := "kube_snat_" + snatGraphName
 	graphName := "kube_svc_global"
 	cluster := func(nmap map[string]string) apicapi.ApicObject {
 		var nodes []string


### PR DESCRIPTION
If we want to use an external IP from a LB service, open ports on that service's contract. Whenever a snat policy is provided without a snatIP, find services that match the policy spec labels and use that service IP for SNAT