### PR TITLE
After hostagent restart Policy UID is missing in EP file.

### DIFF
--- a/pkg/hostagent/nodeinfo.go
+++ b/pkg/hostagent/nodeinfo.go
@@ -49,6 +49,17 @@ func (agent *HostAgent) InformNodeInfo(nodeInfoClient *nodeInfoclientset.Clients
 		if !reflect.DeepEqual(nodeInfo.Spec.SnatPolicyNames, snatpolicies) {
 			nodeInfo.Spec.SnatPolicyNames = snatpolicies
 			_, err = nodeInfoClient.AciV1().NodeInfos(agent.config.AciSnatNamespace).Update(nodeInfo)
+		} else {
+			// This case can hit restart of the Hostagent and having  same number of policeis present in nodinfo crd.
+			agent.indexMutex.Lock()
+			var poduids []string
+			for name := range snatpolicies {
+				for uuid, _ := range agent.snatPods[name] {
+					poduids = append(poduids, uuid)
+				}
+			}
+			agent.updateEpFiles(poduids)
+			agent.indexMutex.Unlock()
 		}
 	}
 	if err == nil {


### PR DESCRIPTION
1. This issue is seen becuase the nodeinfo CRD is present with snatpolicy and restart the hostagent,
   then after recomputing the policies. if the policyinfo  matches with the nodeinfo CRD there is no sync is triggred.
   now we are explicitly triggering the Epfile update if info matches to avoid this issue.

(cherry picked from commit 72edf1b1ee56f9e0d04fb0f39f4fc23500c1c2db)