### PR TITLE
Temporarily disabling prometheus conf

### DIFF
--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -1,5 +1,6 @@
 FROM noiro/opflex-build-base
-ARG BUILDOPTS="--enable-grpc --enable-prometheus"
+# ARG BUILDOPTS="--enable-grpc --enable-prometheus"
+ARG BUILDOPTS="--enable-grpc"
 WORKDIR /opflex
 COPY libopflex /opflex/libopflex
 ARG make_args=-j4


### PR DESCRIPTION
Can be enabled once we have a way to dynamically turn
the prometheus metrics collection ON or OFF.