### PR TITLE
Option to set contract scope of SNAT svc graph

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -175,6 +175,9 @@ type ControllerConfig struct {
 	SnatDefaultPortRangeStart int `json:"snat-default-port-range-start,omitempty"`
 	SnatDefaultPortRangeEnd   int `json:"snat-default-port-range-end,omitempty"`
 
+        // Contract scope used for SNAT svc graph
+        SnatSvcContractScope string `json:"snat-contract-scope,omitempty"`
+
 	// Maximum number of nodes permitted in a svc graph
 	MaxSvcGraphNodes int `json:"max-nodes-svc-graph,omitempty"`
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -379,6 +379,11 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		cont.config.SnatDefaultPortRangeStart = defStart
 		cont.config.SnatDefaultPortRangeEnd = defEnd
 	}
+
+        // Set contract scope for snat svc graph to global by default
+        if cont.config.SnatSvcContractScope == "" {
+                cont.config.SnatSvcContractScope = "global"
+        }
 	if cont.config.MaxSvcGraphNodes == 0 {
 		cont.config.MaxSvcGraphNodes = 32
 	}

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -652,7 +652,7 @@ func (cont *AciController) updateServiceDeviceInstanceSnat(key string) error {
 	sort.Strings(nodes)
 	name := cont.aciNameForKey("snat", key)
 	var conScope string
-	conScope = "global"
+	conScope = cont.config.SnatSvcContractScope
 	sharedSecurity := true
 
 	graphName := cont.aciNameForKey("svc", "global")


### PR DESCRIPTION
Can be set through acc_provision input file, more details: https://github.com/noironetworks/acc-provision/pull/192
Default is set to "global"