### PR TITLE
Clean Stale EpFile.

### DIFF
--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -342,7 +342,7 @@ func (agent *HostAgent) syncEps() bool {
 				seen[epidstr] = true
 			}
 		}
-		if !ok {
+		if !ok || (ok && !seen[epidstr]) {
 			logger.Info("Removing endpoint")
 			os.Remove(epfile)
 		}


### PR DESCRIPTION
Issue:
What seems to be happening in this case is that the container exits and the kubelet creates a new one for the same pod. So the pod UID doesn’t change but the container and interface changes.
But our EP file clean up logic only looks at the UID. If the ep file has the UID we don’t delete it, this results in the stale EP files not getting deleted.
Fix:
include the interface name also in the clean-up logic, meaning if the interface doesnt exist (even if the UID exists) we will clean up the EP file