### PR TITLE
CSCvv23505: Changing ServiceGraphTemplate connection's adjType

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -486,7 +486,7 @@ var metadata = map[string]*apicMeta{
 	"vnsAbsConnection": {
 		attributes: map[string]interface{}{
 			"name":          "",
-			"adjType":       "L2",
+			"adjType":       "L3",
 			"connDir":       "unknown",
 			"connType":      "external",
 			"directConnect": "no",


### PR DESCRIPTION
Issue: In cases where ACI CNI created SG is consumed by multiple EPGs spreaded across different BDs, adjType L2 results in a fault on APIC.

Fix: Change the adjType of SGT's vnsAbsConnection to L3 so that ACI CNI created SG can be usable in more deployment scenarios.