### PR TITLE
Handling acc-restart gracefully

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -426,7 +426,6 @@ func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {
 	}()
 
 	conn.indexMutex.Lock()
-	ApicVersion = conn.version
 	oldState := conn.cacheDnSubIds
 	conn.cachedState = make(map[string]ApicSlice)
 	conn.cacheDnSubIds = make(map[string]map[string]bool)
@@ -469,6 +468,7 @@ func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {
 				conn.log.Error("Error while getting APIC version: ", err)
 			} else {
 				conn.log.Debug("Cached version:", conn.CachedVersion, " New version:", version)
+				ApicVersion = version
 				if version <=3.1 && conn.CachedVersion >=3.2 {
 					conn.log.Debug("APIC is downgraded from >=3.2 to a lower version, Exiting ")
 					os.Exit(1) //K8S shall restart the container and fallback to tagInst

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -370,6 +370,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 			panic(err)
 		}
 		cont.apicConn.CachedVersion = version
+		apicapi.ApicVersion = version
 		// APIC version 3.2 introduced tagAnnotation support for better scalability.
 		if version >= 3.2 {
 			cont.apicConn.UseAPICInstTag = false


### PR DESCRIPTION
When ACC restarts, during the initialization ACC builds the desired-state of all the APICObjects based on node/pod/services information. Then, as part of subscribing to all interested APIC classes/Dns, current APIC state will be built based on the subscription response. Comparing these desired/current states will help reconciling the state changes that may have happened while ACC was down.

With tagAnnotation dn format dependency on APIC version, we need to initialize the ApicVersion (Global) early enough so that the desired-state can be built correctly.