### PR TITLE
Revert "Use filter-chain for SNAT PBR contract"

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -627,41 +627,6 @@ var metadata = map[string]*apicMeta{
 		children: []string{
 			"vzRsSubjFiltAtt",
 			"vzRsSubjGraphAtt",
-			"vzInTerm",
-			"vzOutTerm",
-		},
-	},
-	"vzInTerm": {
-		attributes: map[string]interface{}{
-			"name": "",
-		},
-		children: []string{
-			"vzRsFiltAtt",
-			"vzRsInTermGraphAtt",
-		},
-	},
-	"vzOutTerm": {
-		attributes: map[string]interface{}{
-			"name": "",
-		},
-		children: []string{
-			"vzRsFiltAtt",
-			"vzRsOutTermGraphAtt",
-		},
-	},
-	"vzRsInTermGraphAtt": {
-		attributes: map[string]interface{}{
-			"tnVnsAbsGraphName": "",
-		},
-	},
-	"vzRsOutTermGraphAtt": {
-		attributes: map[string]interface{}{
-			"tnVnsAbsGraphName": "",
-		},
-	},
-	"vzRsFiltAtt": {
-		attributes: map[string]interface{}{
-			"tnVzFilterName": "",
 		},
 	},
 	"vzRsSubjFiltAtt": {
@@ -693,7 +658,6 @@ var metadata = map[string]*apicMeta{
 			"prot":        "unspecified",
 			"sFromPort":   "unspecified",
 			"sToPort":     "unspecified",
-			"tcpRules":    "",
 			"stateful":    "no",
 		},
 		normalizer: filterEntryNormalizer,

--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -806,44 +806,6 @@ func NewVzSubj(parentDn string, name string) ApicObject {
 	return ret
 }
 
-func NewVzInTerm(parentDn string) ApicObject {
-	ret := newApicObject("vzInTerm")
-	ret["vzInTerm"].Attributes["dn"] =
-		fmt.Sprintf("%s/intmnl", parentDn)
-	return ret
-}
-
-func NewVzOutTerm(parentDn string) ApicObject {
-	ret := newApicObject("vzOutTerm")
-	ret["vzOutTerm"].Attributes["dn"] =
-		fmt.Sprintf("%s/outtmnl", parentDn)
-	return ret
-}
-
-func NewVzRsFiltAtt(parentDn string, tnVzFilterName string) ApicObject {
-	ret := newApicObject("vzRsFiltAtt")
-	ret["vzRsFiltAtt"].Attributes["tnVzFilterName"] = tnVzFilterName
-	ret["vzRsFiltAtt"].Attributes["dn"] =
-		fmt.Sprintf("%s/rsfiltAtt-%s", parentDn, tnVzFilterName)
-	return ret
-}
-
-func NewVzRsInTermGraphAtt(parentDn string, tnVnsAbsGraphName string) ApicObject {
-	ret := newApicObject("vzRsInTermGraphAtt")
-	ret["vzRsInTermGraphAtt"].Attributes["tnVnsAbsGraphName"] = tnVnsAbsGraphName
-	ret["vzRsInTermGraphAtt"].Attributes["dn"] =
-		fmt.Sprintf("%s/rsInTermGraphAtt", parentDn)
-	return ret
-}
-
-func NewVzRsOutTermGraphAtt(parentDn string, tnVnsAbsGraphName string) ApicObject {
-	ret := newApicObject("vzRsOutTermGraphAtt")
-	ret["vzRsOutTermGraphAtt"].Attributes["tnVnsAbsGraphName"] = tnVnsAbsGraphName
-	ret["vzRsOutTermGraphAtt"].Attributes["dn"] =
-		fmt.Sprintf("%s/rsOutTermGraphAtt", parentDn)
-	return ret
-}
-
 func NewVzRsSubjFiltAtt(parentDn string, tnVzFilterName string) ApicObject {
 	ret := newApicObject("vzRsSubjFiltAtt")
 	ret["vzRsSubjFiltAtt"].Attributes["tnVzFilterName"] = tnVzFilterName

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -392,7 +392,7 @@ func TestServiceAnnotation(t *testing.T) {
 	service1.ObjectMeta.Annotations[metadata.ServiceContractScopeAnnotation] = "global"
 	time.Sleep(2 * time.Second)
 	cont.fakeServiceSource.Modify(service1)
-	contract := apicContract(name, "common", graphName, "global", false)
+	contract := apicContract(name, "common", graphName, "global")
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
@@ -464,7 +464,7 @@ func TestServiceGraph(t *testing.T) {
 	})
 
 	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, false, false)
-	contract := apicContract(name, "common", graphName, conScope, false)
+	contract := apicContract(name, "common", graphName, conScope)
 	rsCons := apicExtNetCons(name, "common", "l3out", "ext1")
 
 	filter := apicapi.NewVzFilter("common", name)

--- a/pkg/controller/snats_test.go
+++ b/pkg/controller/snats_test.go
@@ -102,9 +102,8 @@ func TestSnatGraph(t *testing.T) {
 			end:   65000,
 		},
 	}
-	contract := apicContract(name, "common", graphName, "global", true)
-	filterIn := apicFilterSnat(name+"_fromCons-toProv", "common", portRanges, false)
-	filterOut := apicFilterSnat(name+"_fromProv-toCons", "common", portRanges, true)
+	contract := apicContract(name, "common", graphName, "global")
+	filter := apicFilterSnat(name, "common", portRanges)
 	cc := apicDevCtx(name, "common", graphName,
 		"kube_bd_kubernetes-service", twoNodeRedirect.GetDn())
 
@@ -163,7 +162,7 @@ func TestSnatGraph(t *testing.T) {
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
-		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet, contract, rsProv, filterIn, filterOut, cc},
+		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet, contract, rsProv, filter, cc},
 			"kube", name),
 	}
 	sgWait(t, "snat graph creation", cont, expected)
@@ -174,7 +173,7 @@ func TestSnatGraph(t *testing.T) {
 	expected2 := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
-		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet2, contract, rsProv, filterIn, filterOut, cc},
+		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet2, contract, rsProv, filter, cc},
 			"kube", name),
 	}
 	sgWait(t, "snat graph addition", cont, expected2)
@@ -184,7 +183,7 @@ func TestSnatGraph(t *testing.T) {
 	expectedDeleteSnatPolicy := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
-		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet, contract, rsProv, filterIn, filterOut, cc},
+		name: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeRedirect, extNet, contract, rsProv, filter, cc},
 			"kube", name),
 	}
 	sgWait(t, "snat policy deleted", cont, expectedDeleteSnatPolicy)


### PR DESCRIPTION
Reverts noironetworks/aci-containers#579

We see an issue with APIC behavior which results in ServiceGraph faults. Reverting for now till we have a fix (or) work-around from APIC side.