### PR TITLE
Locking prometheus branch to a commit sha

### DIFF
--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -10,6 +10,7 @@ ARG make_args=-j4
 RUN git clone https://github.com/noironetworks/3rdparty-debian.git
 RUN git clone https://github.com/jupp0r/prometheus-cpp.git \
   && cd prometheus-cpp \
+  && git checkout 9effb90b0c266316358680cbf862a8564eb2c2d4 \
   && git submodule init \
   && git submodule update \
   && git apply ../3rdparty-debian/prometheus/prometheus-cpp.patch \


### PR DESCRIPTION
Today we are pulling master branch where commits keep happening. To avoid resolving any build issues as a side effect of upstream changes, locking the branch to last commit done in upstream.

Last commit taken from upstream:
commit 9effb90b0c266316358680cbf862a8564eb2c2d4 (HEAD, origin/master, origin/HEAD, master)
Merge: fca9c7e 9463d7b
Author: Gregor Jasny <gjasny@googlemail.com>
Date:   Mon Mar 2 08:40:59 2020 +0100

    Merge pull request #343 from jupp0r/package-version

    fix(cmake): Explicitly initialize package version for older cmake

Signed-off-by: Gautam Venkataramanan <gautam.chennai@gmail.com>