### PR TITLE
Matching the pods label with snatlabel for other namespaces.

### DIFF
--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -379,6 +379,17 @@ func (agent *HostAgent) handleSnatUpdate(policy *snatpolicy.SnatPolicy) {
 	}
 }
 
+func (agent *HostAgent) updateSnatPolicyLabels(obj interface{}, policyname string) (poduids []string) {
+	uids, res := agent.getPodsMatchingObjet(obj, policyname)
+	if len(uids) > 0 {
+		key, _ := cache.MetaNamespaceKeyFunc(obj)
+		if _, ok := agent.snatPolicyLabels[key]; ok {
+			agent.snatPolicyLabels[key][policyname] = res
+		}
+	}
+	return uids
+}
+
 // Get all the pods matching the Policy Selector
 func (agent *HostAgent) getPodUidsMatchingLabel(namespace string, label map[string]string, policyname string) (poduids []string,
 	deppoduids []string, nspoduids []string) {
@@ -387,36 +398,16 @@ func (agent *HostAgent) getPodUidsMatchingLabel(namespace string, label map[stri
 		func(podobj interface{}) {
 			pod := podobj.(*v1.Pod)
 			if pod.Spec.NodeName == agent.config.NodeName {
-				key, _ := cache.MetaNamespaceKeyFunc(podobj)
-				poduids = append(poduids, string(pod.ObjectMeta.UID))
-				if _, ok := agent.snatPolicyLabels[key]; ok {
-					agent.snatPolicyLabels[key][policyname] = POD
-				}
+				poduids = append(poduids, agent.updateSnatPolicyLabels(podobj, policyname)...)
 			}
 		})
 	cache.ListAll(agent.depInformer.GetIndexer(), selector,
 		func(depobj interface{}) {
-			key, _ := cache.MetaNamespaceKeyFunc(depobj)
-			dep := depobj.(*appsv1.Deployment)
-			uids, _ := agent.getPodsMatchingObjet(dep, policyname)
-			deppoduids = append(deppoduids, uids...)
-			if len(deppoduids) > 0 {
-				if _, ok := agent.snatPolicyLabels[key]; ok {
-					agent.snatPolicyLabels[key][policyname] = DEPLOYMENT
-				}
-			}
+			deppoduids = append(deppoduids, agent.updateSnatPolicyLabels(depobj, policyname)...)
 		})
 	cache.ListAll(agent.nsInformer.GetIndexer(), selector,
 		func(nsobj interface{}) {
-			ns := nsobj.(*v1.Namespace)
-			key, _ := cache.MetaNamespaceKeyFunc(nsobj)
-			uids, _ := agent.getPodsMatchingObjet(ns, policyname)
-			nspoduids = append(nspoduids, uids...)
-			if len(nspoduids) > 0 {
-				if _, ok := agent.snatPolicyLabels[key]; ok {
-					agent.snatPolicyLabels[key][policyname] = NAMESPACE
-				}
-			}
+			nspoduids = append(nspoduids, agent.updateSnatPolicyLabels(nsobj, policyname)...)
 		})
 	return
 }
@@ -1075,7 +1066,6 @@ func (agent *HostAgent) handleObjectUpdateForSnat(obj interface{}) {
 	sync := false
 	if len(plcynames) == 0 {
 		polcies := agent.getMatchingSnatPolicy(obj)
-		agent.log.Info("HandleObject matching policies: ", polcies)
 		for name, resources := range polcies {
 			for _, res := range resources {
 				poduids, _ := agent.getPodsMatchingObjet(obj, name)
@@ -1194,7 +1184,6 @@ func (agent *HostAgent) getSnatUuids(poduuid string) []string {
 	val, check := agent.opflexSnatLocalInfos[poduuid]
 	agent.indexMutex.Unlock()
 	if check {
-		agent.log.Debug("Syncing snat Uuids: ", val.PlcyUuids)
 		return val.PlcyUuids
 
 	} else {


### PR DESCRIPTION
Problem is when we apply the Snatpolicy having label with namespace,
Policy is applied for existing pod which is matching with snatlabel belongs to other namespaces
This problem is seen for only pod resources. other resources are fine
Moved the code to common function to avoid this issue.

(cherry picked from commit e70975a242c1395bc05385c1effcfa8dbbd3d405)