### PR TITLE
Reduce the size of some of our docker images

### DIFF
--- a/docker/Dockerfile-openvswitch
+++ b/docker/Dockerfile-openvswitch
@@ -1,6 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum update -y && \
-  yum install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+RUN yum install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
   --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms openvswitch logrotate conntrack-tools \
   tcpdump curl strace ltrace iptables net-tools && yum clean all
 COPY docker/launch-ovs.sh docker/liveness-ovs.sh dist-static/ovsresync /usr/local/bin/

--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -1,6 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* update -y && \
-  yum --disablerepo=\*ubi\* install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+RUN yum --disablerepo=\*ubi\* install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
   --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms libstdc++ libuv \
   boost-program-options boost-system boost-date-time boost-filesystem \
   boost-iostreams libnetfilter_conntrack openssl net-tools procps-ng ca-certificates \

--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -3,19 +3,19 @@ ARG BUILDOPTS="--enable-grpc --enable-prometheus"
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/share/pkgconfig
 WORKDIR /opflex
 COPY libopflex /opflex/libopflex
+COPY genie /opflex/genie
+COPY agent-ovs /opflex/agent-ovs
 ARG make_args=-j4
 RUN cd /opflex/libopflex \
   && ./autogen.sh && ./configure --disable-assert \
-  && make $make_args && make install && make clean
-COPY genie /opflex/genie
-RUN cd /opflex/genie/target/libmodelgbp \
+  && make $make_args && make install && make clean \
+  && cd /opflex/genie/target/libmodelgbp \
   && sh autogen.sh && ./configure --disable-static \
-  && make $make_args && make install && make clean
-COPY agent-ovs /opflex/agent-ovs
-RUN cd /opflex/agent-ovs \
+  && make $make_args && make install && make clean \
+  && cd /opflex/agent-ovs \
   && ./autogen.sh && ./configure $BUILDOPTS \
-  && make $make_args && make install && make clean
-RUN for p in `find /usr/local/lib/ /usr/local/bin/ -type f \(\
+  && make $make_args && make install && make clean \
+  && for p in `find /usr/local/lib/ /usr/local/bin/ -type f \(\
     -name 'opflex_agent' -o \
     -name 'gbp_inspect' -o \
     -name 'mcast_daemon' -o \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -1,36 +1,44 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV ROOT=/usr/local
-RUN microdnf update && microdnf install --enablerepo codeready-builder-for-rhel-8-x86_64-rpms \
+ARG make_args=-j4
+RUN microdnf install --enablerepo codeready-builder-for-rhel-8-x86_64-rpms \
     libtool pkgconfig autoconf automake make cmake file python2-six \
     openssl-devel git gcc gcc-c++ boost-devel diffutils python2-devel \
     libnetfilter_conntrack-devel wget which curl-devel procps zlib-devel \
     && microdnf clean all
-ARG make_args=-j4
 RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
   && tar xvfz v1.1.0.tar.gz \
   && cd rapidjson-1.1.0 \
   && cmake CMakeLists.txt \
   && cp -R include/rapidjson/ /usr/local/include/ \
   && mkdir /usr/local/lib/pkgconfig \
-  && cp RapidJSON.pc /usr/local/lib/pkgconfig/
-RUN git clone https://github.com/libuv/libuv.git --branch v1.20.3 --depth 1 \
+  && cp RapidJSON.pc /usr/local/lib/pkgconfig/ \
+  && cd / \
+  && rm -rf v1.1.0.tar.gz \
+  && rm -rf rapidjson-1.1.0 \
+  && git clone https://github.com/libuv/libuv.git --branch v1.20.3 --depth 1 \
   && cd libuv \
   && ./autogen.sh \
   && ./configure \
   && make $make_args \
-  && make install && make clean
-RUN git clone https://github.com/noironetworks/3rdparty-debian.git
-RUN git clone https://github.com/jupp0r/prometheus-cpp.git \
+  && make install && make clean \
+  && cd / \
+  && rm -rf libuv \
+  && git clone https://github.com/noironetworks/3rdparty-debian.git \
+  && git clone https://github.com/jupp0r/prometheus-cpp.git \
   && cd prometheus-cpp \
   && git checkout 9effb90b0c266316358680cbf862a8564eb2c2d4 \
   && git submodule init \
   && git submodule update \
-  && git apply ../3rdparty-debian/prometheus/prometheus-cpp.patch \
+  && git apply /3rdparty-debian/prometheus/prometheus-cpp.patch \
   && mkdir _build && cd _build \
   && cmake .. -DBUILD_SHARED_LIBS=ON \
   && make $make_args && make install && make clean \
-  && mv /usr/local/lib64/libprometheus-cpp-* /usr/local/lib/
-RUN git clone https://github.com/grpc/grpc \
+  && mv /usr/local/lib64/libprometheus-cpp-* /usr/local/lib/ \
+  && cd / \
+  && rm -rf 3rdparty-debian \
+  && rm -rf prometheus-cpp \
+  && git clone https://github.com/grpc/grpc \
   && cd grpc \
   && git checkout 5052efd666ab6fdda2a4b3045569f70ce0c5fa57 \
   && git submodule update --init \
@@ -38,7 +46,9 @@ RUN git clone https://github.com/grpc/grpc \
   && cd third_party/protobuf \
   && ./autogen.sh \
   && ./configure \
-  && make $make_args && make install && make clean
+  && make $make_args && make install && make clean \
+  && cd / \
+  && rm -rf grpc
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'
@@ -51,4 +61,5 @@ RUN git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1 
   && mv $ROOT/include/openflow $ROOT/include/openvswitch \
   && cp include/*.h "$ROOT/include/openvswitch/" \
   && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \; \
-  && make clean
+  && cd / \
+  && rm -rf ovs 

--- a/docker/Dockerfile-opflexserver
+++ b/docker/Dockerfile-opflexserver
@@ -1,6 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* update -y && \
-  yum --disablerepo=\*ubi\* install -y libstdc++ libuv \
+RUN yum --disablerepo=\*ubi\* install -y libstdc++ libuv \
   boost-program-options boost-system boost-date-time boost-filesystem \
   boost-iostreams libnetfilter_conntrack openssl net-tools procps-ng ca-certificates \
   && yum clean all


### PR DESCRIPTION
Reduce the size of images by reducing the number of layers created and cleaning up repos after 'make install'. This primarily benefits our intermediate containers (opflex-build and opflex-build-base) 

Current master-test image sizes

10.30.120.20/noiro/opflex-server                master-test        5b4947a65422   2 hours ago         328 MB
10.30.120.20/noiro/opflex                       master-test        a1d5a1a0ffe1   2 hours ago         329 MB
10.30.120.20/noiro/opflex-build                 master-test        9a2f55ce9518   2 hours ago         4.81 GB
10.30.120.20/noiro/openvswitch                  master-test        dca5e353212e   2 days ago          440 MB
10.30.120.20/noiro/opflex-build-base            master-test        b6a123f70984   6 days ago          3.81 GB

Updated image sizes after changes

10.30.120.23/noiro/opflex-server                master-test-quay   a5446fb726a4   19 minutes ago      317 MB
10.30.120.23/noiro/opflex                       master-test-quay   9762082573c7   20 minutes ago      329 MB
10.30.120.23/noiro/opflex-build                 master-test-quay   69e6aa2f8120   2 minutes ago        2.12 GB
10.30.120.23/noiro/openvswitch                  master-test-quay   5ed3a309e47b   38 seconds ago      430 MB
10.30.120.23/noiro/opflex-build-base            master-test-quay   371bd6e9dc77   5 minutes ago    1.51 GB

