### PR TITLE
Change set2 : Using filter-chain for SNAT PBR contract

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -486,7 +486,7 @@ var metadata = map[string]*apicMeta{
 	"vnsAbsConnection": {
 		attributes: map[string]interface{}{
 			"name":          "",
-			"adjType":       "L2",
+			"adjType":       "L3",
 			"connDir":       "unknown",
 			"connType":      "external",
 			"directConnect": "no",

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -305,7 +305,7 @@ func TestServiceAnnotation(t *testing.T) {
 		filter.AddChild(fe)
 	}
 	s1Dcc := apicDevCtx(name, "common", graphName,
-		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn())
+		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn(), false)
 	endpoints1 := endpoints("testns", "service1",
 		[]string{"node1", "node2"}, nil, nil)
 	service1 := service("testns", "service1", "10.4.2.2")
@@ -487,7 +487,7 @@ func TestServiceGraph(t *testing.T) {
 	}
 
 	s1Dcc := apicDevCtx(name, "common", graphName,
-		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn())
+		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn(), false)
 
 	endpoints1 := endpoints("testns", "service1",
 		[]string{"node1", "node2"}, nil, nil)


### PR DESCRIPTION

+ To work-around an APIC issue (CSCvv22925), SG's consumer/provider connectors have to be associated with different PBR policies
+ Changed the SGT's adjacencyType to L3 for CSCvv23505
+ Test code is fixed to reflect different PBR policies for SNAT ServiceGraph.

Reference to first set of changes: 
https://github.com/noironetworks/aci-containers/pull/579
noironetworks/support#1213
 