### PR TITLE
Added Endpointslice support

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -199,6 +199,8 @@ type ControllerConfig struct {
 
 	// Maximum CSR tunnels
 	MaxCSRTunnels int `json:"max-csr-tunnels,omitempty"`
+	// enable EndpointSlice
+	EnabledEndpointSlice bool `json:"enable_endpointslice,omitempty"`
 }
 
 type netIps struct {

--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -38,6 +38,7 @@ type testHostAgent struct {
 	fakeNodeSource          *framework.FakeControllerSource
 	fakePodSource           *framework.FakeControllerSource
 	fakeEndpointsSource     *framework.FakeControllerSource
+	fakeEndpointSliceSource *framework.FakeControllerSource
 	fakeServiceSource       *framework.FakeControllerSource
 	fakeNamespaceSource     *framework.FakeControllerSource
 	fakeDeploymentSource    *framework.FakeControllerSource
@@ -66,7 +67,8 @@ func testAgentWithConf(hcf *HostAgentConfig) *testHostAgent {
 	}
 
 	agent.env.(*K8sEnvironment).agent = agent.HostAgent
-
+	agent.serviceEndPoints = &serviceEndpoint{}
+	agent.serviceEndPoints.(*serviceEndpoint).agent = agent.HostAgent
 	agent.fakeNodeSource = framework.NewFakeControllerSource()
 	agent.config.OvsDbSock = ""
 	agent.initNodeInformerBase(
@@ -93,6 +95,12 @@ func testAgentWithConf(hcf *HostAgentConfig) *testHostAgent {
 		&cache.ListWatch{
 			ListFunc:  agent.fakeEndpointsSource.List,
 			WatchFunc: agent.fakeEndpointsSource.Watch,
+		})
+	agent.fakeEndpointSliceSource = framework.NewFakeControllerSource()
+	agent.initEndpointSliceInformerBase(
+		&cache.ListWatch{
+			ListFunc:  agent.fakeEndpointSliceSource.List,
+			WatchFunc: agent.fakeEndpointSliceSource.Watch,
 		})
 
 	agent.fakeServiceSource = framework.NewFakeControllerSource()

--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -213,6 +213,9 @@ type HostAgentConfig struct {
 
 	// More than one droplog within the repeat interval for the same event is suppressed
 	DropLogRepeatIntervalTime uint `json:"drop-log-repeat-intvl,omitempty"`
+
+	// enable EndpointSlice
+	EnabledEndpointSlice bool `json:"enable_endpointslice,omitempty"`
 }
 
 func (config *HostAgentConfig) InitFlags() {

--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -132,7 +132,7 @@ func (env *K8sEnvironment) Init(agent *HostAgent) error {
 	env.agent.log.Debug("Initializing informers")
 	env.agent.initNodeInformerFromClient(env.kubeClient)
 	env.agent.initPodInformerFromClient(env.kubeClient)
-	env.agent.initEndpointsInformerFromClient(env.kubeClient)
+	env.agent.serviceEndPoints.InitClientInformer(env.kubeClient)
 	env.agent.initServiceInformerFromClient(env.kubeClient)
 	env.agent.initNamespaceInformerFromClient(env.kubeClient)
 	env.agent.initNetworkPolicyInformerFromClient(env.kubeClient)
@@ -163,7 +163,7 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 	env.agent.log.Debug("Exporting node info: ", env.agent.config.NodeName)
 	go env.agent.podInformer.Run(stopCh)
 	go env.agent.controllerInformer.Run(stopCh)
-	go env.agent.endpointsInformer.Run(stopCh)
+	env.agent.serviceEndPoints.Run(stopCh)
 	go env.agent.serviceInformer.Run(stopCh)
 	go env.agent.nsInformer.Run(stopCh)
 	go env.agent.netPolInformer.Run(stopCh)
@@ -174,9 +174,9 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 	go env.agent.rdConfigInformer.Run(stopCh)
 	env.agent.log.Info("Waiting for cache sync for remaining objects")
 	cache.WaitForCacheSync(stopCh,
-		env.agent.podInformer.HasSynced, env.agent.endpointsInformer.HasSynced,
-		env.agent.serviceInformer.HasSynced, env.agent.snatGlobalInformer.HasSynced,
-		env.agent.snatPolicyInformer.HasSynced, env.agent.rdConfigInformer.HasSynced)
+		env.agent.podInformer.HasSynced, env.agent.serviceInformer.HasSynced,
+		env.agent.snatGlobalInformer.HasSynced, env.agent.snatPolicyInformer.HasSynced,
+		env.agent.rdConfigInformer.HasSynced)
 	env.agent.log.Info("Cache sync successful")
 	return true, nil
 }


### PR DESCRIPTION
1. Added watchers to listen for Endpoint slices changes both in controller and hostagent code
2. Service points to multiple endpointslice Object and each Slice Object points to list of Endpoints
   made changes for the Services code accordingly.
3. Egress netwokpolicy changes are done to handle the Endpoint Slices
4. Currently endpointslice support flag is turned off for this commit
5. Added multiple  UT's in services and networkpolicies by enabling the endpointslice support flag in tests