### PR TITLE
Removed the default MTU  value check of 1600 as it not working for RHCOS image

### DIFF
--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -72,7 +72,6 @@ type HostAgentNodeConfig struct {
 
 	// Registry Server URL -- for updating remote EP information
 	RegistryURL string `json:"registry-url,omitempty"`
-
 }
 
 // Configuration for the host agent
@@ -200,7 +199,7 @@ type HostAgentConfig struct {
 	//Namespace for SNAT CRDs
 	AciSnatNamespace string `json:"aci-snat-namespace,omitempty"`
 
-        //DropLogging enabled
+	//DropLogging enabled
 	EnableDropLogging bool `json:"enable-drop-log,omitempty"`
 
 	// DropLog Interface connecting to access bridge

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -49,8 +49,8 @@ func (agent *HostAgent) discoverHostConfig() (conf *HostAgentNodeConfig) {
 			if link.VlanId != int(agent.config.AciInfraVlan) {
 				continue
 			}
-
-			if link.MTU < 1600 {
+			// giving extra headroom of 100 bytes
+			if link.MTU < 100+agent.config.InterfaceMtu {
 				agent.log.WithFields(logrus.Fields{
 					"name": link.Name,
 					"vlan": agent.config.AciInfraVlan,
@@ -67,7 +67,7 @@ func (agent *HostAgent) discoverHostConfig() (conf *HostAgentNodeConfig) {
 				}
 
 				parent = plink
-				if parent.Attrs().MTU < 1600 {
+				if parent.Attrs().MTU < 100+agent.config.InterfaceMtu {
 					agent.log.WithFields(logrus.Fields{
 						"name": parent.Attrs().Name,
 						"vlan": agent.config.AciInfraVlan,


### PR DESCRIPTION
Removed the default MTU  value check of 1600 as it not working for RHCOS image
And verified  with configured MTU value which is initialized  with 1554(1500 + VXLAN header size)