### PR TITLE
Flip contract relationship for external svc graph

### DIFF
--- a/pkg/controller/cf_update_handlers.go
+++ b/pkg/controller/cf_update_handlers.go
@@ -333,7 +333,7 @@ func (env *CfEnvironment) createAppServiceGraph(appId string, extIps []string) (
 		// 2. Service graph contract and external network
 		serviceObjs = append(serviceObjs,
 			apicExtNet(name, cont.config.AciVrfTenant,
-				cont.config.AciL3Out, extIps, DefaultServiceExtSubNetShared))
+				cont.config.AciL3Out, extIps, DefaultServiceExtSubNetShared, false))
 
 		contract := apicContract(name, cont.config.AciVrfTenant, graphName, DefaultServiceContractScope)
 		serviceObjs = append(serviceObjs, contract)

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -269,8 +269,8 @@ func TestServiceAnnotation(t *testing.T) {
 	twoNodeRedirect := redirect(seMap{
 		"node1": &metadata.ServiceEndpoint{
 			HealthGroupDn:  "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1",
-			Mac:  			"8a:35:a1:a6:e4:60",
-			Ipv4: 			net.ParseIP("10.6.1.1"),
+			Mac:			"8a:35:a1:a6:e4:60",
+			Ipv4:			net.ParseIP("10.6.1.1"),
 		},
 		"node2": &metadata.ServiceEndpoint{
 			HealthGroupDn:  "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node2",
@@ -284,24 +284,24 @@ func TestServiceAnnotation(t *testing.T) {
 			Ipv4: net.ParseIP("10.6.1.1"),
 		},
 	})
-	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, true)
-	rsProv := apicExtNetProv(name, "common", "l3out", "ext1")
+	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, true, false)
+	rsCons := apicExtNetCons(name, "common", "l3out", "ext1")
 	filter := apicapi.NewVzFilter("common", name)
 	filterDn := filter.GetDn()
 	{
 		fe := apicapi.NewVzEntry(filterDn, "0")
 		fe.SetAttr("etherT", "ip")
 		fe.SetAttr("prot", "tcp")
-		fe.SetAttr("sFromPort", "80")
-		fe.SetAttr("sToPort", "80")
+		fe.SetAttr("dFromPort", "80")
+		fe.SetAttr("dToPort", "80")
 		filter.AddChild(fe)
 	}
 	{
 		fe := apicapi.NewVzEntry(filterDn, "1")
 		fe.SetAttr("etherT", "ip")
 		fe.SetAttr("prot", "udp")
-		fe.SetAttr("sFromPort", "53")
-		fe.SetAttr("sToPort", "53")
+		fe.SetAttr("dFromPort", "53")
+		fe.SetAttr("dToPort", "53")
 		filter.AddChild(fe)
 	}
 	s1Dcc := apicDevCtx(name, "common", graphName,
@@ -396,7 +396,7 @@ func TestServiceAnnotation(t *testing.T) {
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
-		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet, contract, rsProv, filter, s1Dcc},
+		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet, contract, rsCons, filter, s1Dcc},
 			"kube", name),
 		nameS2: nil,
 	}
@@ -463,9 +463,9 @@ func TestServiceGraph(t *testing.T) {
 		},
 	})
 
-	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, false)
+	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, false, false)
 	contract := apicContract(name, "common", graphName, conScope)
-	rsProv := apicExtNetProv(name, "common", "l3out", "ext1")
+	rsCons := apicExtNetCons(name, "common", "l3out", "ext1")
 
 	filter := apicapi.NewVzFilter("common", name)
 	filterDn := filter.GetDn()
@@ -473,16 +473,16 @@ func TestServiceGraph(t *testing.T) {
 		fe := apicapi.NewVzEntry(filterDn, "0")
 		fe.SetAttr("etherT", "ip")
 		fe.SetAttr("prot", "tcp")
-		fe.SetAttr("sFromPort", "80")
-		fe.SetAttr("sToPort", "80")
+		fe.SetAttr("dFromPort", "80")
+		fe.SetAttr("dToPort", "80")
 		filter.AddChild(fe)
 	}
 	{
 		fe := apicapi.NewVzEntry(filterDn, "1")
 		fe.SetAttr("etherT", "ip")
 		fe.SetAttr("prot", "udp")
-		fe.SetAttr("sFromPort", "53")
-		fe.SetAttr("sToPort", "53")
+		fe.SetAttr("dFromPort", "53")
+		fe.SetAttr("dToPort", "53")
 		filter.AddChild(fe)
 	}
 
@@ -558,7 +558,7 @@ func TestServiceGraph(t *testing.T) {
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
 		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{
-			twoNodeRedirect, extNet, contract, rsProv, filter, s1Dcc},
+			twoNodeRedirect, extNet, contract, rsCons, filter, s1Dcc},
 			"kube", name),
 		nameS2: nil,
 	}
@@ -567,7 +567,7 @@ func TestServiceGraph(t *testing.T) {
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{oneNodeCluster,
 			graph}, "kube", graphName),
 		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{
-			oneNodeRedirect, extNet, contract, rsProv, filter, s1Dcc},
+			oneNodeRedirect, extNet, contract, rsCons, filter, s1Dcc},
 			"kube", name),
 		nameS2: nil,
 	}

--- a/pkg/controller/snats_test.go
+++ b/pkg/controller/snats_test.go
@@ -88,7 +88,7 @@ func TestSnatGraph(t *testing.T) {
 			Ipv4: net.ParseIP("10.6.1.2"),
 		},
 	})
-	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2", "10.20.30.40/20"}, true)
+	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2", "10.20.30.40/20"}, true, true)
 	rsProv := apicExtNetProv(name, "common", "l3out", "ext1")
 
 	portRanges := []portRangeSnat{
@@ -164,7 +164,7 @@ func TestSnatGraph(t *testing.T) {
 
 	cont.fakeSnatPolicySource.Add(policy2)
 	time.Sleep(2 * time.Second)
-	extNet2 := apicExtNet(name, "common", "l3out", []string{"10.4.2.2", "10.20.30.40/20", "172.2.2.1/32"}, true)
+	extNet2 := apicExtNet(name, "common", "l3out", []string{"10.4.2.2", "10.20.30.40/20", "172.2.2.1/32"}, true, true)
 	expected2 := map[string]apicapi.ApicSlice{
                 graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
                         graph}, "kube", graphName),


### PR DESCRIPTION
This was originally changed in https://github.com/noironetworks/aci-containers/pull/300 for the SNAT feature. Reverting it back for the ext services to fix issue described by the bug https://cdetsng.cisco.com/summary/#/defect/CSCvr67770