### PR TITLE
Snat sync for when acc restarts

### DIFF
--- a/pkg/apicapi/apic_sync.go
+++ b/pkg/apicapi/apic_sync.go
@@ -19,8 +19,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"sort"
-	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -256,10 +254,6 @@ func prepareApicCache(parentDn string, obj ApicObject) {
 }
 
 func (conn *ApicConnection) fullSync() {
-	// Sleep for service sync up except for unit tests
-	if !strings.Contains(conn.apic[conn.apicIndex], "127.0.0.1") {
-		time.Sleep(5 * time.Second)
-	}
 	conn.log.Info("Starting APIC full sync")
 	var updates ApicSlice
 	var deletes []string

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -275,6 +275,7 @@ func (cont *AciController) nodeChanged(obj interface{}) {
 				nodeUpdated = true
 			}
 			cont.updateServicesForNode(node.ObjectMeta.Name)
+			cont.snatFullSync()
 		}
 	}
 
@@ -339,6 +340,7 @@ func (cont *AciController) nodeDeleted(obj interface{}) {
 	}
 	delete(cont.nodeServiceMetaCache, node.ObjectMeta.Name)
 	cont.updateServicesForNode(node.ObjectMeta.Name)
+	cont.snatFullSync()
 }
 
 // must have index lock

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1159,7 +1159,7 @@ func (cont *AciController) handleServiceUpdate(service *v1.Service) bool {
 			cont.indexMutex.Unlock()
 			err = cont.updateServiceDeviceInstance(servicekey, service)
 			if err != nil {
-				return false
+				return true
 			}
 		} else {
 			cont.indexMutex.Unlock()

--- a/pkg/controller/snats.go
+++ b/pkg/controller/snats.go
@@ -131,7 +131,7 @@ func (cont *AciController) handleSnatUpdate(snatpolicy *snatpolicy.SnatPolicy) b
 		} else {
 			err = cont.updateServiceDeviceInstanceSnat(snatGraphName)
 		}
-		if err == nil {
+		if err != nil {
 			requeue = true
 		}
 	} else {
@@ -159,6 +159,7 @@ func (cont *AciController) handleSnatPolicyForServices(snatpolicy *snatpolicy.Sn
 			cont.indexMutex.Lock()
 			if service.GetDeletionTimestamp() == nil {
 				cont.snatServices[servicekey] = true
+				cont.queueServiceUpdateByKey(servicekey)
 			}
 			cont.indexMutex.Unlock()
 		}
@@ -190,6 +191,7 @@ func (cont *AciController) snatPolicyDelete(snatobj interface{}) {
 							servicekey = service.ObjectMeta.Namespace + "/" + service.ObjectMeta.Name
 						}
 						delete(cont.snatServices, servicekey)
+						cont.queueServiceUpdateByKey(servicekey)
 					}
 				}
 			}


### PR DESCRIPTION
Removed the 5 sec sleep time introduced in https://github.com/noironetworks/aci-containers/pull/350

(cherry picked from commit dc8285e1fb70f6801a44fe3e5b7704bba8a871ef)