### PR TITLE
Change order of veth plumbing and file creation

### DIFF
--- a/docker/Dockerfile-host
+++ b/docker/Dockerfile-host
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* install -y iproute nftables \
+RUN yum --disablerepo=\*ubi\* --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms install -y iproute nftables openvswitch \
   && yum clean all
 COPY dist-static/aci-containers-host-agent dist-static/opflex-agent-cni docker/launch-hostagent.sh docker/enable-hostacc.sh docker/enable-droplog.sh /usr/local/bin/
 ENV TENANT=kube

--- a/docker/enable-hostacc.sh
+++ b/docker/enable-hostacc.sh
@@ -30,6 +30,12 @@ else
     ip link set veth_host up
     ip link set veth_host_ac up
 fi
+
+# plumb veth_host_ac to ovs bridges
+ovs-vsctl --may-exist add-port br-access veth_host_ac
+ovs-vsctl --may-exist add-port br-access pa-veth_host_ac -- set interface pa-veth_host_ac type=patch options:peer=pi-veth_host_ac
+ovs-vsctl --may-exist add-port br-int pi-veth_host_ac -- set interface pi-veth_host_ac type=patch options:peer=pa-veth_host_ac
+
 ACC_MAC=$(get_mac veth_host)
 
 vtep=$($HOSTAGENT -get-vtep)

--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -68,6 +68,7 @@ func testAgentWithConf(hcf *HostAgentConfig) *testHostAgent {
 	agent.env.(*K8sEnvironment).agent = agent.HostAgent
 
 	agent.fakeNodeSource = framework.NewFakeControllerSource()
+	agent.config.OvsDbSock = ""
 	agent.initNodeInformerBase(
 		&cache.ListWatch{
 			ListFunc:  agent.fakeNodeSource.List,

--- a/pkg/hostagent/ovs.go
+++ b/pkg/hostagent/ovs.go
@@ -279,18 +279,11 @@ func (agent *HostAgent) diffPorts(bridges map[string]ovsBridge) []libovsdb.Opera
 			if _, pok := accbr.ports["veth_host_ac"]; pok {
 				found[agent.config.AccessBridgeName]["veth_host_ac"] = true
 			} else {
-				agent.log.Debug("Adding host access port veth_host_ac")
-				adds, err :=
-					addIfaceOps("veth_host_ac", "pi-veth_host_ac",
-						"pa-veth_host_ac",
-						bridges[agent.config.AccessBridgeName].uuid,
-						bridges[agent.config.IntBridgeName].uuid,
-						strconv.Itoa(opid))
-				opid++
-				if err != nil {
-					agent.log.Error(err)
+				if agent.config.OvsDbSock != "" {
+					agent.log.Fatal("Could not find host access ports for veth_host_ac")
+				} else {
+					agent.log.Info("skipping host access port check for veth_host_ac")
 				}
-				ops = append(ops, adds...)
 			}
 			agent.ignoreOvsPorts[agent.config.IntBridgeName] = []string{"pi-veth_host_ac"}
 			agent.ignoreOvsPorts[agent.config.AccessBridgeName] = []string{"pa-veth_host_ac"}

--- a/pkg/hostagent/ovs_test.go
+++ b/pkg/hostagent/ovs_test.go
@@ -36,27 +36,11 @@ func TestDiffPorts(t *testing.T) {
 	agent.config.IntBridgeName = "br-int"
         agent.config.OpflexMode = "overlay"
 
-	onepodBr := map[string]ovsBridge{
-		"br-access": {
-			uuid: "86d9e696-00d0-43dd-9fd2-d43f7f6a883d",
-			ports: map[string]string{
-				"vethf3323b92":    "640a7740-d51e-4579-86e2-609d38b38e11",
-				"pa-vethf3323b92": "9dd84a8e-7a8e-4fe3-828e-9bb859490763",
-			},
-		},
-		"br-int": {
-			uuid: "aba85930-00f9-4665-9917-40beff731d87",
-			ports: map[string]string{
-				"pi-vethf3323b92": "baa976d4-3b8b-4cfb-976e-08477ffcf72c",
-			},
-		},
-	}
 	partialBr := map[string]ovsBridge{
 		"br-access": {
 			uuid: "86d9e696-00d0-43dd-9fd2-d43f7f6a883d",
 			ports: map[string]string{
 				"vethf3323b92": "640a7740-d51e-4579-86e2-609d38b38e11",
-				"veth_host_ac": "640a7740-d51e-4579-86e2-609d38b38000",
 			},
 		},
 		"br-int": {
@@ -79,9 +63,7 @@ func TestDiffPorts(t *testing.T) {
 	emptyBrWhostac := map[string]ovsBridge{
 		"br-access": {
 			uuid: "86d9e696-00d0-43dd-9fd2-d43f7f6a883d",
-			ports: map[string]string{
-				"veth_host_ac": "640a7740-d51e-4579-86e2-609d38b38000",
-			},
+			ports: map[string]string{},
 		},
 		"br-int": {
 			uuid:  "aba85930-00f9-4665-9917-40beff731d87",
@@ -105,10 +87,6 @@ func TestDiffPorts(t *testing.T) {
 		},
 	}
 
-	addHost_ac0, _ := addIfaceOps("veth_host_ac", "pi-veth_host_ac", "pa-veth_host_ac",
-		"86d9e696-00d0-43dd-9fd2-d43f7f6a883d", "aba85930-00f9-4665-9917-40beff731d87", "0")
-	addHost_ac1, _ := addIfaceOps("veth_host_ac", "pi-veth_host_ac", "pa-veth_host_ac",
-		"86d9e696-00d0-43dd-9fd2-d43f7f6a883d", "aba85930-00f9-4665-9917-40beff731d87", "1")
 	addOnePod, _ := addIfaceOps("vethf3323b92", "pi-vethf3323b92",
 		"pa-vethf3323b92", "86d9e696-00d0-43dd-9fd2-d43f7f6a883d",
 		"aba85930-00f9-4665-9917-40beff731d87", "0")
@@ -133,14 +111,8 @@ func TestDiffPorts(t *testing.T) {
 		{
 			bridges:  emptyBr,
 			metadata: onepodMeta,
-			expected: append(addOnePod, addHost_ac1...),
+			expected: addOnePod,
 			desc:     "simple add",
-		},
-		{
-			bridges:  onepodBr,
-			metadata: onepodMeta,
-			expected: addHost_ac0,
-			desc:     "no change",
 		},
 		{
 			bridges:  partialBr,


### PR DESCRIPTION
- create file after plumbing
- for this move plumbing to launch script
- needs openvswitch package for ovs-vsctl commands to be part of host-agent
- also adds ovsdb server dependency on openvswitch container
- if openvswitch is not ready will keep restarting until vsctl can connect to db