### PR TITLE
Reduce the size of some of our k8s docker images

### DIFF
--- a/docker/Dockerfile-cnideploy
+++ b/docker/Dockerfile-cnideploy
@@ -1,7 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* update -y && \
-  yum --disablerepo=\*ubi\* install -y wget ca-certificates \
-  && yum clean all
-RUN mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar xz -C /opt/cni/bin
+RUN yum --disablerepo=\*ubi\* install -y wget ca-certificates \
+  && yum clean all \
+  && mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar xz -C /opt/cni/bin
 COPY launch-cnideploy.sh /usr/local/bin/
 CMD ["/usr/local/bin/launch-cnideploy.sh"]

--- a/docker/Dockerfile-controller
+++ b/docker/Dockerfile-controller
@@ -1,12 +1,11 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* update -y && \
-  yum --disablerepo=\*ubi\* install -y curl git \
-  && yum clean all
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
-RUN chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
-RUN curl -sL "https://github.com/istio/istio/releases/download/1.5.2/istioctl-1.5.2-linux.tar.gz" | tar xz
-RUN chmod u+x istioctl && mv istioctl /usr/local/bin/istioctl
-RUN mkdir -p /usr/local/var/lib/aci-cni
+RUN yum --disablerepo=\*ubi\* install -y curl git \
+  && yum clean all \
+  && curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
+  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl \
+  && curl -sL "https://github.com/istio/istio/releases/download/1.5.2/istioctl-1.5.2-linux.tar.gz" | tar xz \
+  && chmod u+x istioctl && mv istioctl /usr/local/bin/istioctl \
+  && mkdir -p /usr/local/var/lib/aci-cni
 COPY pkg/istiocrd/upstream-istio-cr-1.5.2.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
 COPY dist-static/aci-containers-controller /usr/local/bin/
 ENV AWS_SUBNETS="None"

--- a/docker/Dockerfile-host
+++ b/docker/Dockerfile-host
@@ -1,6 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* update -y && \
-  yum --disablerepo=\*ubi\* install -y iproute nftables \
+RUN yum --disablerepo=\*ubi\* install -y iproute nftables \
   && yum clean all
 COPY dist-static/aci-containers-host-agent dist-static/opflex-agent-cni docker/launch-hostagent.sh docker/enable-hostacc.sh docker/enable-droplog.sh /usr/local/bin/
 ENV TENANT=kube

--- a/docker/Dockerfile-operator
+++ b/docker/Dockerfile-operator
@@ -1,8 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* update -y && \
-  yum --disablerepo=\*ubi\* install -y curl git \
-  && yum clean all
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.6/bin/linux/amd64/kubectl
-RUN chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
+RUN yum --disablerepo=\*ubi\* install -y curl git \
+  && yum clean all \
+  && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.6/bin/linux/amd64/kubectl \
+  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
 COPY dist-static/aci-containers-operator /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/aci-containers-operator"]


### PR DESCRIPTION
Avoid yum update when building and reduce the number of layers created by combining RUN commands.

Image sizes prior to changes

10.30.120.20/noiro/aci-containers-operator      master-test        9e3fa6e5caee   14 hours ago         450 MB
10.30.120.20/noiro/cnideploy                    master-test        816ef46af7c6   14 hours ago         311 MB
10.30.120.20/noiro/aci-containers-controller    master-test        b884bc4bb248   14 hours ago         657 MB
10.30.120.20/noiro/aci-containers-host          master-test        4a03cc0670f5   14 hours ago         285 MB


Image sizes after changes

10.30.120.23/noiro/aci-containers-operator      master-test-quay   1daa40b330ca   5 minutes ago       396 MB
10.30.120.23/noiro/cnideploy                    master-test-quay   f1bc5c1586a5   7 minutes ago       300 MB
10.30.120.23/noiro/aci-containers-controller    master-test-quay   7018bd0537f2   8 minutes ago       506 MB
10.30.120.23/noiro/aci-containers-host          master-test-quay   d8ba9140d6db   10 minutes ago      273 MB

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>