### PR TITLE
vmmInjectedHost.id: Populate only if APIC version >=5.0

### DIFF
--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -285,7 +285,9 @@ func (cont *AciController) writeApicNode(node *v1.Node) {
 	aobj.SetAttr("mgmtIp", getNodeIP(node, v1.NodeInternalIP))
 	aobj.SetAttr("os", node.Status.NodeInfo.OSImage)
 	aobj.SetAttr("kernelVer", node.Status.NodeInfo.KernelVersion)
-	aobj.SetAttr("id", fmt.Sprintf("%v", tunnelID))
+    if apicapi.ApicVersion >= 5.0 {
+		aobj.SetAttr("id", fmt.Sprintf("%v", tunnelID))
+	}
 	cont.apicConn.WriteApicObjects(key, apicapi.ApicSlice{aobj})
 }
 


### PR DESCRIPTION
Problem:
K8S node wasn't getting added to APIC with below error.
level=error msg="Could not update dn comp/prov-Kubernetes/ctrlr-[kjonnala2]-kjonnala2/injcont/host-[k8s16-node-5.local.lan]"
	code=0 status=400 text="unknown attribute 'id' in element 'vmmInjectedHost'"
	url="https://10.30.120.180/api/mo/comp/prov-Kubernetes/ctrlr-[kjonnala2]-kjonnala2/injcont/host-[k8s16-node-5.local.lan].json

Fix:
This attribute "id" got added recently, hence this has to be populated based on the APIC version (>=5.0)

Tests:
Tested on k8s16