### PR TITLE
Update opflex containers to use UBI 8 instead of alpine

### DIFF
--- a/docker/Dockerfile-openvswitch
+++ b/docker/Dockerfile-openvswitch
@@ -1,6 +1,7 @@
-FROM alpine:3.11.5
-RUN apk upgrade --no-cache && \
-  apk --no-cache add openvswitch logrotate conntrack-tools tcpdump curl strace \
-  ltrace iptables net-tools
+FROM registry.access.redhat.com/ubi8/ubi:latest
+RUN yum update -y && \
+  yum install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms openvswitch logrotate conntrack-tools \
+  tcpdump curl strace ltrace iptables net-tools && yum clean all
 COPY docker/launch-ovs.sh docker/liveness-ovs.sh dist-static/ovsresync /usr/local/bin/
 CMD ["/usr/local/bin/launch-ovs.sh"]

--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -1,8 +1,10 @@
-FROM alpine:3.11.5
-RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
-  boost-program_options boost-system boost-date_time boost-filesystem \
-  boost-iostreams libnetfilter_conntrack libssl1.1 libcrypto1.1 ca-certificates \
-  && update-ca-certificates
+FROM registry.access.redhat.com/ubi8/ubi:latest
+RUN yum --disablerepo=\*ubi\* update -y && \
+  yum --disablerepo=\*ubi\* install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms libstdc++ libuv \
+  boost-program-options boost-system boost-date-time boost-filesystem \
+  boost-iostreams libnetfilter_conntrack openssl net-tools procps-ng ca-certificates \
+  && yum clean all
 COPY bin/* /usr/local/bin/
 COPY lib/* /usr/local/lib/
 ENV SSL_MODE="encrypted"

--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -1,5 +1,6 @@
 FROM noiro/opflex-build-base
 ARG BUILDOPTS="--enable-grpc --enable-prometheus"
+ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/share/pkgconfig
 WORKDIR /opflex
 COPY libopflex /opflex/libopflex
 ARG make_args=-j4

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -2,10 +2,9 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV ROOT=/usr/local
 RUN microdnf update && microdnf install --enablerepo codeready-builder-for-rhel-8-x86_64-rpms \
     libtool pkgconfig autoconf automake make cmake file python2-six \
-    openssl-devel git gcc gcc-c++ boost-devel diffutils \
-    python2-devel libnetfilter_conntrack-devel \
-    wget which curl-devel procps zlib-devel java-1.8.0-openjdk-devel.x86_64 \
-    maven && microdnf clean all
+    openssl-devel git gcc gcc-c++ boost-devel diffutils python2-devel \
+    libnetfilter_conntrack-devel wget which curl-devel procps zlib-devel \
+    && microdnf clean all
 ARG make_args=-j4
 RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
   && tar xvfz v1.1.0.tar.gz \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -1,13 +1,25 @@
-FROM alpine:3.11.5
-ARG ROOT=/usr/local
-#COPY ovs-musl.patch /
-COPY ovsdb-idlc.in-fix-dict-change-during-iteration.patch /
-RUN apk upgrade --no-cache && apk add --no-cache build-base \
-    libtool pkgconfig autoconf automake cmake file py3-six \
-    linux-headers libuv-dev boost-dev openssl-dev git \
-    libnetfilter_conntrack-dev rapidjson-dev python3-dev bzip2-dev \
-    curl libcurl curl-dev zlib-dev
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+ENV ROOT=/usr/local
+RUN microdnf update && microdnf install --enablerepo codeready-builder-for-rhel-8-x86_64-rpms \
+    libtool pkgconfig autoconf automake make cmake file python2-six \
+    openssl-devel git gcc gcc-c++ boost-devel diffutils \
+    python2-devel libnetfilter_conntrack-devel \
+    wget which curl-devel procps zlib-devel java-1.8.0-openjdk-devel.x86_64 \
+    maven && microdnf clean all
 ARG make_args=-j4
+RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
+  && tar xvfz v1.1.0.tar.gz \
+  && cd rapidjson-1.1.0 \
+  && cmake CMakeLists.txt \
+  && cp -R include/rapidjson/ /usr/local/include/ \
+  && mkdir /usr/local/lib/pkgconfig \
+  && cp RapidJSON.pc /usr/local/lib/pkgconfig/
+RUN git clone https://github.com/libuv/libuv.git --branch v1.20.3 --depth 1 \
+  && cd libuv \
+  && ./autogen.sh \
+  && ./configure \
+  && make $make_args \
+  && make install && make clean
 RUN git clone https://github.com/noironetworks/3rdparty-debian.git
 RUN git clone https://github.com/jupp0r/prometheus-cpp.git \
   && cd prometheus-cpp \
@@ -32,7 +44,7 @@ ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buff
 ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'
 RUN git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1 \
-  && cd ovs && patch -p1 < /ovsdb-idlc.in-fix-dict-change-during-iteration.patch \
+  && cd ovs \
   && ./boot.sh && ./configure --disable-ssl --disable-libcapng --enable-shared \
   && make $make_args && make install \
   && mkdir -p $ROOT/include/openvswitch/openvswitch \

--- a/docker/Dockerfile-opflexserver
+++ b/docker/Dockerfile-opflexserver
@@ -1,8 +1,9 @@
-FROM alpine:3.11.5
-RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
-  boost-program_options boost-system boost-date_time boost-filesystem \
-  boost-iostreams libnetfilter_conntrack libssl1.1 libcrypto1.1 ca-certificates \
-  && update-ca-certificates
+FROM registry.access.redhat.com/ubi8/ubi:latest
+RUN yum --disablerepo=\*ubi\* update -y && \
+  yum --disablerepo=\*ubi\* install -y libstdc++ libuv \
+  boost-program-options boost-system boost-date-time boost-filesystem \
+  boost-iostreams libnetfilter_conntrack openssl net-tools procps-ng ca-certificates \
+  && yum clean all
 COPY bin/opflex_server /usr/local/bin/
 COPY bin/launch-opflexserver.sh /usr/local/bin/
 COPY lib/* /usr/local/lib/


### PR DESCRIPTION
This changeset updates the base image for our opflex/ovs containers to be UBI 8

Unlike alpine, devel packages for libuv and rapidjson are not available so the build now builds/installs them manually to allow compilation to proceed