### PR TITLE
opflexagentcni: ensure CNI Result is the same version as CNI config

### DIFF
--- a/cmd/opflexagentcni/main.go
+++ b/cmd/opflexagentcni/main.go
@@ -243,7 +243,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 	}
 
 	logger.Debug("ADD result: ", result)
-	return result.Print()
+	return types.PrintResult(result, n.CNIVersion)
 }
 
 func cmdDel(args *skel.CmdArgs) error {


### PR DESCRIPTION
CNI spec requires that the Result returned is the same version as the
CNI config sent to the plugin. The opflexagentcni was not filling in
the Result CNIVersion field, so all Results appeared to be CNI
spec 0.1.0, even though the result structure being used (types/current)
is 0.3.0+.

CNI spec 0.4.0 and later clarify this requirement in the Result
section:

https://github.com/containernetworking/cni/blob/master/SPEC.md#result

When libcni 0.8.0+ is used in the runtime with config/result caching,
this could lead to errors setting up container sandboxes as the
cached result (version 0.1.0) is not compatible with the config (0.3.x).
