### PR TITLE
Change order of veth patch ports and ep files

### DIFF
--- a/docker/enable-hostacc.sh
+++ b/docker/enable-hostacc.sh
@@ -85,9 +85,9 @@ if [[ ! -z "$VTEP_IFACE" && ! -z "$VTEP_IP_CIDR" ]]; then
     # Create Host EP file
     UUID=${HOSTNAME}_${VTEP_IP}_veth_host_ac
     #FNAME=${UUID}.ep
-    FNAME=veth_host_ac.ep
+    FNAME=veth_host_ac.ep.gen
 
-cat <<EOF > ${VARDIR}/lib/opflex-agent-ovs/endpoints/${FNAME}
+cat <<EOF > ${VARDIR}/lib/opflex-agent-ovs/${FNAME}
 {
   "uuid": "$UUID",
   "eg-policy-space": "$TENANT",
@@ -109,5 +109,5 @@ cat <<EOF > ${VARDIR}/lib/opflex-agent-ovs/endpoints/${FNAME}
 }
 EOF
 
-    cat ${VARDIR}/lib/opflex-agent-ovs/endpoints/${FNAME}
+    cat ${VARDIR}/lib/opflex-agent-ovs/${FNAME}
 fi

--- a/pkg/hostagent/nodes.go
+++ b/pkg/hostagent/nodes.go
@@ -39,8 +39,9 @@ import (
 )
 
 const (
-	hostVethEP   = "veth_host_ac.ep"
-	hostVethName = "veth_host"
+	hostVethEP    = "veth_host_ac.ep"
+	hostVethEPGen = "veth_host_ac.ep.gen"
+	hostVethName  = "veth_host"
 )
 
 func (agent *HostAgent) initNodeInformerFromClient(
@@ -149,8 +150,13 @@ func (agent *HostAgent) registerHostVeth() {
 			epfile := filepath.Join(agent.config.OpFlexEndpointDir, hostVethEP)
 			datacont, err := ioutil.ReadFile(epfile)
 			if err != nil {
-				agent.log.Errorf("Unable to read %s - %v", epfile, err)
-				return
+				agent.log.Errorf("Unable to read, trying generated file %s - %v", epfile, err)
+				epfile = filepath.Join(agent.config.OpFlexEndpointDir, "..", hostVethEPGen)
+				datacont, err = ioutil.ReadFile(epfile)
+				if err != nil {
+					agent.log.Errorf("Unable to read %s - %v", epfile, err)
+					return
+				}
 			}
 
 			err = json.Unmarshal(datacont, ep)


### PR DESCRIPTION
- currently launch script creates ep file
- go code creates patch ports
- this can cause issues when agent sees the ep file
  before the patch ports are completely setup
- make the launch code create ep.gen file
- go code creates patch ports
- copies the .gen file into the endpoints dir
- in addition the nodes.go reads the file at init
- make it read the .gen file if ep file is missing