### PR TITLE
Move to OVS 2.12

### DIFF
--- a/docker/Dockerfile-openvswitch
+++ b/docker/Dockerfile-openvswitch
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 RUN yum install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
-  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms openvswitch logrotate conntrack-tools \
+  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms openvswitch2.12 logrotate conntrack-tools \
   tcpdump curl strace ltrace iptables net-tools && yum clean all
 # Required OpenShift Labels
 LABEL name="ACI CNI Openvswitch" \


### PR DESCRIPTION
By default we get OVS 2.11 from the repo. Move to OVS 2.12 instead to match what we test with locally

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>