### PR TITLE
Revert net namespace configuration for non-root pods

### DIFF
--- a/cmd/hostagent/main.go
+++ b/cmd/hostagent/main.go
@@ -68,7 +68,7 @@ func main() {
 	}
 	log.Level = logLevel
 	if config.ChildMode {
-		hostagent.StartPlugin(log, config)
+		hostagent.StartPlugin(log)
 		return
 	}
 

--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -75,9 +75,6 @@ type HostAgentConfig struct {
 	// separate process.
 	ChildMode bool `json:"child-mode,omitempty"`
 
-	// FsUid to use for the child-mode process
-	ChildModeFsUid int `json:"child-mode-fsuid,omitempty"`
-
 	// Log level
 	LogLevel string `json:"log-level,omitempty"`
 
@@ -176,7 +173,6 @@ type HostAgentConfig struct {
 
 func (config *HostAgentConfig) InitFlags() {
 	flag.BoolVar(&config.ChildMode, "child-mode", false, "Child Mode")
-	flag.IntVar(&config.ChildModeFsUid, "child-mode-fsuid", 0, "Child Mode FS Uid")
 
 	flag.StringVar(&config.LogLevel, "log-level", "info", "Log level")
 

--- a/pkg/hostagent/setup_test.go
+++ b/pkg/hostagent/setup_test.go
@@ -14,7 +14,7 @@
 
 package hostagent
 
-import (
+/*import (
 	"fmt"
 	"os"
 	"testing"
@@ -31,4 +31,4 @@ func TestGetSandboxUserId(t *testing.T) {
 		getSandboxUserId(log, fmt.Sprintf("/proc/%d/ns/net", os.Getpid())))
 
 	assert.Equal(t, "", getSandboxUserId(log, "/var/vcap/data/1234"))
-}
+}*/


### PR DESCRIPTION
Reverting PR https://github.com/noironetworks/aci-containers/commit/f1a564c9abdf320eaf3af3654bbd5c02c092ce96
The changes above don't work when the pod doesn't have enough permissions to access resources in its own namespace. So instead, we give the host agent pod additional linux capabilities here https://github.com/noironetworks/acc-provision/pull/159

(cherry picked from commit 95f768060f3daa3c1d1cff5255cdbf9b1503a8fa)