### PR TITLE
Copy entire lib dir into container to preserve symlinks

### DIFF
--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -18,10 +18,7 @@ COPY bin/mcast_daemon /usr/local/bin/
 COPY bin/gbp_inspect /usr/local/bin/
 COPY bin/launch-opflexagent.sh /usr/local/bin/
 COPY bin/launch-mcastdaemon.sh /usr/local/bin/
-COPY lib/libm* /usr/local/lib/
-COPY lib/libo* /usr/local/lib/
-COPY lib/libp* /usr/local/lib/
-COPY lib/libs* /usr/local/lib/
+COPY agent/lib/ /usr/local/lib/
 ENV SSL_MODE="encrypted"
 ENV REBOOT_WITH_OVS="true"
 CMD ["/usr/local/bin/launch-opflexagent.sh"]

--- a/docker/Dockerfile-opflexserver
+++ b/docker/Dockerfile-opflexserver
@@ -5,8 +5,5 @@ RUN yum --disablerepo=\*ubi\* install -y libstdc++ libuv \
   && yum clean all
 COPY bin/opflex_server /usr/local/bin/
 COPY bin/launch-opflexserver.sh /usr/local/bin/
-COPY lib/libm* /usr/local/lib/
-COPY lib/libopflex* /usr/local/lib/
-COPY lib/libp* /usr/local/lib/
-COPY lib/libg* /usr/local/lib/
+COPY server/lib/ /usr/local/lib/
 CMD ["/usr/local/bin/launch-opflexserver.sh"]


### PR DESCRIPTION
Copy only the libs required by opflex server/agent

Doing this saves 26MB in the opflex container and a similar amount for opflex-server

10.30.120.20/noiro/opflex                                     tom-test                   8c68aed432ac   26 minutes ago      248 MB
10.30.120.20/noiro/opflex                                     master-test                7ebd57c44eac   3 hours ago         274 MB

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>