### PR TITLE
Change null map ep file exists check

### DIFF
--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -50,8 +50,8 @@ func testAgent() *testHostAgent {
 	hcf := &HostAgentConfig{
 		NodeName:  nodename,
 		NetConfig: []cniNetConfig{ncf},
+                GroupDefaults: GroupDefaults{DefaultEg: metadata.OpflexGroup{Name: "aci-containers-test|aci-contianers-default"}},
 	}
-
 	return testAgentWithConf(hcf)
 }
 func testAgentWithConf(hcf *HostAgentConfig) *testHostAgent {

--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -290,13 +290,14 @@ func (agent *HostAgent) syncEps() bool {
 	needRetry := false
 	seen := make(map[string]bool)
 	nullMacFile := false
+        nullMacCheck := agent.getEpFileName(agent.config.DefaultEg.Name)
 	for _, f := range files {
 		if !strings.HasSuffix(f.Name(), ".ep") ||
 			strings.Contains(f.Name(), "veth_host_ac") {
 			continue
 		}
 
-		if strings.Contains(f.Name(), NullMac) {
+		if f.Name() == nullMacCheck {
 			nullMacFile = true
 			continue
 		}
@@ -372,15 +373,20 @@ func (agent *HostAgent) syncEps() bool {
 	return needRetry
 }
 
+func (agent *HostAgent) getEpFileName(epGroupName string) string {
+        temp := strings.Split(epGroupName, "|")
+        var EpFileName string
+        if len(temp) == 1 {
+                EpFileName = epGroupName + "_" + NullMac + ".ep"
+        } else {
+                EpFileName = temp[1] + "_" + NullMac + ".ep"
+        }
+        return EpFileName
+}
+
 func (agent *HostAgent) creatNullMacEp() {
 	epGroup := agent.config.DefaultEg
-	temp := strings.Split(epGroup.Name, "|")
-	var EpFileName string
-	if len(temp) == 1 {
-		EpFileName = epGroup.Name + "_" + NullMac + ".ep"
-	} else {
-		EpFileName = temp[1] + "_" + NullMac + ".ep"
-	}
+        EpFileName := agent.getEpFileName(epGroup.Name)
 	EpFilePath := filepath.Join(agent.config.OpFlexEndpointDir, EpFileName)
 	ep_file_exists := fileExists(EpFilePath)
 	if ep_file_exists {


### PR DESCRIPTION
Currently host-agent pod creates a null mac ep file only if there's no file with "null-mac" in its name.
There might a situation in dev/prod mode where we provision an existing cluster with new naming convention. We need to be able to delete the "kube-default_null-mac" ep file and create "aci-containers-default_null-mac" file instead.
To accomplish that, we now look for a the filename with default EPG name in it.