### PR TITLE
Cloud changes

### DIFF
--- a/build-priv.sh
+++ b/build-priv.sh
@@ -16,7 +16,7 @@ DOCKER_TAG=$2
 export GOPATH
 ACICONTAINERS_DIR=.
 
-[ -z "$OPFLEX_DIR" ] && OPFLEX_DIR=$HOME/work/opflex-master
+[ -z "$OPFLEX_DIR" ] && OPFLEX_DIR=$HOME/work/opflex
 export OPFLEX_DIR
 
 [ -z "$DOCKER_TAG" ] && DOCKER_TAG=
@@ -46,8 +46,9 @@ docker run -w /usr/local $DOCKER_HUB_ID/opflex-build$DOCKER_TAG /bin/sh -c 'find
 	 -name '\''libopflex*.so*'\'' -o \
 	 -name '\''libmodelgbp*so*'\'' -o \
 	 -name '\''libopenvswitch*so*'\'' -o \
+         -name '\''libprometheus-cpp-*so*'\'' -o \
 	 -name '\''libsflow*so*'\'' -o \
-	 -name '\''libofproto*so*'\'' \
+	 -name '\''libofproto*so*'\'' -o \
 	 -name '\''libgrpc*so*'\'' -o \
 	 -name '\''libgpr*so*'\'' \
            \) ! -name '\''*debug'\'' \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -17,7 +17,7 @@ RUN git clone https://github.com/jupp0r/prometheus-cpp.git \
   && cmake .. -DBUILD_SHARED_LIBS=ON \
   && make $make_args && make install \
   && mv /usr/local/lib64/libprometheus-cpp-* /usr/local/lib/
-RUN git clone https://github.com/grpc/grpc \
+RUN git clone https://github.com/grpc/grpc --branch v1.25.x \
   && cd grpc \
   && git submodule update --init \
   && make $make_args && make install \

--- a/docker/launch-opflexserver.sh
+++ b/docker/launch-opflexserver.sh
@@ -5,17 +5,24 @@ set -x
 
 PREFIX=/usr/local
 OPFLEXSERVER=${PREFIX}/bin/mock_server
-OPFLEXSERVER_CONF_PATH=/usr/local/etc/opflex-server
-OPFLEXSERVER_CONF=${OPFLEXSERVER_CONF_PATH}/policy.json
-mkdir -p ${OPFLEXSERVER_CONF_PATH}
+OPFLEXSERVER_POL_PATH=/usr/local/var/lib/opflex-server
+OPFLEXSERVER_POL=${OPFLEXSERVER_POL_PATH}/policy.json
+OPFLEXSERVER_CONF=${OPFLEXSERVER_POL_PATH}/config.json
+mkdir -p ${OPFLEXSERVER_POL_PATH}
 
-if [ ! -f ${OPFLEXSERVER_CONF} ]; then
-    cat <<EOF > ${OPFLEXSERVER_CONF}
+if [ ! -f ${OPFLEXSERVER_POL} ]; then
+    cat <<EOF > ${OPFLEXSERVER_POL}
 [
     {
     }
 ]
 EOF
+
+if [ ! -f ${OPFLEXSERVER_CONF} ]; then
+    cat <<EOF > ${OPFLEXSERVER_CONF}
+{
+}
+EOF
 fi
 
-exec ${OPFLEXSERVER} --policy=${OPFLEXSERVER_CONF} $@
+exec ${OPFLEXSERVER} --policy=${OPFLEXSERVER_POL} --grpc_conf=${OPFLEXSERVER_CONF} $@


### PR DESCRIPTION
- use iptables or nftables depending on what is installed
- derive VTEP_IFACE/VTEP_IP via route to 8.8.8.8 when
  all static checks fail
- pass grpc-address using ${OPFLEXSERVER_POL_PATH}/config.json
- change OPFLEXSERVER_POL_PATH to
  /usr/local/var/lib/opflex-server since its mounted
  in gbp sever pod.

Signed-off-by: Madhu Challa <challa@gmail.com>