### PR TITLE
launch-ovs.sh: fix postrotate script for ovs logrotation

### DIFF
--- a/docker/launch-ovs.sh
+++ b/docker/launch-ovs.sh
@@ -30,7 +30,7 @@ cat <<EOF > /etc/logrotate.conf
 include /etc/logrotate.d
 EOF
 
-cat <<EOF > /etc/logrotate.d/openvswitch
+cat <<'EOF' > /etc/logrotate.d/openvswitch
 /var/log/openvswitch/*.log {
     size 100k
     compress


### PR DESCRIPTION
ovs container stops logging to STDOUT after the first logrotation
because the logfile is renamed and ovs is not informed to close/reopen
it's log. The reason is the postrotate script calling "ovs-appctl" with
empty targets:

ovs-appctl -t "" vlog/reopen

This fix prevents variable expansion and command substitution in the
HERE document that creates the logrotate configuration vor ovs.

(cherry picked from commit 236a040dfdcdc984394cab234c12fcc21f05abef)