### PR TITLE
Host-agent configures directly Uplink-mac address as Service-mac

### DIFF
--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -289,7 +289,8 @@ func (agent *HostAgent) updateServiceDesc(external bool, as *v1.Service,
 
 		ofas.InterfaceName = agent.config.UplinkIface
 		ofas.InterfaceVlan = uint16(agent.config.ServiceVlan)
-		ofas.ServiceMac = agent.serviceEp.Mac
+		// Directly using the Uplink MacAdress instead of using Opflex injected mac
+		ofas.ServiceMac = agent.config.UplinkMacAdress
 		ofas.InterfaceIp = agent.serviceEp.Ipv4.String()
 		ofas.Uuid = ofas.Uuid + "-external"
 	}

--- a/pkg/hostagent/services_test.go
+++ b/pkg/hostagent/services_test.go
@@ -193,7 +193,7 @@ func (agent *testHostAgent) doTestService(t *testing.T, tempdir string,
 			desc, st.name, "uuid-external")
 		agent.checkAs(t, st, asexternal, desc)
 
-		assert.Equal(t, "76:47:db:97:ba:4c", asexternal.ServiceMac,
+		assert.Equal(t, agent.config.UplinkMacAdress, asexternal.ServiceMac,
 			desc, st.name, "service-mac")
 		assert.Equal(t, "10.6.0.1", asexternal.InterfaceIp,
 			desc, st.name, "service-ip")
@@ -213,6 +213,7 @@ func TestServiceSync(t *testing.T) {
 	agent.config.OpFlexServiceDir = tempdir
 	agent.config.OpFlexSnatDir = tempdir
 	agent.config.UplinkIface = "eth42"
+	agent.config.UplinkMacAdress = "76:47:db:97:ba:4c"
 	agent.config.ServiceVlan = 4003
 	agent.config.AciVrf = "kubernetes-vrf"
 	agent.config.AciVrfTenant = "common"

--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -644,7 +644,7 @@ func (agent *HostAgent) snaGlobalInfoChanged(snatobj interface{}, logger *logrus
 			ServiceMappings:   make([]opflexServiceMapping, 0),
 			InterfaceName:     agent.config.UplinkIface,
 			InterfaceVlan:     uint16(agent.config.ServiceVlan),
-			ServiceMac:        agent.serviceEp.Mac,
+			ServiceMac:        agent.config.UplinkMacAdress,
 			InterfaceIp:       agent.serviceEp.Ipv4.String(),
 		}
 		sm := &opflexServiceMapping{
@@ -655,7 +655,7 @@ func (agent *HostAgent) snaGlobalInfoChanged(snatobj interface{}, logger *logrus
 		if !file_exists {
 			wrote, err := writeAs(filePath, as)
 			if err != nil {
-				agent.log.Debug("Unable to write snat ext service file")
+				agent.log.Debug("Unable to write snat ext service file:")
 			} else if wrote {
 				agent.log.Debug("Created snat ext service file")
 			}


### PR DESCRIPTION
Opflex-agent  inject the Uplink MAC address to APIC, which in turn  ACC controllers reads that Mac from APIC by subscribing to OpflexDevice change,
and annotates that using node info,  and host-agent uses that Mac to program the Service-mac in file.
If opflex-agent fails to inject that device  Mac,  acc controller allocates a random Mac. Because of this random Mac, inconsistency is coming between interface  Mac and service mac.

with SnatPolicy installed OVS adds a rule to allow only packets destained to the interface Mac this is breaking the Service and Snat traffic.
Now to fix this issue host-agent directly uses the Uplink MAC address to configure Service-mac in service files