### PR TITLE
Increase default mac-table-size for each OVS bridge

### DIFF
--- a/docker/launch-ovs.sh
+++ b/docker/launch-ovs.sh
@@ -19,7 +19,8 @@ for i in br-int br-access; do
     if ! ${VSCTL} br-exists ${i}; then
 	${VSCTL} add-br ${i} -- set-fail-mode ${i} secure \
 	    -- set bridge ${i} \
-	    other-config:datapath-id=000000000000000$dpid
+	    other-config:datapath-id=000000000000000$dpid \
+	    other-config:mac-table-size="${OVS_MAC_TABLE_SIZE:=50000}"
     fi
 done
 


### PR DESCRIPTION
Default size in recent OVS builds is 8K. This change increases the default size to 50K

This avoids revalidation in most setups.
OVS_MAC_TABLE_SIZE env var can be used to customize size if desired