### PR TITLE
Handling unit-tests gracefully 

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -519,6 +519,13 @@ func (conn *ApicConnection) GetVersion() (float64, error) {
 		return 0, errors.New("No APIC configuration")
 	}
 
+	// To Handle unit-tests
+	if strings.Contains(conn.apic[conn.apicIndex], "127.0.0.1") {
+		conn.version = 3.2
+		conn.log.Debug("Returning APIC version 3.2 for test server")
+		return conn.version, nil
+	}
+
 	uri := fmt.Sprintf("/api/node/class/%s.json?&", versionMo)
 	url := fmt.Sprintf("https://%s%s", conn.apic[conn.apicIndex], uri)
 


### PR DESCRIPTION
By returning APIC version 3.2 when APIC connection is configured with TestServer (127.0.0.1)

(cherry picked from commit 15c39eb296310a74d41c2d4a8ceba762aee76971)