### PR TITLE
DropLog Event changes

### DIFF
--- a/cmd/hostagent/main.go
+++ b/cmd/hostagent/main.go
@@ -106,5 +106,6 @@ func main() {
 	agent := hostagent.NewHostAgent(config, env, log)
 	agent.Init()
 	agent.Run(wait.NeverStop)
+	agent.RunPacketEventListener(wait.NeverStop)
 	agent.RunStatus()
 }

--- a/docker/launch-opflexagent.sh
+++ b/docker/launch-opflexagent.sh
@@ -20,6 +20,7 @@ if [ -w ${PREFIX} ]; then
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/mcast
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/snats
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/reboot-conf.d
+    mkdir -p ${VARDIR}/lib/opflex-agent-ovs/droplog
 fi
 
 if [ -d ${OPFLEXAGENT_CONF_PATH} ]; then

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -49,6 +49,7 @@ type HostAgent struct {
 	opflexEps          map[string][]*opflexEndpoint
 	opflexServices     map[string]*opflexService
 	epMetadata         map[string]map[string]*md.ContainerMetadata
+	podIpToName        map[string]string
 	cniToPodID         map[string]string
 	serviceEp          md.ServiceEndpoint
 	crdClient          aciv1.AciV1Interface
@@ -89,6 +90,7 @@ type HostAgent struct {
 	snatPolicyLabels map[string]map[string]ResourceType
 	snatPolicyCache  map[string]*snatpolicy.SnatPolicy
 	rdConfig         *opflexRdConfig
+        poster           *EventPoster
 }
 
 type Vtep struct {
@@ -104,6 +106,7 @@ func NewHostAgent(config *HostAgentConfig, env Environment, log *logrus.Logger) 
 		opflexEps:      make(map[string][]*opflexEndpoint),
 		opflexServices: make(map[string]*opflexService),
 		epMetadata:     make(map[string]map[string]*md.ContainerMetadata),
+	        podIpToName:    make(map[string]string),
 		cniToPodID:     make(map[string]string),
 
 		podIps: ipam.NewIpCache(),

--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	framework "k8s.io/client-go/tools/cache/testing"
 	"net"
+        record "k8s.io/client-go/tools/record"
+        "time"
 )
 
 const nodename = "test-node"
@@ -145,6 +147,10 @@ func testAgentWithConf(hcf *HostAgentConfig) *testHostAgent {
 			ListFunc:  agent.fakeRdConfigSource.List,
 			WatchFunc: agent.fakeRdConfigSource.Watch,
 		})
+	agent.poster = &EventPoster{
+		recorder:           record.NewFakeRecorder(100),
+		eventSubmitTimeMap: make(map[string]time.Time),
+        }
 	agent.initNetPolPodIndex()
 	agent.initNetPolPodIndex()
 	agent.initDepPodIndex()

--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -72,6 +72,7 @@ type HostAgentNodeConfig struct {
 
 	// Registry Server URL -- for updating remote EP information
 	RegistryURL string `json:"registry-url,omitempty"`
+
 }
 
 // Configuration for the host agent
@@ -127,6 +128,9 @@ type HostAgentConfig struct {
 
 	// File for writing Opflex server configuration
 	OpFlexServerConfigFile string `json:"opflex-server-config-file,omitempty"`
+
+	// Location of the packet event notification socket which listens to opflex-agent packet events
+	PacketEventNotificationSock string `json:"packet-event-notification-socket,omitempty"`
 
 	// Location of the OVS DB socket
 	OvsDbSock string `json:"ovs-db-sock,omitempty"`
@@ -189,6 +193,21 @@ type HostAgentConfig struct {
 
 	//Namespace for SNAT CRDs
 	AciSnatNamespace string `json:"aci-snat-namespace,omitempty"`
+
+        //DropLogging enabled
+	EnableDropLogging bool `json:"enable-drop-log,omitempty"`
+
+	// DropLog Interface connecting to access bridge
+	DropLogAccessInterface string `json:"drop-log-access-iface,omitempty"`
+
+	// DropLog Interface connecting to access bridge
+	DropLogIntInterface string `json:"drop-log-int-iface,omitempty"`
+
+	// Droplogs older than the expiry-time will be discarded if not published
+	DropLogExpiryTime uint `json:"drop-log-expiry,omitempty"`
+
+	// More than one droplog within the repeat interval for the same event is suppressed
+	DropLogRepeatIntervalTime uint `json:"drop-log-repeat-intvl,omitempty"`
 }
 
 func (config *HostAgentConfig) InitFlags() {
@@ -221,6 +240,7 @@ func (config *HostAgentConfig) InitFlags() {
 	flag.StringVar(&config.OpFlexServerConfigFile, "opflex-server-config-file",
 		"/usr/local/var/lib/opflex-server/config.json",
 		"Config file for opflex server")
+	flag.StringVar(&config.PacketEventNotificationSock, "packet-event-notification-socket", "/usr/local/var/run/aci-containers-packet-event-notification.sock", "Location of the packet event notification socket")
 	flag.StringVar(&config.OvsDbSock, "ovs-db-sock", "/usr/local/var/run/openvswitch/db.sock", "Location of the OVS DB socket")
 	flag.StringVar(&config.EpRpcSock, "ep-rpc-sock", "/usr/local/var/run/aci-containers-ep-rpc.sock", "Location of the endpoint RPC socket used for communicating with the CNI plugin")
 	flag.StringVar(&config.EpRpcSockPerms, "ep-rpc-sock-perms", "", "Permissions to set for endpoint RPC socket file. Octal string")
@@ -247,4 +267,9 @@ func (config *HostAgentConfig) InitFlags() {
 	flag.StringVar(&config.AciVrfTenant, "aci-vrf-tenant", "common", "ACI Tenant containing the ACI VRF for this kubernetes instance")
 	flag.UintVar(&config.Zone, "zone", 8191, "Zone Id for snat flows")
 	flag.StringVar(&config.AciSnatNamespace, "aci-snat-namespace", "aci-containers-system", "Namespace for SNAT CRDs")
+	flag.BoolVar(&config.EnableDropLogging, "enable-drop-log", false, "Allow dropped packets to be logged")
+	flag.StringVar(&config.DropLogAccessInterface, "drop-log-access-iface", "gen2", "Interface in Access bridge to send dropped packets")
+	flag.StringVar(&config.DropLogIntInterface, "drop-log-int-iface", "gen1", "Interface in Integration bridge to send dropped packets")
+	flag.UintVar(&config.DropLogExpiryTime, "drop-log-expiry", 10, "Expiry time for droplogs in the pipeline in minutes")
+	flag.UintVar(&config.DropLogRepeatIntervalTime, "drop-log-repeat-intvl", 2, "Deduplication interval for droplogs of the same event in minutes")
 }

--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -137,6 +137,7 @@ func (env *K8sEnvironment) Init(agent *HostAgent) error {
 	env.agent.initNetPolPodIndex()
 	env.agent.initDepPodIndex()
 	env.agent.initRCPodIndex()
+	env.agent.initEventPoster(env.kubeClient)
 	return nil
 }
 

--- a/pkg/hostagent/event_poster.go
+++ b/pkg/hostagent/event_poster.go
@@ -1,0 +1,165 @@
+// Copyright 2020 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/tools/reference"
+	"time"
+	"fmt"
+)
+
+type EventPoster struct {
+	recorder           record.EventRecorder
+	eventSubmitTimeMap map[string]time.Time // (srcIP+dstIP) as key, posted time as value
+}
+
+// Init Poster and return its pointer
+func (agent *HostAgent) initEventPoster(kubeClient *kubernetes.Clientset) {
+	recorder := agent.initEventRecorder(kubeClient)
+	agent.poster = &EventPoster{
+		recorder:           recorder,
+		eventSubmitTimeMap: make(map[string]time.Time),
+	}
+}
+
+// Init Event Recorder for poster object
+func (agent *HostAgent) initEventRecorder(kubeClient *kubernetes.Clientset) record.EventRecorder {
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartRecordingToSink(
+		&typedcorev1.EventSinkImpl{Interface: kubeClient.CoreV1().Events("")})
+	component := "aci-containers-host"
+	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: component})
+	return recorder
+}
+
+// Submit an event using kube API with message attached
+func (agent *HostAgent) submitEvent(pod *v1.Pod, message string, dropReason string) error {
+	agent.log.Info("Posting event ", message)
+	ref, err := reference.GetReference(scheme.Scheme, pod)
+	if err != nil {
+		agent.log.Error("Returning ", err)
+		return err
+	}
+	if dropReason == "" {
+		dropReason = "Unspecified"
+	}
+	if agent.poster != nil && agent.poster.recorder != nil {
+		agent.poster.recorder.Event(ref, v1.EventTypeWarning, dropReason, message)
+	}
+	return nil
+}
+
+// Check if given PacketEvent should be ignored
+func (agent *HostAgent) shouldIgnore(packetEvent PacketEvent, currTime time.Time) bool {
+	// ignore if the given packetDrop is out of date
+	logTime, err := time.Parse(time.UnixDate, packetEvent.TimeStamp)
+	if (err != nil) || (currTime.Sub(logTime).Minutes() > float64(agent.config.DropLogExpiryTime)) {
+		agent.log.Debug("Ignoring expired event")
+		return true
+	}
+	// ignore if the event has been posted within the defined time period
+	key := packetEvent.SourceIP + packetEvent.DestinationIP
+	lastPostedTime := agent.poster.eventSubmitTimeMap[key]
+	repeatEventIntervalMinutes := float64(agent.config.DropLogRepeatIntervalTime)
+	if !lastPostedTime.IsZero() && (logTime.Sub(lastPostedTime).Minutes() <= repeatEventIntervalMinutes) {
+		agent.log.Debug("Ignoring event as it occurred within repeatInterval")
+		return true
+	}
+	return false
+}
+
+// Construct packet drop message
+func getPacketDropMessage(srcIp string, dstIp string) string {
+	return fmt.Sprintf("Packet from %s to %s was dropped", srcIp, dstIp)
+}
+
+// Handle the given PacketDrop, return error if api server does not work
+func (agent *HostAgent) processPacketEvent(packetEvent PacketEvent, currTime time.Time) error {
+	if packetEvent.SourceIP == "" || packetEvent.DestinationIP == "" {
+		return nil
+	}
+	if agent.shouldIgnore(packetEvent, currTime) {
+		return nil
+	}
+	var srcEventPosted bool = false
+	agent.indexMutex.Lock()
+	srcPodKey, srcOk := agent.podIpToName[packetEvent.SourceIP]
+	agent.indexMutex.Unlock()
+	agent.log.Debug("srcPodKey for ", packetEvent.SourceIP, ": ", srcPodKey)
+	if !srcOk {
+		agent.log.Debug(packetEvent.SourceIP, "may not be a pod or not a local pod")
+	} else {
+		obj1, srcExists, err := agent.podInformer.GetStore().GetByKey(srcPodKey)
+		if err == nil {
+			if srcExists  && (obj1 != nil) {
+				srcPod := obj1.(*v1.Pod)
+				// post events
+				if srcPod != nil && (srcPod.Status.Phase == "Running") &&
+					!srcPod.Spec.HostNetwork {
+					if err := agent.submitEvent(srcPod,
+						getPacketDropMessage(packetEvent.SourceIP,
+							packetEvent.DestinationIP),
+							packetEvent.DropReason); err != nil {
+						return err
+					}
+					srcEventPosted = true
+				}
+			}
+		} else {
+			srcExists = false
+		}
+		srcOk = srcExists
+	}
+	agent.indexMutex.Lock()
+	dstPodKey, dstOk := agent.podIpToName[packetEvent.DestinationIP]
+	agent.indexMutex.Unlock()
+	agent.log.Debug("dstPodKey for ", packetEvent.DestinationIP, ": ", dstPodKey)
+	if !dstOk {
+		agent.log.Debug(packetEvent.SourceIP, "may not be a pod or not a local pod")
+	} else {
+		obj2, dstExists, err := agent.podInformer.GetStore().GetByKey(dstPodKey)
+		if err == nil {
+			//Avoid posting to both src and dst pods, if src has already been posted
+			if dstExists && (obj2 != nil) && !srcEventPosted {
+				dstPod := obj2.(*v1.Pod)
+				if dstPod != nil && (dstPod.Status.Phase == "Running") &&
+					!dstPod.Spec.HostNetwork {
+					if err := agent.submitEvent(dstPod,
+						getPacketDropMessage(packetEvent.SourceIP,
+							packetEvent.DestinationIP),
+							packetEvent.DropReason); err != nil {
+						return err
+					}
+				}
+			}
+		} else {
+			dstExists = false
+		}
+		dstOk = dstExists
+	}
+
+	if !srcOk && !dstOk {
+		return nil
+	}
+
+	// update poster's eventSubmitTimeMap
+	agent.poster.eventSubmitTimeMap[packetEvent.SourceIP+packetEvent.DestinationIP] = currTime
+	return nil
+}

--- a/pkg/hostagent/event_poster_test.go
+++ b/pkg/hostagent/event_poster_test.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"github.com/noironetworks/aci-containers/pkg/metadata"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Check if ignoring PacketEvent based on time of reporting works
+func TestShouldIgnoreDelayed(t *testing.T) {
+	var packetEvent PacketEvent = PacketEvent{
+		TimeStamp:       "Sun Mar 08 20:02:59 EDT 2020",
+		DropReason:      "PolicyDrop-br-int/POL_TABLE",
+		SourceMac:       "16:39:19:fa:f8:40",
+		DestinationMac:  "62:58:da:98:01:97",
+		EtherType:       "IPv4",
+		SourceIP:        "10.1.1.1",
+		DestinationIP:   "10.1.1.2",
+		IPProto:         "UDP",
+		SourcePort:      "10023",
+		DestinationPort: "53",
+	}
+	agent := testAgent()
+	agent.config.DropLogExpiryTime = 10
+	agent.config.DropLogRepeatIntervalTime = 2
+	currTime, _ := time.Parse(time.UnixDate, "Sun Mar 08 20:13:59 EDT 2020")
+	assert.Equal(t, true, agent.shouldIgnore(packetEvent, currTime), "late event prune test failed")
+}
+
+// Check if ignoring PacketEvent based on frequency works
+func TestShouldIgnoreRepeated(t *testing.T) {
+	var packetEvent PacketEvent = PacketEvent{
+		TimeStamp:       "Sun Mar 08 20:02:59 EDT 2020",
+		DropReason:      "PolicyDrop-br-int/POL_TABLE",
+		SourceMac:       "16:39:19:fa:f8:40",
+		DestinationMac:  "62:58:da:98:01:97",
+		EtherType:       "IPv4",
+		SourceIP:        "10.1.1.1",
+		DestinationIP:   "10.1.1.2",
+		IPProto:         "UDP",
+		SourcePort:      "10023",
+		DestinationPort: "53",
+	}
+	tempdir, err := ioutil.TempDir("", "hostagent_test_")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tempdir)
+	agent := testAgent()
+	agent.config.OpFlexEndpointDir = tempdir
+	agent.config.OpFlexServiceDir = tempdir
+	agent.config.UplinkIface = "eth10"
+	agent.config.NodeName = "test-node"
+	agent.config.ServiceVlan = 4003
+	agent.config.UplinkMacAdress = "5a:fd:16:e5:e7:c0"
+	agent.config.DropLogExpiryTime = 10
+	agent.config.DropLogRepeatIntervalTime = 2
+	agent.run()
+	for i, pt := range podTests {
+		if i%2 == 0 {
+			ioutil.WriteFile(filepath.Join(tempdir,
+				pt.uuid+"_"+pt.cont+"_"+pt.veth+".ep"),
+				[]byte("random gibberish"), 0644)
+		}
+
+		pod := pod(pt.uuid, pt.namespace, pt.name, pt.eg, pt.sg)
+		pod.Status.PodIP = pt.ip
+		cnimd := cnimd(pt.namespace, pt.name, pt.ip, pt.cont, pt.veth)
+		agent.epMetadata[pt.namespace+"/"+pt.name] =
+			map[string]*metadata.ContainerMetadata{
+				cnimd.Id.ContId: cnimd,
+			}
+		agent.fakePodSource.Add(pod)
+	}
+	time.Sleep(3000 * time.Millisecond)
+	currTime, _ := time.Parse(time.UnixDate, "Sun Mar 08 20:03:59 EDT 2020")
+	err = agent.processPacketEvent(packetEvent, currTime)
+	assert.Nil(t, err, "Failed to process event")
+	packetEvent.TimeStamp = "Sun Mar 08 20:04:59 EDT 2020"
+	currTime = currTime.Add(time.Minute * 1)
+	assert.Equal(t, true, agent.shouldIgnore(packetEvent, currTime), "repeated event prune test failed")
+	packetEvent.TimeStamp = "Sun Mar 08 20:06:59 EDT 2020"
+	currTime = currTime.Add(time.Minute * 5)
+	assert.Equal(t, false, agent.shouldIgnore(packetEvent, currTime), "post event test failed")
+	agent.stop()
+}

--- a/pkg/hostagent/packet_event.go
+++ b/pkg/hostagent/packet_event.go
@@ -1,0 +1,89 @@
+// Copyright 2020 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"time"
+)
+
+type PacketEvent struct {
+	TimeStamp       string
+	DropReason      string
+	SourceMac       string
+	DestinationMac  string
+	EtherType       string
+	SourceIP        string
+	DestinationIP   string
+	IPProto         string
+	SourcePort      string
+	DestinationPort string
+}
+
+func (agent *HostAgent) RunPacketEventListener(stopCh <-chan struct{}) {
+	os.Remove(agent.config.PacketEventNotificationSock)
+	pc, err := net.Listen("unix", agent.config.PacketEventNotificationSock)
+	if err != nil {
+		agent.log.Errorf("Failed to listen on unix socket %s: %s ",
+			agent.config.PacketEventNotificationSock, err)
+		return
+	} else {
+		agent.log.Info("Listening for packet events on unix socket ",
+			agent.config.PacketEventNotificationSock)
+	}
+
+	go func() {
+		for {
+			fd, err := pc.Accept()
+			if err != nil {
+				agent.log.Warnf("Failed to accept %s", err)
+				return
+			}
+			go func(newFd net.Conn) {
+				defer newFd.Close()
+				for {
+					buffer := make([]byte, 4096)
+					n, err := newFd.Read(buffer)
+					if err != nil {
+						if err != io.EOF {
+							agent.log.Errorf("packet event socket read error %s", err)
+						}
+						break
+					}
+					var m []PacketEvent
+					err1 := json.Unmarshal(buffer[:n], &m)
+					agent.log.Infof("PacketEvent Received length %d", n)
+					if err1 != nil {
+						agent.log.Info("Unmarshaling error ", err1)
+					}
+					for _, event := range m {
+						err2 := agent.processPacketEvent(event, time.Now())
+						if err2 != nil {
+							agent.log.Errorf("Failed to post event %d", err2)
+						}
+					}
+				}
+			}(fd)
+		}
+	}()
+
+	go func() {
+		<-stopCh
+		pc.Close()
+	}()
+}

--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -453,7 +453,9 @@ func (agent *HostAgent) podChangedLocked(podobj interface{}) {
 		return
 	}
 	agent.cniToPodID[epMetaKey] = epUuid
-
+        if pod.Status.PodIP != "" {
+		agent.podIpToName[pod.Status.PodIP] = epMetaKey;
+	}
 	epGroup, secGroup, _ := agent.assignGroups(pod)
 	epAttributes := pod.ObjectMeta.Labels
 	if epAttributes == nil {
@@ -576,6 +578,9 @@ func (agent *HostAgent) podDeletedLocked(obj interface{}) {
 		agent.log.Infof("podDeleted: delete %s/%s", pod.ObjectMeta.Namespace, pod.ObjectMeta.Name)
 		delete(agent.opflexEps, u)
 		agent.scheduleSyncEps()
+	}
+        if pod.Status.PodIP != "" {
+		delete(agent.podIpToName, pod.Status.PodIP);
 	}
 	agent.epDeleted(&u)
 }


### PR DESCRIPTION
Add Unix Listener for packet events
DropLogger in opflexagent will send json messages to hostagent.
HostAgent will emit events to src and destination pods for the drops received.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>