### PR TITLE
Add option configure max nodes per service graph

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -162,6 +162,9 @@ type ControllerConfig struct {
 	// default port range to use for SNAT svc graph filter
         SnatDefaultPortRangeStart int `json:"snat-default-port-range-start,omitempty"`
         SnatDefaultPortRangeEnd int `json:"snat-default-port-range-end,omitempty"`
+
+	// Maximum number of nodes permitted in a svc graph
+	MaxSvcGraphNodes int `json:"max-nodes-svc-graph,omitempty"`
 }
 
 type netIps struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -350,6 +350,10 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		cont.config.SnatDefaultPortRangeStart = defStart
 		cont.config.SnatDefaultPortRangeEnd = defEnd
 	}
+	if cont.config.MaxSvcGraphNodes == 0 {
+		cont.config.MaxSvcGraphNodes = 32
+	}
+	cont.log.Info("Max number of nodes per svc graph is set to: ", cont.config.MaxSvcGraphNodes)
 
 	cont.apicConn, err = apicapi.New(cont.log, cont.config.ApicHosts,
 		cont.config.ApicUsername, cont.config.ApicPassword,

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -626,7 +626,10 @@ func (cont *AciController) updateServiceDeviceInstanceSnat(key string) error {
 		return nil
 	}
 	cont.indexMutex.Lock()
-	for _, nodeItem := range nodeList {
+	for itr, nodeItem := range nodeList {
+		if itr == cont.config.MaxSvcGraphNodes {
+			break
+		}
 		node := nodeItem.(*v1.Node)
 		nodeName := node.ObjectMeta.Name
 		nodeMeta, ok := cont.nodeServiceMetaCache[nodeName]

--- a/pkg/controller/snats_test.go
+++ b/pkg/controller/snats_test.go
@@ -105,18 +105,12 @@ func TestSnatGraph(t *testing.T) {
 	snatIp := []string{"10.4.2.2", "10.20.30.40/20"}
 	labels := map[string]string{
 			"lab_key" : "lab_value"}
-	//label := ContLabel{Key: "lab_key", Value: "lab_value"}
-//	var labels []ContLabel
-//	labels = append(labels, label)
 	policy := testsnatpolicy("testpolicy", "common", "deployment",
 		snatIp, labels)
 
 	snatIp2 := []string{"172.2.2.1/32"}
 	labels2 := map[string]string{
 			"lab_key2" : "lab_value2"}
-//	label2 := ContLabel{Key: "lab_key2", Value: "lab_value2"}
-//	var labels2 []ContLabel
-//	labels2 = append(labels2, label2)
 	policy2 := testsnatpolicy("testpolicy2", "common", "deployment2",
 		snatIp2, labels2)
 
@@ -126,6 +120,9 @@ func TestSnatGraph(t *testing.T) {
 	node2 := node("node2")
 	node2.ObjectMeta.Annotations[metadata.ServiceEpAnnotation] =
 		"{\"mac\":\"a2:7e:45:57:a0:d4\",\"ipv4\":\"10.6.1.2\"}"
+	node3 := node("node3")
+	node3.ObjectMeta.Annotations[metadata.ServiceEpAnnotation] =
+		"{\"mac\":\"3e:13:a1:a1:34:60\",\"ipv4\":\"10.6.1.3\"}"
 
 	opflexDevice1 := apicapi.EmptyApicObject("opflexODev", "dev1")
 	opflexDevice1.SetAttr("hostName", "node1")
@@ -146,8 +143,10 @@ func TestSnatGraph(t *testing.T) {
 	cont := sgCont()
 	cont.config.AciVmmDomain = "kube"
 	cont.config.AciVmmController = "kube"
+	cont.config.MaxSvcGraphNodes = 2
 	cont.fakeNodeSource.Add(node1)
 	cont.fakeNodeSource.Add(node2)
+	cont.fakeNodeSource.Add(node3)
 
 	cont.run()
 	cont.fakeSnatPolicySource.Add(policy)


### PR DESCRIPTION
This can be configured through acc-provision. Default value is set to 24.