### PR TITLE
disable sending grat-arp on veth_host

### DIFF
--- a/docker/launch-hostagent.sh
+++ b/docker/launch-hostagent.sh
@@ -119,6 +119,7 @@ cat <<EOF > ${VARDIR}/lib/opflex-agent-ovs/endpoints/${FNAME}
     "$VTEP_IP"
   ],
   "mac": "$ACC_MAC",
+  "disable-adv": true,
   "access-interface": "veth_host_ac",
   "access-uplink-interface": "pa-veth_host_ac",
   "interface-name": "pi-veth_host_ac",


### PR DESCRIPTION
see https://git.opendaylight.org/gerrit/c/opflex/+/88276

This was also causing the mtu issue.
(dependent on the opflex change, so both containers need to be rebuilt)

Signed-off-by: Madhu Challa <challa@gmail.com>