### PR TITLE
Removing "make vendor" from travis.yml to support new vendor packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ matrix:
       install:
         - go get -v -u github.com/golang/dep/cmd/dep
         - export PATH=$PATH:$GOPATH/bin
-        - make vendor
       script:
         - make goinstall
         - make check >& /tmp/check.log


### PR DESCRIPTION

Removing "make vendor" from travis.yml to support new vendor packages which
restrict updating preexisting packages which can cause version mis-match and lead to failure of testcases