### PR TITLE
Fixed the test case TestServiceGraph

### DIFF
--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -268,14 +268,14 @@ func TestServiceAnnotation(t *testing.T) {
 	}
 	twoNodeRedirect := redirect(seMap{
 		"node1": &metadata.ServiceEndpoint{
-			HealthGroupDn:  "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1",
-			Mac:			"8a:35:a1:a6:e4:60",
-			Ipv4:			net.ParseIP("10.6.1.1"),
+			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1",
+			Mac:           "8a:35:a1:a6:e4:60",
+			Ipv4:          net.ParseIP("10.6.1.1"),
 		},
 		"node2": &metadata.ServiceEndpoint{
-			HealthGroupDn:  "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node2",
-			Mac:  "a2:7e:45:57:a0:d4",
-			Ipv4: net.ParseIP("10.6.1.2"),
+			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node2",
+			Mac:           "a2:7e:45:57:a0:d4",
+			Ipv4:          net.ParseIP("10.6.1.2"),
 		},
 	})
 	oneNodeRedirect := redirect(seMap{
@@ -346,8 +346,8 @@ func TestServiceAnnotation(t *testing.T) {
 	opflexDevice2.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/34]")
 	opflexDevice2.SetAttr("devType", "k8s")
-        opflexDevice2.SetAttr("domName", "kube")
-        opflexDevice2.SetAttr("ctrlrName", "kube")
+	opflexDevice2.SetAttr("domName", "kube")
+	opflexDevice2.SetAttr("ctrlrName", "kube")
 
 	cont := sgCont()
 	cont.config.AciVmmDomain = "kube"
@@ -446,20 +446,20 @@ func TestServiceGraph(t *testing.T) {
 	twoNodeRedirect := redirect(seMap{
 		"node1": &metadata.ServiceEndpoint{
 			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1",
-			Mac:  "8a:35:a1:a6:e4:60",
-			Ipv4: net.ParseIP("10.6.1.1"),
+			Mac:           "8a:35:a1:a6:e4:60",
+			Ipv4:          net.ParseIP("10.6.1.1"),
 		},
 		"node2": &metadata.ServiceEndpoint{
 			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node2",
-			Mac:  "a2:7e:45:57:a0:d4",
-			Ipv4: net.ParseIP("10.6.1.2"),
+			Mac:           "a2:7e:45:57:a0:d4",
+			Ipv4:          net.ParseIP("10.6.1.2"),
 		},
 	})
 	oneNodeRedirect := redirect(seMap{
 		"node1": &metadata.ServiceEndpoint{
 			HealthGroupDn: "uni/tn-common/svcCont/redirectHealthGroup-kube_svc_node1",
-			Mac:  "8a:35:a1:a6:e4:60",
-			Ipv4: net.ParseIP("10.6.1.1"),
+			Mac:           "8a:35:a1:a6:e4:60",
+			Ipv4:          net.ParseIP("10.6.1.1"),
 		},
 	})
 
@@ -519,40 +519,40 @@ func TestServiceGraph(t *testing.T) {
 	opflexDevice1.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/33]")
 	opflexDevice1.SetAttr("devType", "k8s")
-        opflexDevice1.SetAttr("domName", "kube")
-        opflexDevice1.SetAttr("ctrlrName", "kube")
+	opflexDevice1.SetAttr("domName", "kube")
+	opflexDevice1.SetAttr("ctrlrName", "kube")
 
 	opflexDevice2 := apicapi.EmptyApicObject("opflexODev", "dev2")
 	opflexDevice2.SetAttr("hostName", "node2")
 	opflexDevice2.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/34]")
 	opflexDevice2.SetAttr("devType", "k8s")
-        opflexDevice2.SetAttr("domName", "kube")
-        opflexDevice2.SetAttr("ctrlrName", "kube")
+	opflexDevice2.SetAttr("domName", "kube")
+	opflexDevice2.SetAttr("ctrlrName", "kube")
 
 	opflexDevice3 := apicapi.EmptyApicObject("opflexODev", "dev1")
 	opflexDevice3.SetAttr("hostName", "node3")
 	opflexDevice3.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/50]")
 	opflexDevice3.SetAttr("devType", "k8s")
-        opflexDevice3.SetAttr("domName", "kube")
-        opflexDevice3.SetAttr("ctrlrName", "kube")
+	opflexDevice3.SetAttr("domName", "kube")
+	opflexDevice3.SetAttr("ctrlrName", "kube")
 
 	opflexDevice4 := apicapi.EmptyApicObject("opflexODev", "dev2")
 	opflexDevice4.SetAttr("hostName", "node4")
 	opflexDevice4.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/51]")
 	opflexDevice4.SetAttr("devType", "k8s")
-        opflexDevice4.SetAttr("domName", "kube")
-        opflexDevice4.SetAttr("ctrlrName", "kube")
+	opflexDevice4.SetAttr("domName", "kube")
+	opflexDevice4.SetAttr("ctrlrName", "kube")
 
 	opflexDevice1_alt := apicapi.EmptyApicObject("opflexODev", "dev1")
 	opflexDevice1_alt.SetAttr("hostName", "node1")
 	opflexDevice1_alt.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/100]")
 	opflexDevice1_alt.SetAttr("devType", "k8s")
-        opflexDevice1_alt.SetAttr("domName", "kube")
-        opflexDevice1_alt.SetAttr("ctrlrName", "kube")
+	opflexDevice1_alt.SetAttr("domName", "kube")
+	opflexDevice1_alt.SetAttr("ctrlrName", "kube")
 
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
@@ -581,7 +581,7 @@ func TestServiceGraph(t *testing.T) {
 
 	cont := sgCont()
 	cont.config.AciVmmDomain = "kube"
-        cont.config.AciVmmController = "kube"
+	cont.config.AciVmmController = "kube"
 	cont.fakeNodeSource.Add(node1)
 	cont.fakeNodeSource.Add(node2)
 	cont.fakeServiceSource.Add(service2)
@@ -628,6 +628,11 @@ func TestServiceGraph(t *testing.T) {
 	cont.fakeNodeSource.Delete(node1)
 	cont.fakeNodeSource.Delete(node2)
 	sgWait(t, "delete node", cont, map[string]apicapi.ApicSlice{name: nil})
+	//reset the node annotations with diffrent values before adding the node
+	node1.ObjectMeta.Annotations[metadata.ServiceEpAnnotation] =
+		"{\"mac\":\"8a:35:a1:a6:e4:60\",\"ipv4\":\"10.6.1.5\"}"
+	node2.ObjectMeta.Annotations[metadata.ServiceEpAnnotation] =
+		"{\"mac\":\"a2:7e:45:57:a0:d4\",\"ipv4\":\"10.6.1.6\"}"
 
 	cont.fakeNodeSource.Add(node1)
 	cont.fakeNodeSource.Add(node2)


### PR DESCRIPTION
It Is the  test case issue from day one, it is working occasionally because before delete is completely processed node adds are trigged so still stale data is present. In this test as node is annotated with IP 10.6.1.1,   when node gets deleted the IP is added back to IPAM. And when the node comes back IPAM allocates the same IP from start,  So as node annotations are same, Service sync is not trigged to populate APIC data to be written.  now test case is fixed by setting node annotations with different values  