### PR TITLE
CSCvu92591: Handling DeletedFinalStateUnknown

### DIFF
--- a/pkg/controller/deployments.go
+++ b/pkg/controller/deployments.go
@@ -146,7 +146,19 @@ func (cont *AciController) deploymentChanged(oldobj interface{},
 }
 
 func (cont *AciController) deploymentDeleted(obj interface{}) {
-	dep := obj.(*appsv1.Deployment)
+	dep, isDeployment := obj.(*appsv1.Deployment)
+	if !isDeployment {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			cont.log.Error("Received unexpected object:", obj)
+			return
+		}
+		dep, ok = deletedState.Obj.(*appsv1.Deployment)
+		if !ok {
+		    cont.log.Error("DeletedFinalStateUnknown contained non-Deployment object: ", deletedState.Obj)
+			return
+		}
+	}
 	depkey, err :=
 		cache.MetaNamespaceKeyFunc(dep)
 	if err != nil {

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -1180,7 +1180,21 @@ func (cont *AciController) networkPolicyChanged(oldobj interface{},
 }
 
 func (cont *AciController) networkPolicyDeleted(obj interface{}) {
-	np := obj.(*v1net.NetworkPolicy)
+    np, isNetworkpolicy := obj.(*v1net.NetworkPolicy)
+    if !isNetworkpolicy {
+        deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+        if !ok {
+            networkPolicyLogger(cont.log, np).
+                Error("Received unexpected object: ", obj)
+            return
+        }
+        np, ok = deletedState.Obj.(*v1net.NetworkPolicy)
+        if !ok {
+            networkPolicyLogger(cont.log, np).
+                Error("DeletedFinalStateUnknown contained non-Networkpolicy object: ", deletedState.Obj)
+            return
+        }
+    }
 	npkey, err := cache.MetaNamespaceKeyFunc(np)
 	if err != nil {
 		networkPolicyLogger(cont.log, np).

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -414,7 +414,19 @@ func (cont *AciController) nodeChanged(obj interface{}) {
 }
 
 func (cont *AciController) nodeDeleted(obj interface{}) {
-	node := obj.(*v1.Node)
+    node, isNode := obj.(*v1.Node)
+    if !isNode {
+        deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+        if !ok {
+			cont.log.Error("Received unexpected object: ", obj)
+            return
+        }
+        node, ok = deletedState.Obj.(*v1.Node)
+        if !ok {
+			cont.log.Error("DeletedFinalStateUnknown contained non-Node object: ", deletedState.Obj)
+            return
+        }
+    }
 	cont.apicConn.ClearApicObjects(cont.aciNameForKey("node", node.Name))
 	cont.apicConn.ClearApicObjects(cont.aciNameForKey("node-vmm", node.Name))
 

--- a/pkg/controller/nodes_test.go
+++ b/pkg/controller/nodes_test.go
@@ -70,15 +70,15 @@ func setupODev(cont *testAciController, nodeName string, hasMac bool) {
 	oDev.SetAttr("fabricPathDn",
 		"topology/pod-1/paths-301/pathep-[eth1/33]")
 	oDev.SetAttr("devType", "k8s")
-        oDev.SetAttr("domName", "kube")
-        oDev.SetAttr("ctrlrName", "kube")
+	oDev.SetAttr("domName", "kube")
+	oDev.SetAttr("ctrlrName", "kube")
 	cont.opflexDeviceChanged(oDev)
 }
 
 func TestServiceEpAnnotationV4(t *testing.T) {
 	cont := testController()
 	cont.config.AciVmmDomain = "kube"
-        cont.config.AciVmmController = "kube"
+	cont.config.AciVmmController = "kube"
 	cont.config.NodeServiceIpPool = []ipam.IpRange{
 		{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.1.3")},
 	}
@@ -140,7 +140,7 @@ func TestServiceEpAnnotationV6(t *testing.T) {
 func TestServiceEpAnnotationExisting(t *testing.T) {
 	cont := testController()
 	cont.config.AciVmmDomain = "kube"
-        cont.config.AciVmmController = "kube"
+	cont.config.AciVmmController = "kube"
 	cont.config.NodeServiceIpPool = []ipam.IpRange{
 		{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.1.4")},
 		{Start: net.ParseIP("fd43:85d7:bcf2:9ad2::2"), End: net.ParseIP("fd43:85d7:bcf2:9ad2::4")},
@@ -232,7 +232,7 @@ func TestPodNetV6Annotation(t *testing.T) {
 func TestPodNetAnnotation(t *testing.T) {
 	cont := testController()
 	cont.config.AciVmmDomain = "kube"
-        cont.config.AciVmmController = "kube"
+	cont.config.AciVmmController = "kube"
 	cont.config.PodIpPoolChunkSize = 2
 	cont.config.PodIpPool = []ipam.IpRange{
 		{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.1.13")},

--- a/pkg/controller/replicasets.go
+++ b/pkg/controller/replicasets.go
@@ -98,7 +98,21 @@ func (cont *AciController) replicaSetChanged(oldobj interface{},
 }
 
 func (cont *AciController) replicaSetDeleted(obj interface{}) {
-	rs := obj.(*appsv1.ReplicaSet)
+    rs, isReplicaset := obj.(*appsv1.ReplicaSet)
+    if !isReplicaset {
+        deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+        if !ok {
+			replicaSetLogger(cont.log, rs).
+            	Error("Received unexpected object: ", obj)
+            return
+        }
+        rs, ok = deletedState.Obj.(*appsv1.ReplicaSet)
+        if !ok {
+			replicaSetLogger(cont.log, rs).
+            	Error("DeletedFinalStateUnknown contained non-Replicaset object: ", deletedState.Obj)
+            return
+        }
+    }
 	rskey, err :=
 		cache.MetaNamespaceKeyFunc(rs)
 	if err != nil {


### PR DESCRIPTION
K8S resourceEventHandler can return a DeletedFinalStateUnknown object in some scenarios, in which case we parse it accordingly and handle without panicing.