### PR TITLE
Collect configmaps in cluster-report

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -192,16 +192,25 @@ func clusterReport(cmd *cobra.Command, args []string) {
 		},
 		{
 			name: "cluster-report/status/pods_status.log",
-			args: []string{"get", "pods", "--all-namespaces", "--include-uninitialized"},
+			args: []string{"get", "pods", "--all-namespaces"},
 		},
 		{
 			name: "cluster-report/status/services_status.log",
-			args: []string{"get", "services", "--all-namespaces", "--include-uninitialized"},
+			args: []string{"get", "services", "--all-namespaces"},
 		},
 		{
 			name: "cluster-report/status/cluster-info.log",
 			args: []string{"cluster-info"},
 		},
+                {
+                        name: "cluster-report/status/configmap_controller.log",
+                        args: []string{"-n", systemNamespace, "describe", "configmap", "aci-containers-config"},
+                },
+                {
+                        name: "cluster-report/status/configmap_snatoperator.log",
+                        args: []string{"-n", systemNamespace, "describe", "configmap", "snat-operator"},
+                },
+
 	}
 
 	// Get all nodes of k8s cluster


### PR DESCRIPTION
1. Save aci-containers-config cmap in cluster-report/status/configmap_controller.log
2. Save snat operator cmaps(snat-operator-config and snat-operator-lock) in cluster-report/status/configmap_snatoperator.log

Also removed the flag --include-uninitialized from kubectl get commands as it's no longer supported starting k8s1.16. Now kubectl will show all uninitialized resources by default itself.