### PR TITLE
Setting local interface-mac in Snatfile

### DIFF
--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -701,6 +701,7 @@ func (agent *HostAgent) syncSnat() bool {
 			// set the local portrange
 			snatinfo.InterfaceName = agent.config.UplinkIface
 			snatinfo.InterfaceVlan = agent.config.ServiceVlan
+			snatinfo.InterfaceMac = agent.config.UplinkMacAdress
 			snatinfo.Local = false
 			if _, ok := localportrange[ginfo.SnatIp]; ok {
 				snatinfo.PortRange = localportrange[ginfo.SnatIp]


### PR DESCRIPTION
This is local mac is used by opflex agent to create the flow for checking dmac before processing packets

(cherry picked from commit 0a1a29ced191985aa760c385f06dc41849c535d9)