### PR TITLE
Reduce the size of intermediate opflex artifacts

### DIFF
--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -5,15 +5,15 @@ COPY libopflex /opflex/libopflex
 ARG make_args=-j4
 RUN cd /opflex/libopflex \
   && ./autogen.sh && ./configure --disable-assert \
-  && make $make_args && make install
+  && make $make_args && make install && make clean
 COPY genie /opflex/genie
 RUN cd /opflex/genie/target/libmodelgbp \
   && sh autogen.sh && ./configure --disable-static \
-  && make $make_args && make install
+  && make $make_args && make install && make clean
 COPY agent-ovs /opflex/agent-ovs
 RUN cd /opflex/agent-ovs \
   && ./autogen.sh && ./configure $BUILDOPTS \
-  && make $make_args && make install
+  && make $make_args && make install && make clean
 RUN for p in `find /usr/local/lib/ /usr/local/bin/ -type f \(\
     -name 'opflex_agent' -o \
     -name 'gbp_inspect' -o \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -17,7 +17,7 @@ RUN git clone https://github.com/jupp0r/prometheus-cpp.git \
   && git apply ../3rdparty-debian/prometheus/prometheus-cpp.patch \
   && mkdir _build && cd _build \
   && cmake .. -DBUILD_SHARED_LIBS=ON \
-  && make $make_args && make install \
+  && make $make_args && make install && make clean \
   && mv /usr/local/lib64/libprometheus-cpp-* /usr/local/lib/
 RUN git clone https://github.com/grpc/grpc \
   && cd grpc \
@@ -27,7 +27,7 @@ RUN git clone https://github.com/grpc/grpc \
   && cd third_party/protobuf \
   && ./autogen.sh \
   && ./configure \
-  && make $make_args && make install
+  && make $make_args && make install && make clean
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'
@@ -39,4 +39,5 @@ RUN git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1 
   && mv $ROOT/include/openvswitch/*.h $ROOT/include/openvswitch/openvswitch \
   && mv $ROOT/include/openflow $ROOT/include/openvswitch \
   && cp include/*.h "$ROOT/include/openvswitch/" \
-  && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \;
+  && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \; \
+  && make clean


### PR DESCRIPTION
Manually doing a make clean after each make install
reduced the build-base by 25% and build by 40%

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>