### PR TITLE
Fix Pod/NodeBD/L3Out VRF validation

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -791,12 +791,13 @@ func (conn *ApicConnection) ValidateAciVrfAssociation(acivrfdn string, expectedV
 			aciVrfBdL3OuttDns = append(aciVrfBdL3OuttDns, tDn)
 		}
     }
+	sort.Strings(aciVrfBdL3OuttDns)
 	conn.log.Debug("aciVrfBdL3OuttDns:", aciVrfBdL3OuttDns)
     for _, expectedDn := range expectedVrfRelations {
 		i := sort.SearchStrings(aciVrfBdL3OuttDns, expectedDn)
 		if !(i < len(aciVrfBdL3OuttDns) && aciVrfBdL3OuttDns[i] == expectedDn) {
-			conn.log.Debug("Missing Vrf assciation:", expectedDn)
-			return errors.New("Incorrect Pod/NodeBD/L3OUT VRF Assoication")
+			conn.log.Debug("Missing (or) Incorrect Vrf association: ", expectedDn)
+			return errors.New("Incorrect Pod/NodeBD/L3OUT VRF association")
 		}
 	}
 	return nil

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -357,12 +357,6 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		panic(err)
 	}
 
-    // Build Pod/NodeBD Dn's if not defined.
-    if cont.config.AciPodBdDn == "" || cont.config.AciNodeBdDn == "" {
-		cont.config.AciPodBdDn = "uni/tn-"+cont.config.AciPolicyTenant+"/BD-"+cont.config.AciPolicyTenant+"-pod-bd"
-		cont.config.AciNodeBdDn = "uni/tn-"+cont.config.AciPolicyTenant+"/BD-"+cont.config.AciPolicyTenant+"-node-bd"
-	}
-
 	// If not defined, default to 32
 	if cont.config.PodIpPoolChunkSize == 0 {
 		cont.config.PodIpPoolChunkSize = 32
@@ -422,7 +416,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	cont.log.Debug("UseAPICInstTag set to:", cont.apicConn.UseAPICInstTag)
 
     // Make sure Pod/NodeBDs and AciL3Out are assoicated to same VRF.
-	if len(cont.config.ApicHosts) != 0 {
+	if len(cont.config.ApicHosts) != 0 && cont.config.AciPodBdDn != "" && cont.config.AciNodeBdDn != "" {
 		acivrfdn := "uni/tn-"+cont.config.AciVrfTenant+"/ctx-"+cont.config.AciVrf
 		acil3outdn := "uni/tn-"+cont.config.AciVrfTenant+"/out-"+cont.config.AciL3Out
 		var expectedVrfRelations []string


### PR DESCRIPTION
- Sort actual vrf assoications that are read from APIC before comparing with expectedDns.
- Also, removed the code which builds pod/node-bd Dn when they are not present in config-map.