### PR TITLE
Move OVS/OpFlex containers to alpine 3.11.5

### DIFF
--- a/docker/Dockerfile-openvswitch
+++ b/docker/Dockerfile-openvswitch
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.11.5
 RUN apk upgrade --no-cache && \
   apk --no-cache add openvswitch logrotate conntrack-tools tcpdump curl strace \
   ltrace iptables net-tools

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -1,10 +1,11 @@
-FROM alpine:3.10.2
+FROM alpine:3.11.5
 ARG ROOT=/usr/local
-COPY ovs-musl.patch /
+#COPY ovs-musl.patch /
+COPY ovsdb-idlc.in-fix-dict-change-during-iteration.patch /
 RUN apk upgrade --no-cache && apk add --no-cache build-base \
-    libtool pkgconfig autoconf automake cmake doxygen file py-six \
+    libtool pkgconfig autoconf automake cmake file py3-six \
     linux-headers libuv-dev boost-dev openssl-dev git \
-    libnetfilter_conntrack-dev rapidjson-dev python-dev bzip2-dev \
+    libnetfilter_conntrack-dev rapidjson-dev python3-dev bzip2-dev \
     curl libcurl curl-dev zlib-dev
 ARG make_args=-j4
 RUN git clone https://github.com/noironetworks/3rdparty-debian.git
@@ -31,7 +32,7 @@ ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buff
 ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'
 RUN git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1 \
-  && cd ovs \
+  && cd ovs && patch -p1 < /ovsdb-idlc.in-fix-dict-change-during-iteration.patch \
   && ./boot.sh && ./configure --disable-ssl --disable-libcapng --enable-shared \
   && make $make_args && make install \
   && mkdir -p $ROOT/include/openvswitch/openvswitch \

--- a/docker/Dockerfile-opflexserver
+++ b/docker/Dockerfile-opflexserver
@@ -1,4 +1,4 @@
-FROM alpine:3.10.2
+FROM alpine:3.11.5
 RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
   boost-program_options boost-system boost-date_time boost-filesystem \
   boost-iostreams libnetfilter_conntrack libssl1.1 libcrypto1.1 ca-certificates \

--- a/docker/ovsdb-idlc.in-fix-dict-change-during-iteration.patch
+++ b/docker/ovsdb-idlc.in-fix-dict-change-during-iteration.patch
@@ -1,0 +1,38 @@
+From d84109f0b60096ce71cd0537b31b69a7f5ea8756 Mon Sep 17 00:00:00 2001
+From: Flavio Leitner <fbl@sysclose.org>
+Date: Sat, 14 Sep 2019 20:17:28 -0300
+Subject: [PATCH] ovsdb-idlc.in: fix dict change during iteration.
+
+Python3 complains if a dict key is changed during the
+iteration.
+
+Use list() to create a copy of it.
+
+Traceback (most recent call last):
+  File "./ovsdb/ovsdb-idlc.in", line 1581, in <module>
+    func(*args[1:])
+  File "./ovsdb/ovsdb-idlc.in", line 185, in printCIDLHeader
+    replace_cplusplus_keyword(schema)
+  File "./ovsdb/ovsdb-idlc.in", line 179, in replace_cplusplus_keyword
+    for columnName in table.columns:
+RuntimeError: dictionary keys changed during iteration
+
+Signed-off-by: Flavio Leitner <fbl@sysclose.org>
+Signed-off-by: Ben Pfaff <blp@ovn.org>
+---
+ ovsdb/ovsdb-idlc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ovsdb/ovsdb-idlc.in b/ovsdb/ovsdb-idlc.in
+index 40fef39edf..22d0a4e22e 100755
+--- a/ovsdb/ovsdb-idlc.in
++++ b/ovsdb/ovsdb-idlc.in
+@@ -176,7 +176,7 @@ def replace_cplusplus_keyword(schema):
+                 'wchar_t', 'while', 'xor', 'xor_eq'}
+ 
+     for tableName, table in schema.tables.items():
+-        for columnName in table.columns:
++        for columnName in list(table.columns):
+             if columnName in keywords:
+                 table.columns[columnName + '_'] = table.columns.pop(columnName)
+ 


### PR DESCRIPTION
Remove doxygen from opflex-build-base
Move to python3 for OVS and apply required patch for 2.12 (fixed in next release)

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>