### PR TITLE
Making build-priv.sh more usable

### DIFF
--- a/build-priv.sh
+++ b/build-priv.sh
@@ -2,15 +2,21 @@
 # Build opflex and aci-containers private images in non jenkins environment
 # 1. go get github.com/noironetworks/aci-containers
 # 2. mkdir -p $HOME/work && cd $HOME/work
-# 3. git clone https://github.com/noironetworks/opflex opflex-noiro
-# 4. Modify docker/Dockerfile-* and Makefile to reflect DOCKER_HUB_ID
-# 5. docker login as DOCKER_HUB_ID
+# 3. git clone https://github.com/noironetworks/opflex opflex
+# 4. docker login as DOCKER_HUB_ID
 # usage: build.sh <docker-user> :<tag>
 # example: ./build-priv.sh challa :demo
 set -x
 
 DOCKER_HUB_ID=$1
 DOCKER_TAG=$2
+
+# Modify docker/Dockerfile-opflex-build to reflect DOCKER_TAG
+sed -i -e 's/FROM noiro\/opflex-build-base/FROM noiro\/opflex-build-base$DOCKER_TAG/g' \
+           docker/Dockerfile-opflex-build
+# Modify docker/Dockerfile-* and Makefile to reflect DOCKER_HUB_ID
+sed -i -e 's/DOCKER_HUB_ID ?= noiro/DOCKER_HUB_ID ?= $DOCKER_HUB_ID/g' Makefile
+sed -i -e 's/ noiro\/opflex/ $DOCKER_HUB_ID\/opflex/g' docker/*
 
 [ -z "$GOPATH" ] && GOPATH=$HOME/go
 export GOPATH


### PR DESCRIPTION
- Modify docker/Dockerfile-opflex-build to reflect DOCKER_TAG
- Modify docker/Dockerfile-* and Makefile to reflect DOCKER_HUB_ID
- Updating comments to reflect what opflex dir to create

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>