### PR TITLE
Temporarily removing veth_host interface and EP file - part 2

### DIFF
--- a/pkg/hostagent/nodes.go
+++ b/pkg/hostagent/nodes.go
@@ -18,12 +18,7 @@ package hostagent
 
 import (
 	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"path/filepath"
 	"reflect"
-	"strings"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -36,11 +31,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/noironetworks/aci-containers/pkg/metadata"
-)
-
-const (
-	hostVethEP   = "veth_host_ac.ep"
-	hostVethName = "veth_host"
 )
 
 func (agent *HostAgent) initNodeInformerFromClient(
@@ -118,75 +108,15 @@ func (agent *HostAgent) nodeChanged(obj interface{}) {
 		}
 	}
 
-	gotVtep := false
-	if agent.vtepIP == "" {
-		for _, a := range node.Status.Addresses {
-			if a.Type == v1.NodeInternalIP {
-				agent.vtepIP = a.Address
-				agent.log.Infof("vtepIP: %s", agent.vtepIP)
-				gotVtep = true
-			}
-		}
-	}
-
 	agent.indexMutex.Unlock()
-	if gotVtep {
-		agent.routeInit()
-		if agent.crdClient != nil {
-			agent.registerHostVeth()
-		}
-	}
 
 	if updateServices {
 		agent.updateAllServices()
 	}
 }
 
-func (agent *HostAgent) registerHostVeth() {
-	go func() {
-		for {
-			ep := &opflexEndpoint{}
-			epfile := filepath.Join(agent.config.OpFlexEndpointDir, hostVethEP)
-			datacont, err := ioutil.ReadFile(epfile)
-			if err != nil {
-				agent.log.Errorf("Unable to read %s - %v", epfile, err)
-				return
-			}
-
-			err = json.Unmarshal(datacont, ep)
-			if err != nil {
-				agent.log.Errorf("Unable to read %s - %v", epfile, err)
-				return
-			}
-
-			vmName := ep.Attributes["vm-name"]
-			if !strings.Contains(vmName, agent.vtepIP) {
-				vmName = fmt.Sprintf("%s.%s", vmName, agent.vtepIP)
-				ep.Attributes["vm-name"] = vmName
-			}
-			agent.log.Infof("-- Adding %+v to registry", ep)
-			agent.EPRegAdd(ep)
-			if ep.registered {
-				return
-			}
-			time.Sleep(5 * time.Second)
-		}
-	}()
-}
-
 func (agent *HostAgent) nodeDeleted(obj interface{}) {
 	agent.indexMutex.Lock()
 	defer agent.indexMutex.Unlock()
 
-}
-
-func (agent *HostAgent) routeInit() {
-	for _, nc := range agent.config.NetConfig {
-		err := addPodRoute(nc.Subnet, hostVethName, agent.vtepIP)
-		if err != nil {
-			agent.log.Errorf("### Could not add route for subnet %+v", nc.Subnet)
-			continue
-		}
-		agent.log.Infof("VtepIP: %s, subnet: %+v, interface: %s", agent.vtepIP, nc.Subnet, hostVethName)
-	}
 }


### PR DESCRIPTION
Since we are seeing some asymmetrical routing on account
of the route to the pod network added to support the
use of the veth_host interface.