### PR TITLE
Update dockerfile to use ubi for gbpserver and the dev environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,13 @@ CF_COMMON_SRC=$(wildcard pkg/cf_common/*.go)
 UTIL_SRC=$(wildcard pkg/util/*.go)
 DEBIAN_FILES=$(wildcard debian/*)
 GOPKG_FILES=$(wildcard Gopkg.*)
+GOBUILD=noirolabs/gobuild1.14
+UNAME := $(shell uname -s)
+ifeq ($(UNAME),Darwin)
+    DOCKER_EXT = -dev
+else
+    DOCKER_EXT =
+endif
 
 HOSTAGENT_DEPS=${METADATA_SRC} ${IPAM_SRC} ${HOSTAGENT_SRC} \
 	${CF_ETCD_SRC} ${CF_COMMON_SRC} ${KEYVALUESVC_SRC}
@@ -65,10 +72,10 @@ all-static: dist-static/aci-containers-host-agent \
 
 go-targets: nodep-opflex-agent-cni nodep-aci-containers-host-agent nodep-aci-containers-controller gbpserver
 go-build:
-	docker run --rm -m 16g -v ${PWD}:/go/src/github.com/noironetworks/aci-containers -w /go/src/github.com/noironetworks/aci-containers --network=host -it noirolabs/gobuild make go-targets
+	docker run --rm -m 16g -v ${PWD}:/go/src/github.com/noironetworks/aci-containers -w /go/src/github.com/noironetworks/aci-containers --network=host -it ${GOBUILD} make go-targets
 
 go-gbp-build:
-	docker run --rm -m 16g -v ${PWD}:/go/src/github.com/noironetworks/aci-containers -w /go/src/github.com/noironetworks/aci-containers --network=host -it noirolabs/gobuild make go-gbp-target
+	docker run --rm -m 16g -v ${PWD}:/go/src/github.com/noironetworks/aci-containers -w /go/src/github.com/noironetworks/aci-containers --network=host -it ${GOBUILD} make go-gbp-target
 go-gbp-target: gbpserver
 
 clean-dist-static:
@@ -171,9 +178,9 @@ dist-static/simpleservice: ${SIMPLESERVICE_DEPS}
 container-gbpserver: dist-static/gbpserver 
 	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/gbp-server${DOCKER_TAG} -f ./docker/Dockerfile-gbpserver .
 container-host: dist-static/aci-containers-host-agent dist-static/opflex-agent-cni
-	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/aci-containers-host${DOCKER_TAG} -f ./docker/Dockerfile-host .
+	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/aci-containers-host${DOCKER_TAG} -f ./docker/Dockerfile-host${DOCKER_EXT} .
 container-controller: dist-static/aci-containers-controller
-	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/aci-containers-controller${DOCKER_TAG} -f ./docker/Dockerfile-controller .
+	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/aci-containers-controller${DOCKER_TAG} -f ./docker/Dockerfile-controller${DOCKER_EXT} .
 container-opflex-build-base:
 	${DOCKER_BUILD_CMD} -t ${DOCKER_HUB_ID}/opflex-build-base${DOCKER_TAG} -f ./docker/Dockerfile-opflex-build-base docker
 container-openvswitch: dist-static/ovsresync

--- a/docker/Dockerfile-controller-dev
+++ b/docker/Dockerfile-controller-dev
@@ -1,0 +1,11 @@
+FROM noirolabs/ubibase:latest
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+RUN chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
+RUN curl -sL "https://github.com/istio/istio/releases/download/1.5.2/istioctl-1.5.2-linux.tar.gz" | tar xz
+RUN chmod u+x istioctl && mv istioctl /usr/local/bin/istioctl
+RUN mkdir -p /usr/local/var/lib/aci-cni
+COPY pkg/istiocrd/upstream-istio-cr-1.5.2.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
+COPY dist-static/aci-containers-controller /usr/local/bin/
+ENV AWS_SUBNETS="None"
+ENV AWS_VPCID="None"
+ENTRYPOINT exec /usr/local/bin/aci-containers-controller -config-path /usr/local/etc/aci-containers/controller.conf -aws-subnets $AWS_SUBNETS -vpc-id $AWS_VPCID

--- a/docker/Dockerfile-gbpserver
+++ b/docker/Dockerfile-gbpserver
@@ -1,7 +1,5 @@
-FROM alpine:3.10.2
-RUN apk upgrade --no-cache
+FROM registry.access.redhat.com/ubi8/ubi:latest
 COPY dist-static/gbpserver /usr/local/bin/
 
-ENV KUBECONFIG=/kube/kube.yml
 ENV GBP_SERVER_CONF=None
 ENTRYPOINT exec /usr/local/bin/gbpserver -proxy-listen-port 443 --config-path $GBP_SERVER_CONF

--- a/docker/Dockerfile-host-dev
+++ b/docker/Dockerfile-host-dev
@@ -1,0 +1,5 @@
+FROM noirolabs/ubibase:latest
+COPY dist-static/aci-containers-host-agent dist-static/opflex-agent-cni docker/launch-hostagent.sh docker/enable-hostacc.sh docker/enable-droplog.sh /usr/local/bin/
+ENV TENANT=kube
+ENV NODE_EPG='kubernetes|kube-nodes'
+CMD ["/usr/local/bin/launch-hostagent.sh"]


### PR DESCRIPTION
- Created dev dockerfiles for hostagent and controller, using noirolabs/ubibase as the base. This allows building without a RHEL env. 
- Switched gbpserver to use ubi.
- Updated Makefile to use dev dockerfiles if Mac env is detected.