### PR TITLE
Switch to OVS 2.10.1-r2

### DIFF
--- a/docker/Dockerfile-openvswitch
+++ b/docker/Dockerfile-openvswitch
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.10
 RUN apk upgrade --no-cache && \
   apk --no-cache add openvswitch logrotate
 COPY docker/launch-ovs.sh docker/liveness-ovs.sh dist-static/ovsresync /usr/local/bin/


### PR DESCRIPTION
By updating OVS dockerfile to use alpine 3.10.
(cherry picked from commit 28c0b51aa800ac0badd99a034d22ff03bed37f30)