### PR TITLE
Fix PBR-Tracking for services

### DIFF
--- a/pkg/controller/cf_environment.go
+++ b/pkg/controller/cf_environment.go
@@ -672,7 +672,7 @@ func (env *CfEnvironment) SetCellServiceInfo(nodeName, cellId string) {
 		existing = &currMeta.serviceEp
 	}
 	err := env.cont.createServiceEndpoint(existing, &nodeMeta.serviceEp,
-		deviceMac)
+		deviceMac, nodeName)
 	if err != nil {
 		env.log.Error("Couldn't create service EP info for cell: ", err)
 		return

--- a/pkg/controller/cf_update_handlers.go
+++ b/pkg/controller/cf_update_handlers.go
@@ -325,18 +325,9 @@ func (env *CfEnvironment) createAppServiceGraph(appId string, extIps []string) (
 
 	if len(nodes) > 0 {
 		// 1. Service redirect policy
-		var healthGroupDn string
-		if cont.config.AciServiceMonitorInterval > 0 {
-			healthGroup :=
-				apicapi.NewVnsRedirectHealthGroup(cont.config.AciVrfTenant,
-					name)
-			healthGroupDn = healthGroup.GetDn()
-			serviceObjs = append(serviceObjs, healthGroup)
-		}
-
 		rp, rpDn :=
 			apicRedirectPol(name, cont.config.AciVrfTenant, nodes,
-				nodeMap, cont.staticMonPolDn(), healthGroupDn)
+				nodeMap, cont.staticMonPolDn())
 		serviceObjs = append(serviceObjs, rp)
 
 		// 2. Service graph contract and external network

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -282,7 +282,7 @@ func apicRedirectDst(rpDn string, ip string, mac string,
 
 func apicRedirectPol(name string, tenantName string, nodes []string,
 	nodeMap map[string]*metadata.ServiceEndpoint,
-	monPolDn string, healthGroupDn string) (apicapi.ApicObject, string) {
+	monPolDn string) (apicapi.ApicObject, string) {
 
 	rp := apicapi.NewVnsSvcRedirectPol(tenantName, name)
 	rp.SetAttr("thresholdDownAction", "deny")
@@ -294,11 +294,11 @@ func apicRedirectPol(name string, tenantName string, nodes []string,
 		}
 		if serviceEp.Ipv4 != nil {
 			rp.AddChild(apicRedirectDst(rpDn, serviceEp.Ipv4.String(),
-				serviceEp.Mac, node, healthGroupDn))
+				serviceEp.Mac, node, serviceEp.HealthGroupDn))
 		}
 		if serviceEp.Ipv6 != nil {
 			rp.AddChild(apicRedirectDst(rpDn, serviceEp.Ipv6.String(),
-				serviceEp.Mac, node, healthGroupDn))
+				serviceEp.Mac, node, serviceEp.HealthGroupDn))
 		}
 	}
 	if monPolDn != "" {
@@ -560,18 +560,9 @@ func (cont *AciController) updateServiceDeviceInstance(key string,
 		// and IP address of each of the service endpoints for
 		// each node that hosts a pod for this service.  The
 		// example below shows the case of two nodes.
-		var healthGroupDn string
-		if cont.config.AciServiceMonitorInterval > 0 {
-			healthGroup :=
-				apicapi.NewVnsRedirectHealthGroup(cont.config.AciVrfTenant,
-					name)
-			healthGroupDn = healthGroup.GetDn()
-			serviceObjs = append(serviceObjs, healthGroup)
-		}
-
 		rp, rpDn :=
 			apicRedirectPol(name, cont.config.AciVrfTenant, nodes,
-				nodeMap, cont.staticMonPolDn(), healthGroupDn)
+				nodeMap, cont.staticMonPolDn())
 		serviceObjs = append(serviceObjs, rp)
 
 		// 2. Service graph contract and external network
@@ -660,18 +651,9 @@ func (cont *AciController) updateServiceDeviceInstanceSnat(key string) error {
                 // and IP address of each of the service endpoints for
                 // each node that hosts a pod for this service.  The
                 // example below shows the case of two nodes.
-                var healthGroupDn string
-                if cont.config.AciServiceMonitorInterval > 0 {
-                        healthGroup :=
-                                apicapi.NewVnsRedirectHealthGroup(cont.config.AciVrfTenant,
-                                        name)
-                        healthGroupDn = healthGroup.GetDn()
-			serviceObjs = append(serviceObjs, healthGroup)
-                }
-
                 rp, rpDn :=
                         apicRedirectPol(name, cont.config.AciVrfTenant, nodes,
-                                nodeMap, cont.staticMonPolDn(), healthGroupDn)
+                                nodeMap, cont.staticMonPolDn())
 		serviceObjs = append(serviceObjs, rp)
 
 

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -253,8 +253,6 @@ func TestServiceAnnotation(t *testing.T) {
 		"node2": "topology/pod-1/paths-301/pathep-[eth1/34]",
 	})
 	graph := apicServiceGraph(graphName, "common", twoNodeCluster.GetDn())
-	healthGroup := apicapi.NewVnsRedirectHealthGroup("common",
-		name)
 
 	redirect := func(nmap seMap) apicapi.ApicObject {
 		var nodes []string
@@ -265,15 +263,17 @@ func TestServiceAnnotation(t *testing.T) {
 		monPolDn := fmt.Sprintf("uni/tn-%s/ipslaMonitoringPol-%s",
 			"common", "kube_monPol_kubernetes-service")
 		dc, _ := apicRedirectPol(name, "common", nodes,
-			nmap, monPolDn, healthGroup.GetDn())
+			nmap, monPolDn)
 		return dc
 	}
 	twoNodeRedirect := redirect(seMap{
 		"node1": &metadata.ServiceEndpoint{
-			Mac:  "8a:35:a1:a6:e4:60",
-			Ipv4: net.ParseIP("10.6.1.1"),
+			HealthGroupDn:  "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1",
+			Mac:  			"8a:35:a1:a6:e4:60",
+			Ipv4: 			net.ParseIP("10.6.1.1"),
 		},
 		"node2": &metadata.ServiceEndpoint{
+			HealthGroupDn:  "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node2",
 			Mac:  "a2:7e:45:57:a0:d4",
 			Ipv4: net.ParseIP("10.6.1.2"),
 		},
@@ -396,7 +396,7 @@ func TestServiceAnnotation(t *testing.T) {
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
-		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{healthGroup, twoNodeRedirect, extNet, contract, rsProv, filter, s1Dcc},
+		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet, contract, rsProv, filter, s1Dcc},
 			"kube", name),
 		nameS2: nil,
 	}
@@ -431,8 +431,6 @@ func TestServiceGraph(t *testing.T) {
 	name := "kube_svc_testns_service1"
 	conScope := "context"
 	nameS2 := "kube_svc_testns_service2"
-	healthGroup := apicapi.NewVnsRedirectHealthGroup("common",
-		name)
 	redirect := func(nmap seMap) apicapi.ApicObject {
 		var nodes []string
 		for node := range nmap {
@@ -442,21 +440,24 @@ func TestServiceGraph(t *testing.T) {
 		monPolDn := fmt.Sprintf("uni/tn-%s/ipslaMonitoringPol-%s",
 			"common", "kube_monPol_kubernetes-service")
 		dc, _ := apicRedirectPol(name, "common", nodes,
-			nmap, monPolDn, healthGroup.GetDn())
+			nmap, monPolDn)
 		return dc
 	}
 	twoNodeRedirect := redirect(seMap{
 		"node1": &metadata.ServiceEndpoint{
+			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1",
 			Mac:  "8a:35:a1:a6:e4:60",
 			Ipv4: net.ParseIP("10.6.1.1"),
 		},
 		"node2": &metadata.ServiceEndpoint{
+			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node2",
 			Mac:  "a2:7e:45:57:a0:d4",
 			Ipv4: net.ParseIP("10.6.1.2"),
 		},
 	})
 	oneNodeRedirect := redirect(seMap{
 		"node1": &metadata.ServiceEndpoint{
+			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1",
 			Mac:  "8a:35:a1:a6:e4:60",
 			Ipv4: net.ParseIP("10.6.1.1"),
 		},
@@ -556,7 +557,7 @@ func TestServiceGraph(t *testing.T) {
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
-		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{healthGroup,
+		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{
 			twoNodeRedirect, extNet, contract, rsProv, filter, s1Dcc},
 			"kube", name),
 		nameS2: nil,
@@ -565,7 +566,7 @@ func TestServiceGraph(t *testing.T) {
 	expectedOneNode := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{oneNodeCluster,
 			graph}, "kube", graphName),
-		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{healthGroup,
+		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{
 			oneNodeRedirect, extNet, contract, rsProv, filter, s1Dcc},
 			"kube", name),
 		nameS2: nil,

--- a/pkg/controller/snats_test.go
+++ b/pkg/controller/snats_test.go
@@ -63,8 +63,6 @@ func TestSnatGraph(t *testing.T) {
 	})
 
 	graph := apicServiceGraph(graphName, "common", twoNodeCluster.GetDn())
-	healthGroup := apicapi.NewVnsRedirectHealthGroup("common",
-		name)
 
 	redirect := func(nmap seMap) apicapi.ApicObject {
 		var nodes []string
@@ -75,15 +73,17 @@ func TestSnatGraph(t *testing.T) {
 		monPolDn := fmt.Sprintf("uni/tn-%s/ipslaMonitoringPol-%s",
 			"common", "kube_monPol_kubernetes-service")
 		dc, _ := apicRedirectPol(name, "common", nodes,
-			nmap, monPolDn, healthGroup.GetDn())
+			nmap, monPolDn)
 		return dc
 	}
 	twoNodeRedirect := redirect(seMap{
 		"node1": &metadata.ServiceEndpoint{
+			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1",
 			Mac:  "8a:35:a1:a6:e4:60",
 			Ipv4: net.ParseIP("10.6.1.1"),
 		},
 		"node2": &metadata.ServiceEndpoint{
+			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node2",
 			Mac:  "a2:7e:45:57:a0:d4",
 			Ipv4: net.ParseIP("10.6.1.2"),
 		},
@@ -122,10 +122,10 @@ func TestSnatGraph(t *testing.T) {
 
 	node1 := node("node1")
 	node1.ObjectMeta.Annotations[metadata.ServiceEpAnnotation] =
-		"{\"mac\":\"8a:35:a1:a6:e4:60\",\"ipv4\":\"10.6.1.1\"}"
+		"{\"health-group-dn\":\"uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1\",\"mac\":\"8a:35:a1:a6:e4:60\",\"ipv4\":\"10.6.1.1\"}"
 	node2 := node("node2")
 	node2.ObjectMeta.Annotations[metadata.ServiceEpAnnotation] =
-		"{\"mac\":\"a2:7e:45:57:a0:d4\",\"ipv4\":\"10.6.1.2\"}"
+		"{\"health-group-dn\":\"uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node2\",\"mac\":\"a2:7e:45:57:a0:d4\",\"ipv4\":\"10.6.1.2\"}"
 
 	opflexDevice1 := apicapi.EmptyApicObject("opflexODev", "dev1")
 	opflexDevice1.SetAttr("hostName", "node1")
@@ -158,7 +158,7 @@ func TestSnatGraph(t *testing.T) {
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
-		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{healthGroup, twoNodeRedirect, extNet, contract, rsProv, filter, cc},
+		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet, contract, rsProv, filter, cc},
 			"kube", name),
 	}
 	sgWait(t, "snat graph creation", cont, expected)
@@ -169,7 +169,7 @@ func TestSnatGraph(t *testing.T) {
 	expected2 := map[string]apicapi.ApicSlice{
                 graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
                         graph}, "kube", graphName),
-                name: apicapi.PrepareApicSlice(apicapi.ApicSlice{healthGroup, twoNodeRedirect, extNet2, contract, rsProv, filter, cc},
+                name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet2, contract, rsProv, filter, cc},
                         "kube", name),
         }
 	sgWait(t, "snat graph addition", cont, expected2)
@@ -179,7 +179,7 @@ func TestSnatGraph(t *testing.T) {
 	expectedDeleteSnatPolicy := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
-		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{healthGroup, twoNodeRedirect, extNet, contract, rsProv, filter, cc},
+		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet, contract, rsProv, filter, cc},
 			"kube", name),
 	}
 	sgWait(t, "snat policy deleted", cont, expectedDeleteSnatPolicy)

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -32,9 +32,10 @@ type OpflexGroup struct {
 
 // annotation type for service endpoint information
 type ServiceEndpoint struct {
-	Mac  string `json:"mac,omitempty"`
-	Ipv4 net.IP `json:"ipv4,omitempty"`
-	Ipv6 net.IP `json:"ipv6,omitempty"`
+	HealthGroupDn   string `json:"-"`
+	Mac  			string `json:"mac,omitempty"`
+	Ipv4 			net.IP `json:"ipv4,omitempty"`
+	Ipv6 			net.IP `json:"ipv6,omitempty"`
 }
 
 // annotation type for IPs allocation chunks


### PR DESCRIPTION
Current code created one health-group for all compute-nodes when IPSLA interval is set to a positive value.
This is incorrect, as health-group comes up when one of the compute-nodes are unreachable.

Fix is to create one HG per node and associate them to the redirect policy when IPSLA is configured to be more than zero.
With this fix, health-group's are created part of ServiceEndpoint creation (only when IPSLA is configured) and store healthgroupDn in ServiceEndPoint Metadata and use them when Redirect policy is created as the services comes-up.

Tested the behavior on vk8s testbed and there is enough UT coverage.