### PR TITLE
Added code to validate SnatPolicy CR

### DIFF
--- a/pkg/controller/snatglobalinfo_test.go
+++ b/pkg/controller/snatglobalinfo_test.go
@@ -204,6 +204,7 @@ func TestSnatnodeInfo(t *testing.T) {
 	snatdeleted(t, "snat test", cont.AciController.snatGlobalInfoCache)
 	cont.stop()
 }
+
 func TestSnatCfgChangeTest(t *testing.T) {
 	cont := testController()
 	for _, pt := range snatTests {

--- a/pkg/hostagent/integ_test.go
+++ b/pkg/hostagent/integ_test.go
@@ -28,13 +28,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	log "github.com/sirupsen/logrus"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/noironetworks/aci-containers/pkg/eprpcclient"
 	"github.com/noironetworks/aci-containers/pkg/ipam"
 	"github.com/noironetworks/aci-containers/pkg/metadata"
 	snatglobal "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/apis/aci.snat/v1"
 	tu "github.com/noironetworks/aci-containers/pkg/testutil"
+	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	apitypes "k8s.io/apimachinery/pkg/types"
 )
@@ -791,9 +791,10 @@ func TestSnatPolicyDep(t *testing.T) {
 		"deer": "dear",
 	}
 	it.addPodObj(6, "annNS", "", "", depLabels)
-	snatobj1 := snatpolicydata("policy1", "annNS", []string{"10.1.1.8"}, []string{"10.10.0.0/16", "0.0.0.0/0"}, map[string]string{"app": "sample-app"})
-	snatobj2 := snatpolicydata("policy2", "annNS", []string{"10.1.1.9"}, []string{"10.10.10.10/31", "10.10.10.0/24"}, map[string]string{"deer": "dear"})
+	snatobj1 := snatpolicydata("policy1", "annNS", []string{"10.1.1.8"}, []string{"10.10.0.0/16", "172.192.153.0/26"}, map[string]string{"app": "sample-app"})
+	snatobj2 := snatpolicydata("policy2", "annNS", []string{"10.1.1.9"}, []string{"10.10.10.10/31", "10.10.0.0/24"}, map[string]string{"deer": "dear"})
 	it.ta.fakeSnatPolicySource.Add(snatobj1)
+	time.Sleep(100 * time.Millisecond)
 	it.ta.fakeSnatPolicySource.Add(snatobj2)
 	time.Sleep(100 * time.Millisecond)
 	it.ta.fakeSnatGlobalSource.Add(mkSnatGlobalObj())

--- a/pkg/hostagent/snats_test.go
+++ b/pkg/hostagent/snats_test.go
@@ -135,7 +135,7 @@ var snatpolices = []policy{
 		"testns",
 		"policy1",
 		[]string{"10.1.1.8"},
-		[]string{"10.10.10.0/31", "10.10.10.0/24"},
+		[]string{"10.10.10.0/26", "10.10.10.0/31", "10.10.10.0/24"},
 		map[string]string{ /*"key": "value"*/ },
 	},
 }
@@ -164,7 +164,7 @@ func (agent *testHostAgent) doTestSnat(t *testing.T, tempdir string,
 	assert.Equal(t, pt.ip, snat.SnatIp, desc, pt.name, "ip")
 	switch {
 	case pt.policyname == "policy1":
-		assert.Equal(t, []string{"10.10.10.0/31", "10.10.10.0/24"}, snat.DestIpAddress, desc, pt.name, "destip")
+		assert.Equal(t, []string{"10.10.10.0/31", "10.10.10.0/26", "10.10.10.0/24"}, snat.DestIpAddress, desc, pt.name, "destip")
 	case pt.policyname == "policy2":
 		assert.Equal(t, []string{"10.10.0.0/16"}, snat.DestIpAddress, desc, pt.name, "destip")
 	}


### PR DESCRIPTION
 1. Verified that snatIP is not same cross the SnatPolicies
 2. Verfied that  namespace will not be same across the policies if the labels are not provided
 3. Validated the DestIP
 4. Fixed the issue of sorting  Dest IP CIDR if firstIP matches across CIDR's
    eg. if the CIDR are 10.10.0.0/16 and 10.10.0.0/24 ParseCIDR will return 10.10.0.1
    so mask will be considered to sort the destIp's