### PR TITLE
Fixed the issue to  omit network address and broadcast address

### DIFF
--- a/pkg/util/iputil.go
+++ b/pkg/util/iputil.go
@@ -37,7 +37,12 @@ func GetIPsFromCIDR(cidr string) []string {
 	for ip := ip.Mask(ipnet.Mask); ipnet.Contains(ip); inc(ip) {
 		output = append(output, ip.String())
 	}
-	return output[0:len(output)]
+	length := len(output)
+	if length == 1 {
+		return output
+	} else {
+		return output[1 : length-1]
+	}
 }
 
 // Given two slices of IP addresses, finds the difference of two sets


### PR DESCRIPTION
When user provides SnatIP  lets say 10.10.10.1/24 the first IP selected as 10.10.10.0, 
 which is network address,  now to fix this issue we are omitting  network address and broadcast address
