### PR TITLE
Support UBI and Alpine private builds

### DIFF
--- a/build-priv.sh
+++ b/build-priv.sh
@@ -4,16 +4,49 @@
 # 2. mkdir -p $HOME/work && cd $HOME/work
 # 3. git clone https://github.com/noironetworks/opflex opflex
 # 4. docker login as DOCKER_HUB_ID
-# usage: build.sh <docker-user> :<tag>
-# example: ./build-priv.sh challa :demo
+# 5. cd docker && git checkout * when switching between UBI and Alpine builds
+# usage: build_priv.sh <ubi|alpine> docker-id :tag
+# example: ./build-priv.sh <alpine|ubi> challa :demo
 set -x
 
-DOCKER_HUB_ID=$1
-DOCKER_TAG=$2
+TYPE=$1
+DOCKER_HUB_ID=$2
+DOCKER_TAG=$3
+
+UBI_URI="registry.access.redhat.com\/ubi8\/ubi:latest"
+UBI_MIN_URI="registry.access.redhat.com\/ubi8\/ubi-minimal:latest"
+UBIBASE_OPFLEX="noirolabs\/ubibase-opflex:latest"
+UBIBASE_OPFLEX_BUILD_BASE="noirolabs\/ubibase-opflex-build-base:latest"
+UBIBASE_ACI="noirolabs\/ubibase-aci:latest"
+
+opflex_arr='Dockerfile-opflex Dockerfile-opflexserver'
+containers_arr='Dockerfile-controller Dockerfile-host Dockerfile-cnideploy Dockerfile-gbpserver Dockerfile-openvswitch'
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: build_priv.sh <ubi|alpine> docker-id :tag"
+  exit -1
+fi
+
+if [[ $TYPE == "alpine" ]]; then
+   echo "Starting Alpine build"
+   DOCKER_DIR=docker/dev/alpine
+elif [[ $TYPE == "ubi" ]]; then
+   echo "Starting Ubi build"
+   DOCKER_DIR=docker
+   sed -i -e "s/FROM ${UBI_MIN_URI}/FROM ${UBIBASE_OPFLEX_BUILD_BASE}/g" -e ':a;N;$!ba;s/RUN microdnf.*microdnf clean all/RUN :/g' \
+     $DOCKER_DIR/Dockerfile-opflex-build-base
+   for c in $opflex_arr; do
+     sed -i -e "s/FROM ${UBI_URI}/FROM ${UBIBASE_OPFLEX}/g" -e ':a;N;$!ba;s/RUN yum.*yum clean all/RUN :/g' $DOCKER_DIR/$c
+   done
+   for c in $containers_arr; do
+     sed -i -e "s/FROM ${UBI_URI}/FROM ${UBIBASE_ACI}/g" -e ':a;N;$!ba;s/RUN yum.*yum clean all/RUN :/g' $DOCKER_DIR/$c
+   done
+fi
 
 # Modify docker/Dockerfile-opflex-build to reflect DOCKER_HUB_ID and  DOCKER_TAG
 sed -i -e "s/FROM noiro\/opflex-build-base/FROM $DOCKER_HUB_ID\/opflex-build-base$DOCKER_TAG/g" \
-           docker/Dockerfile-opflex-build
+           $DOCKER_DIR/Dockerfile-opflex-build
+
 
 [ -z "$GOPATH" ] && GOPATH=$HOME/go
 export GOPATH
@@ -32,13 +65,13 @@ echo "starting opflex build"
 
 pushd $ACICONTAINERS_DIR
 rm -Rf build
-docker build -t $DOCKER_HUB_ID/opflex-build-base$DOCKER_TAG -f docker/Dockerfile-opflex-build-base docker
+docker build -t $DOCKER_HUB_ID/opflex-build-base$DOCKER_TAG -f $DOCKER_DIR/Dockerfile-opflex-build-base docker
 #docker push $DOCKER_HUB_ID/opflex-build-base$DOCKER_TAG
 
 pushd $OPFLEX_DIR/genie
 mvn compile exec:java
 popd
-docker build -t $DOCKER_HUB_ID/opflex-build$DOCKER_TAG -f docker/Dockerfile-opflex-build $OPFLEX_DIR
+docker build -t $DOCKER_HUB_ID/opflex-build$DOCKER_TAG -f $DOCKER_DIR/Dockerfile-opflex-build $OPFLEX_DIR
 #docker push $DOCKER_HUB_ID/opflex-build$DOCKER_TAG
 
 mkdir -p build/opflex/dist
@@ -63,8 +96,9 @@ docker run -w /usr/local $DOCKER_HUB_ID/opflex-build$DOCKER_TAG /bin/sh -c \
 cp docker/launch-opflexagent.sh build/opflex/dist/bin/
 cp docker/launch-mcastdaemon.sh build/opflex/dist/bin/
 cp docker/launch-opflexserver.sh build/opflex/dist/bin/
-cp docker/Dockerfile-opflex build/opflex/dist/
-cp docker/Dockerfile-opflexserver build/opflex/dist/
+cp -Rf docker/licenses build/opflex/dist
+cp $DOCKER_DIR/Dockerfile-opflex build/opflex/dist/
+cp $DOCKER_DIR/Dockerfile-opflexserver build/opflex/dist/
 
 docker build -t $DOCKER_HUB_ID/opflex$DOCKER_TAG -f ./build/opflex/dist/Dockerfile-opflex build/opflex/dist
 docker push $DOCKER_HUB_ID/opflex$DOCKER_TAG
@@ -73,21 +107,22 @@ docker push $DOCKER_HUB_ID/opflex-server$DOCKER_TAG
 
 echo "starting aci-containers build"
 make all-static
+make go-gbp-build
 
-docker build -t $DOCKER_HUB_ID/aci-containers-controller$DOCKER_TAG -f docker/Dockerfile-controller .
+docker build -t $DOCKER_HUB_ID/aci-containers-controller$DOCKER_TAG -f $DOCKER_DIR/Dockerfile-controller .
 docker push $DOCKER_HUB_ID/aci-containers-controller$DOCKER_TAG
 
-docker build -t $DOCKER_HUB_ID/aci-containers-host$DOCKER_TAG -f docker/Dockerfile-host .
+docker build -t $DOCKER_HUB_ID/aci-containers-host$DOCKER_TAG -f $DOCKER_DIR/Dockerfile-host .
 docker push $DOCKER_HUB_ID/aci-containers-host$DOCKER_TAG
 
-docker build -t $DOCKER_HUB_ID/cnideploy$DOCKER_TAG -f docker/Dockerfile-cnideploy docker
+docker build -t $DOCKER_HUB_ID/cnideploy$DOCKER_TAG -f $DOCKER_DIR/Dockerfile-cnideploy docker
 docker push $DOCKER_HUB_ID/cnideploy$DOCKER_TAG
 
-docker build -t $DOCKER_HUB_ID/gbp-server$DOCKER_TAG -f docker/Dockerfile-gbpserver .
+docker build -t $DOCKER_HUB_ID/gbp-server$DOCKER_TAG -f $DOCKER_DIR/Dockerfile-gbpserver .
 docker push $DOCKER_HUB_ID/gbp-server$DOCKER_TAG
 
 echo "starting openvswitch build"
-docker build -t $DOCKER_HUB_ID/openvswitch$DOCKER_TAG -f docker/Dockerfile-openvswitch .
+docker build -t $DOCKER_HUB_ID/openvswitch$DOCKER_TAG -f $DOCKER_DIR/Dockerfile-openvswitch .
 docker push $DOCKER_HUB_ID/openvswitch$DOCKER_TAG
 
 popd

--- a/docker/dev/alpine/Dockerfile-cnideploy
+++ b/docker/dev/alpine/Dockerfile-cnideploy
@@ -1,0 +1,6 @@
+FROM alpine:3.10.2
+RUN apk upgrade --no-cache && \
+  apk add --no-cache wget ca-certificates && update-ca-certificates
+RUN mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.8.5/cni-plugins-linux-amd64-v0.8.5.tgz | tar xz -C /opt/cni/bin
+COPY launch-cnideploy.sh /usr/local/bin/
+CMD ["/usr/local/bin/launch-cnideploy.sh"]

--- a/docker/dev/alpine/Dockerfile-controller
+++ b/docker/dev/alpine/Dockerfile-controller
@@ -1,0 +1,13 @@
+FROM alpine:3.10.2
+RUN apk upgrade --no-cache
+RUN apk update && apk add curl git
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+RUN chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
+RUN curl -LO https://istio.io/operator.yaml
+RUN mkdir -p /usr/local/var/lib/aci-cni
+COPY pkg/istiocrd/upstream-istio-operator-1.4.0.yaml /usr/local/var/lib/aci-cni/upstream-istio-operator.yaml
+COPY pkg/istiocrd/upstream-istio-cr-1.4.0.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
+COPY dist-static/aci-containers-controller /usr/local/bin/
+ENV AWS_SUBNETS="None"
+ENV AWS_VPCID="None"
+ENTRYPOINT exec /usr/local/bin/aci-containers-controller -config-path /usr/local/etc/aci-containers/controller.conf -aws-subnets $AWS_SUBNETS -vpc-id $AWS_VPCID

--- a/docker/dev/alpine/Dockerfile-gbpserver
+++ b/docker/dev/alpine/Dockerfile-gbpserver
@@ -1,0 +1,7 @@
+FROM alpine:3.10.2
+RUN apk upgrade --no-cache
+COPY dist-static/gbpserver /usr/local/bin/
+
+ENV KUBECONFIG=/kube/kube.yml
+ENV GBP_SERVER_CONF=None
+ENTRYPOINT exec /usr/local/bin/gbpserver -proxy-listen-port 443 --config-path $GBP_SERVER_CONF

--- a/docker/dev/alpine/Dockerfile-gobuild
+++ b/docker/dev/alpine/Dockerfile-gobuild
@@ -1,0 +1,29 @@
+FROM golang
+ARG proxy
+ENV https_proxy=$proxy
+ENV http_proxy=$proxy
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+RUN apt-get update
+RUN apt-get install -y python3 python3-pip && pip3 install -U pytest
+RUN pip3 install -U kubernetes
+
+RUN apt-get -y install git unzip build-essential autoconf libtool
+RUN git clone https://github.com/google/protobuf.git && \
+    cd protobuf && \
+    ./autogen.sh && \
+    ./configure && \
+    make && \
+    make install && \
+    ldconfig && \
+    make clean && \
+    cd .. && \
+    rm -r protobuf
+
+# Get the source from GitHub
+RUN go get google.golang.org/grpc
+# Install protoc-gen-go
+RUN go get github.com/golang/protobuf/protoc-gen-go
+
+ENV https_proxy=
+ENV http_proxy=

--- a/docker/dev/alpine/Dockerfile-host
+++ b/docker/dev/alpine/Dockerfile-host
@@ -1,0 +1,6 @@
+FROM alpine:3.10.2
+RUN apk upgrade --no-cache && apk add --no-cache iproute2 nftables openvswitch
+COPY dist-static/aci-containers-host-agent dist-static/opflex-agent-cni docker/launch-hostagent.sh docker/enable-hostacc.sh docker/enable-droplog.sh /usr/local/bin/
+ENV TENANT=kube
+ENV NODE_EPG='kubernetes|kube-nodes'
+CMD ["/usr/local/bin/launch-hostagent.sh"]

--- a/docker/dev/alpine/Dockerfile-openvswitch
+++ b/docker/dev/alpine/Dockerfile-openvswitch
@@ -1,0 +1,6 @@
+FROM alpine:3.11.5
+RUN apk upgrade --no-cache && \
+  apk --no-cache add openvswitch logrotate conntrack-tools tcpdump curl strace \
+  ltrace iptables net-tools
+COPY docker/launch-ovs.sh docker/liveness-ovs.sh dist-static/ovsresync /usr/local/bin/
+CMD ["/usr/local/bin/launch-ovs.sh"]

--- a/docker/dev/alpine/Dockerfile-operator
+++ b/docker/dev/alpine/Dockerfile-operator
@@ -1,0 +1,7 @@
+FROM alpine:3.10.2
+RUN apk upgrade --no-cache
+RUN apk update && apk add curl git
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.6/bin/linux/amd64/kubectl
+RUN chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
+COPY dist-static/aci-containers-operator /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/aci-containers-operator"]

--- a/docker/dev/alpine/Dockerfile-opflex
+++ b/docker/dev/alpine/Dockerfile-opflex
@@ -1,0 +1,10 @@
+FROM alpine:3.11.5
+RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
+  boost-program_options boost-system boost-date_time boost-filesystem \
+  boost-iostreams libnetfilter_conntrack libssl1.1 libcrypto1.1 ca-certificates \
+  && update-ca-certificates
+COPY bin/* /usr/local/bin/
+COPY lib/* /usr/local/lib/
+ENV SSL_MODE="encrypted"
+ENV REBOOT_WITH_OVS="true"
+CMD ["/usr/local/bin/launch-opflexagent.sh"]

--- a/docker/dev/alpine/Dockerfile-opflex-build
+++ b/docker/dev/alpine/Dockerfile-opflex-build
@@ -1,0 +1,34 @@
+FROM noiro/opflex-build-base
+ARG BUILDOPTS="--enable-grpc --enable-prometheus"
+WORKDIR /opflex
+COPY libopflex /opflex/libopflex
+ARG make_args=-j4
+RUN cd /opflex/libopflex \
+  && ./autogen.sh && ./configure --disable-assert \
+  && make $make_args && make install && make clean
+COPY genie /opflex/genie
+RUN cd /opflex/genie/target/libmodelgbp \
+  && sh autogen.sh && ./configure --disable-static \
+  && make $make_args && make install && make clean
+COPY agent-ovs /opflex/agent-ovs
+RUN cd /opflex/agent-ovs \
+  && ./autogen.sh && ./configure $BUILDOPTS \
+  && make $make_args && make install && make clean
+RUN for p in `find /usr/local/lib/ /usr/local/bin/ -type f \(\
+    -name 'opflex_agent' -o \
+    -name 'gbp_inspect' -o \
+    -name 'mcast_daemon' -o \
+    -name 'opflex_server' -o \
+    -name 'libopflex*so*' -o \
+    -name 'libmodelgbp*so*' -o \
+    -name 'libopenvswitch*so*' -o \
+    -name 'libsflow*so*' -o \
+    -name 'libprometheus-cpp-*so*' -o \
+    -name 'libgrpc*so*' -o \
+    -name 'libgpr*so*' -o \
+    -name 'libofproto*so*' \
+    \)`; do \
+       objcopy --only-keep-debug "$p" "$p.debug"; \
+       objcopy --strip-debug "$p"; \
+       objcopy --add-gnu-debuglink="$p.debug" "$p"; \
+     done

--- a/docker/dev/alpine/Dockerfile-opflex-build-base
+++ b/docker/dev/alpine/Dockerfile-opflex-build-base
@@ -1,0 +1,43 @@
+FROM alpine:3.11.5
+ARG ROOT=/usr/local
+#COPY ovs-musl.patch /
+COPY ovsdb-idlc.in-fix-dict-change-during-iteration.patch /
+RUN apk upgrade --no-cache && apk add --no-cache build-base \
+    libtool pkgconfig autoconf automake cmake file py3-six \
+    linux-headers libuv-dev boost-dev openssl-dev git \
+    libnetfilter_conntrack-dev rapidjson-dev python3-dev bzip2-dev \
+    curl libcurl curl-dev zlib-dev
+ARG make_args=-j4
+RUN git clone https://github.com/noironetworks/3rdparty-debian.git
+RUN git clone https://github.com/jupp0r/prometheus-cpp.git \
+  && cd prometheus-cpp \
+  && git checkout 9effb90b0c266316358680cbf862a8564eb2c2d4 \
+  && git submodule init \
+  && git submodule update \
+  && git apply ../3rdparty-debian/prometheus/prometheus-cpp.patch \
+  && mkdir _build && cd _build \
+  && cmake .. -DBUILD_SHARED_LIBS=ON \
+  && make $make_args && make install && make clean \
+  && mv /usr/local/lib64/libprometheus-cpp-* /usr/local/lib/
+RUN git clone https://github.com/grpc/grpc \
+  && cd grpc \
+  && git checkout 5052efd666ab6fdda2a4b3045569f70ce0c5fa57 \
+  && git submodule update --init \
+  && make $make_args && make install \
+  && cd third_party/protobuf \
+  && ./autogen.sh \
+  && ./configure \
+  && make $make_args && make install && make clean
+ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
+ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
+ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'
+RUN git clone https://github.com/openvswitch/ovs.git --branch v2.12.0 --depth 1 \
+  && cd ovs && patch -p1 < /ovsdb-idlc.in-fix-dict-change-during-iteration.patch \
+  && ./boot.sh && ./configure --disable-ssl --disable-libcapng --enable-shared \
+  && make $make_args && make install \
+  && mkdir -p $ROOT/include/openvswitch/openvswitch \
+  && mv $ROOT/include/openvswitch/*.h $ROOT/include/openvswitch/openvswitch \
+  && mv $ROOT/include/openflow $ROOT/include/openvswitch \
+  && cp include/*.h "$ROOT/include/openvswitch/" \
+  && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \; \
+  && make clean

--- a/docker/dev/alpine/Dockerfile-opflex-build-base-debug
+++ b/docker/dev/alpine/Dockerfile-opflex-build-base-debug
@@ -1,0 +1,32 @@
+FROM alpine:3.10.2
+ARG ROOT=/usr/local
+COPY ovs-musl.patch /
+RUN apk upgrade --no-cache && apk add --no-cache build-base \
+    libtool pkgconfig autoconf automake cmake doxygen file py-six \
+    linux-headers libuv-dev boost-dev openssl-dev git \
+    libnetfilter_conntrack-dev rapidjson-dev python-dev bzip2-dev \
+    && apk add --no-cache libexecinfo-dev --repository \
+    http://nl.alpinelinux.org/alpine/edge/main
+ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
+ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
+ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'
+ARG make_args=-j4
+RUN git clone https://github.com/openvswitch/ovs.git --branch v2.6.0 --depth 1 \
+  && cd ovs \
+  && patch -p1 < /ovs-musl.patch \
+  && ./boot.sh && ./configure --disable-ssl --disable-libcapng --enable-shared \
+  && make $make_args && make install \
+  && mkdir -p $ROOT/include/openvswitch/openvswitch \
+  && mv $ROOT/include/openvswitch/*.h $ROOT/include/openvswitch/openvswitch \
+  && mv $ROOT/include/openflow $ROOT/include/openvswitch \
+  && cp include/*.h "$ROOT/include/openvswitch/" \
+  && find lib -name "*.h" -exec cp --parents {} "$ROOT/include/openvswitch/" \;
+RUN wget https://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz \
+  && tar zxvf boost_1_58_0.tar.gz \
+  && cd boost_1_58_0 \
+  && ./bootstrap.sh --prefix=$ROOT/boost_1_58_0 \
+  && ./b2 cxxflags=-fPIC cflags=-fPIC -a \
+  && ./b2 install --prefix=$ROOT/boost_1_58_0 \
+  && cd .. \
+  && rm -Rf boost_1_58_0.tar.gz \
+  && rm -Rf boost_1_58_0 \;

--- a/docker/dev/alpine/Dockerfile-opflexserver
+++ b/docker/dev/alpine/Dockerfile-opflexserver
@@ -1,0 +1,9 @@
+FROM alpine:3.11.5
+RUN apk upgrade --no-cache && apk add --no-cache musl libstdc++ libuv \
+  boost-program_options boost-system boost-date_time boost-filesystem \
+  boost-iostreams libnetfilter_conntrack libssl1.1 libcrypto1.1 ca-certificates \
+  && update-ca-certificates
+COPY bin/opflex_server /usr/local/bin/
+COPY bin/launch-opflexserver.sh /usr/local/bin/
+COPY lib/* /usr/local/lib/
+CMD ["/usr/local/bin/launch-opflexserver.sh"]

--- a/docker/dev/alpine/Dockerfile-simpleservice
+++ b/docker/dev/alpine/Dockerfile-simpleservice
@@ -1,0 +1,3 @@
+FROM alpine:edge
+COPY dist-static/simpleservice /usr/local/bin/
+CMD ["/usr/local/bin/simpleservice"]

--- a/docker/dev/alpine/Dockerfile-test
+++ b/docker/dev/alpine/Dockerfile-test
@@ -1,0 +1,8 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+RUN yum --disablerepo=\*ubi\* update -y && \
+  yum --disablerepo=\*ubi\* install -y iproute nftables \
+  && yum clean all
+COPY dist-static/aci-containers-host-agent dist-static/opflex-agent-cni docker/launch-hostagent.sh docker/enable-hostacc.sh docker/enable-droplog.sh /usr/local/bin/
+ENV TENANT=kube
+ENV NODE_EPG='kubernetes|kube-nodes'
+CMD ["/usr/local/bin/launch-hostagent.sh"]

--- a/docker/dev/alpine/Dockerfile-test-provision
+++ b/docker/dev/alpine/Dockerfile-test-provision
@@ -1,0 +1,14 @@
+FROM python:2.7.17-slim-buster
+
+RUN pip install ipaddr ipaddress requests pyYAML pyOpenSSL jinja2
+RUN apt-get update
+RUN apt-get install -y git
+WORKDIR /root
+RUN git clone https://github.com/jojimt/acc-provision -b prov-test
+RUN mkdir /root/acc-provision/provision/acc_provision/kube
+ADD test-provision/kube/ /root/acc-provision/provision/acc_provision/kube/
+ADD test-provision/run.sh /root/acc-provision/provision/acc_provision/
+ADD test-provision/helper.sh /root/acc-provision/provision/acc_provision/
+ADD test-provision/config.yaml.template /root/acc-provision/provision/acc_provision/
+WORKDIR /root/acc-provision/provision/acc_provision
+CMD ./run.sh

--- a/docker/dev/ubi/Dockerfile-ubibase-aci
+++ b/docker/dev/ubi/Dockerfile-ubibase-aci
@@ -1,0 +1,5 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+RUN yum --disablerepo=\*ubi\* --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms install -y openvswitch logrotate conntrack-tools \
+  tcpdump curl strace ltrace iptables net-tools curl git wget ca-certificates && yum clean all
+CMD ["/usr/bin/sh"]

--- a/docker/dev/ubi/Dockerfile-ubibase-opflex
+++ b/docker/dev/ubi/Dockerfile-ubibase-opflex
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+RUN yum --disablerepo=\*ubi\* install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms libstdc++ libuv \
+  boost-program-options boost-system boost-date-time boost-filesystem \
+  boost-iostreams libnetfilter_conntrack openssl net-tools procps-ng ca-certificates \
+  && yum clean all
+CMD ["/usr/bin/sh"]

--- a/docker/dev/ubi/Dockerfile-ubibase-opflex-build-base
+++ b/docker/dev/ubi/Dockerfile-ubibase-opflex-build-base
@@ -1,0 +1,7 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN microdnf install --enablerepo codeready-builder-for-rhel-8-x86_64-rpms \
+    libtool pkgconfig autoconf automake make cmake file python2-six \
+    openssl-devel git gcc gcc-c++ boost-devel diffutils python2-devel \
+    libnetfilter_conntrack-devel wget which curl-devel procps zlib-devel \
+    && microdnf clean all
+CMD ["/usr/bin/sh"]

--- a/docker/dev/ubi/README
+++ b/docker/dev/ubi/README
@@ -1,0 +1,3 @@
+The docker files in this directory are meant to be built on the redhat
+server. Normally they do not need to be built unless you need some
+new packages from redhat.

--- a/docker/dev/ubi/build.sh
+++ b/docker/dev/ubi/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -x
+
+docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy --build-arg NO_PROXY=$no_proxy -t noirolabs/ubibase-opflex-build-base -f Dockerfile-ubibase-opflex-build-base
+docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy --build-arg NO_PROXY=$no_proxy -t noirolabs/ubibase-opflex -f Dockerfile-ubibase-opflex
+docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy --build-arg NO_PROXY=$no_proxy -t noirolabs/ubibase-aci -f Dockerfile-ubibase-aci
+
+docker push noirolabs/ubibase-opflex-build-base
+docker push noirolabs/ubibase-opflex
+docker push noirolabs/ubibase-aci
+


### PR DESCRIPTION
Usage: build_priv.sh <ubi|alpine> docker-id :tag

- UBI build uses
   noirolabs/ubibase-aci
   noirolabs/ubibase-opflex-build-base
   noirolabs/ubibase-opflex
   built on redhat machine
- For UBI container builds script updates docker files to use
  above images so it does not need to download anything from
  redhat registry

- Alpine build uses dockerfiles from a separate directory
  docker/dev/alpine and triggers build like earlier.

Signed-off-by: Madhu Challa <challa@gmail.com>