### PR TITLE
Configure snat namespace for hostagent nodeinfo processing

### DIFF
--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -178,6 +178,9 @@ type HostAgentConfig struct {
 
 	//ZoneId for Snat flows
 	Zone uint `json:"zone,omitempty"`
+
+	//Namespace for SNAT CRDs
+	AciSnatNamespace string `json:"aci-snat-namespace,omitempty"`
 }
 
 func (config *HostAgentConfig) InitFlags() {
@@ -232,4 +235,5 @@ func (config *HostAgentConfig) InitFlags() {
 	flag.StringVar(&config.AciVrf, "aci-vrf", "kubernetes-vrf", "ACI VRF for this kubernetes instance")
 	flag.StringVar(&config.AciVrfTenant, "aci-vrf-tenant", "common", "ACI Tenant containing the ACI VRF for this kubernetes instance")
 	flag.UintVar(&config.Zone, "zone", 8191, "Zone Id for snat flows")
+	flag.StringVar(&config.AciSnatNamespace, "aci-snat-namespace", "aci-containers-system", "Namespace for SNAT CRDs")
 }

--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -145,7 +145,7 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 
 	env.agent.log.Debug("Starting remaining informers")
 	env.agent.log.Debug("Exporting node info: ", env.agent.config.NodeName)
-	go env.agent.InformNodeInfo(env.nodeInfo, env.kubeClient)
+	go env.agent.InformNodeInfo(env.nodeInfo)
 	go env.agent.podInformer.Run(stopCh)
 	go env.agent.endpointsInformer.Run(stopCh)
 	go env.agent.serviceInformer.Run(stopCh)


### PR DESCRIPTION
aci-snat-namespace can be set as field in host-agent-config in the aci deployment file. Set to "aci-containers-system" by default.
If the user sets this field to a garbage value(i.e not a valid k8s namespace), print an error statement and ignore. The user needs to either remove that namespace value or set it to something valid.