### PR TITLE
Remove unneeded libs from opflex_agent/opflex_server containers

### DIFF
--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -16,8 +16,8 @@ COPY licenses /licenses
 COPY bin/opflex_agent /usr/local/bin/
 COPY bin/mcast_daemon /usr/local/bin/
 COPY bin/gbp_inspect /usr/local/bin/
-COPY bin/launch_opflexagent.sh /usr/local/bin/
-COPY bin/launch_mcastdaemon.sh /usr/local/bin/
+COPY bin/launch-opflexagent.sh /usr/local/bin/
+COPY bin/launch-mcastdaemon.sh /usr/local/bin/
 COPY lib/libm* /usr/local/lib/
 COPY lib/libo* /usr/local/lib/
 COPY lib/libp* /usr/local/lib/

--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -14,7 +14,10 @@ description="This will deploy a single instance of ACI CNI Opflex."
 # Required Licenses
 COPY licenses /licenses
 COPY bin/* /usr/local/bin/
-COPY lib/* /usr/local/lib/
+COPY lib/libm* /usr/local/lib/
+COPY lib/libo* /usr/local/lib/
+COPY lib/libp* /usr/local/lib/
+COPY lib/libs* /usr/local/lib/
 ENV SSL_MODE="encrypted"
 ENV REBOOT_WITH_OVS="true"
 CMD ["/usr/local/bin/launch-opflexagent.sh"]

--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -13,7 +13,11 @@ summary="This is an ACI CNI Opflex." \
 description="This will deploy a single instance of ACI CNI Opflex."
 # Required Licenses
 COPY licenses /licenses
-COPY bin/* /usr/local/bin/
+COPY bin/opflex_agent /usr/local/bin/
+COPY bin/mcast_daemon /usr/local/bin/
+COPY bin/gbp_inspect /usr/local/bin/
+COPY bin/launch_opflexagent.sh /usr/local/bin/
+COPY bin/launch_mcastdaemon.sh /usr/local/bin/
 COPY lib/libm* /usr/local/lib/
 COPY lib/libo* /usr/local/lib/
 COPY lib/libp* /usr/local/lib/

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -38,9 +38,8 @@ RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
   && cd / \
   && rm -rf 3rdparty-debian \
   && rm -rf prometheus-cpp \
-  && git clone https://github.com/grpc/grpc \
+  && git clone https://github.com/grpc/grpc --branch v1.29.x \
   && cd grpc \
-  && git checkout 5052efd666ab6fdda2a4b3045569f70ce0c5fa57 \
   && git submodule update --init \
   && make $make_args && make install \
   && cd third_party/protobuf \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -38,8 +38,9 @@ RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
   && cd / \
   && rm -rf 3rdparty-debian \
   && rm -rf prometheus-cpp \
-  && git clone https://github.com/grpc/grpc --branch v1.29.x \
+  && git clone https://github.com/grpc/grpc \
   && cd grpc \
+  && git checkout 5052efd666ab6fdda2a4b3045569f70ce0c5fa57 \
   && git submodule update --init \
   && make $make_args && make install \
   && cd third_party/protobuf \

--- a/docker/Dockerfile-opflexserver
+++ b/docker/Dockerfile-opflexserver
@@ -5,5 +5,8 @@ RUN yum --disablerepo=\*ubi\* install -y libstdc++ libuv \
   && yum clean all
 COPY bin/opflex_server /usr/local/bin/
 COPY bin/launch-opflexserver.sh /usr/local/bin/
-COPY lib/* /usr/local/lib/
+COPY lib/libm* /usr/local/lib/
+COPY lib/libopflex* /usr/local/lib/
+COPY lib/libp* /usr/local/lib/
+COPY lib/libg* /usr/local/lib/
 CMD ["/usr/local/bin/launch-opflexserver.sh"]


### PR DESCRIPTION
Reduce the size of a couple of containers

opflex_agent container doesn't need grpc libs
opflex_server container doesn't need OVS libs

Removing them saves ~42MB for the agent and ~11MB for the server.

TODO: Additional savings could be had by fixing the symlinks so that we don't have multiple copies of each lib in /usr/local/lib

10.30.120.20/noiro/opflex-server                tom-test           a308727b78e9   About an hour ago   306 MB
10.30.120.20/noiro/opflex                       tom-test           19ed391bdc3a   About an hour ago   276 MB
10.30.120.20/noiro/opflex-server                master-test        9839f9df5c22   45 minutes ago      317 MB
10.30.120.20/noiro/opflex                       master-test        2e13dd41c9bd   About an hour ago   318 MB