### PR TITLE
Add sleep time for APIC sync

### DIFF
--- a/pkg/apicapi/apic_sync.go
+++ b/pkg/apicapi/apic_sync.go
@@ -19,6 +19,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -254,6 +256,10 @@ func prepareApicCache(parentDn string, obj ApicObject) {
 }
 
 func (conn *ApicConnection) fullSync() {
+	// Sleep for service sync up except for unit tests
+	if !strings.Contains(conn.apic[conn.apicIndex], "127.0.0.1") {
+		time.Sleep(5 * time.Second)
+	}
 	conn.log.Info("Starting APIC full sync")
 	var updates ApicSlice
 	var deletes []string


### PR DESCRIPTION
Add a 5 seconds sleep time before APIC sync to let service and snat updates finish

(cherry picked from commit c057d21f8eae2a012f7c3537ae07cba4161ccbb2)