### PR TITLE
Discarding unrelated k8s node events

### DIFF
--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -152,6 +152,7 @@ func (env *K8sEnvironment) NodePodNetworkChanged(nodeName string) {
 func (env *K8sEnvironment) NodeServiceChanged(nodeName string) {
 	env.cont.nodeChangedByName(nodeName)
 	env.cont.updateServicesForNode(nodeName)
+	env.cont.snatFullSync()
 }
 
 func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -273,9 +273,9 @@ func (cont *AciController) nodeChanged(obj interface{}) {
 				node.ObjectMeta.Annotations[metadata.ServiceEpAnnotation] =
 					serviceEpAnnotation
 				nodeUpdated = true
+				cont.updateServicesForNode(node.ObjectMeta.Name)
+				cont.snatFullSync()
 			}
-			cont.updateServicesForNode(node.ObjectMeta.Name)
-			cont.snatFullSync()
 		}
 	}
 


### PR DESCRIPTION
Issue: On multiple k8s clusters, constant k8s node events were observed related to resourceVersion change. While the root-cause of whats triggering this change is unknown, ACC shall discard these events. ACC shall only process these events if there is a change in node IP or Mac.

Fix: Node IP,Mac are tracked as serviceAnnotation, trigger updateServicesForNode, snatFullSync only when there is a change in serviceAnnotation. Also, invoke snatFullSync upon OpflexDeviceAdd event similar to updateServicesForNode.