### PR TITLE
Fix tagAnnotation dn format

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -487,10 +487,15 @@ func NewTagInst(parentDn string, name string) ApicObject {
 }
 
 func NewTagAnnotation(parentDn string, key string) ApicObject {
+	dn := ""
 	ret := newApicObject("tagAnnotation")
 	ret["tagAnnotation"].Attributes["key"] = key
-	ret["tagAnnotation"].Attributes["dn"] =
-		fmt.Sprintf("%s/annotationKey-%s", parentDn, key)
+	if ApicVersion >=4.1 {
+		dn = fmt.Sprintf("%s/annotationKey-[%s]", parentDn, key)
+	} else {
+		dn = fmt.Sprintf("%s/annotationKey-%s", parentDn, key)
+	}
+	ret["tagAnnotation"].Attributes["dn"] = dn
 	return ret
 }
 

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -44,6 +44,13 @@ import (
 // RefreshInterval is set to 0
 const defaultConnectionRefresh = 30 * time.Second
 
+// ApicVersion - This global variable to be used when dealing with version-
+// dependencies during APIC interaction. It gets filled with actual version
+// as part of runConn()
+var (
+	ApicVersion = 3.1
+)
+
 func complete(resp *http.Response) {
 	if resp.StatusCode != http.StatusOK {
 		rBody, err := ioutil.ReadAll(resp.Body)
@@ -472,6 +479,7 @@ func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {
 	if refreshInterval == 0 {
 		refreshInterval = defaultConnectionRefresh
 	}
+	ApicVersion = conn.version
 	// Adjust refreshTickerInterval.
 	// To refresh the subscriptions early than actual refresh timeout value
 	refreshTickerInterval := refreshInterval - conn.RefreshTickerAdjust


### PR DESCRIPTION
It appears that APIC4.1 onwards seems to have changed the format of tagAnnotation object.
This change will accommodate the same, so that it avoids treating an object as altered when processing a websocket notification on any of the ACC managed objects.

Example:
Prior to 4.1: uni/tn-common/brc-vk8s_2_snat_svcgraph/annotationKey-aci-containers-controller-tag
4.1+        : uni/tn-common/brc-vk8s_2_snat_svcgraph/annotationKey-[aci-containers-controller-tag]

Tests:
Reproduced the issue on Fab14 and tested with fix.