### PR TITLE
Port Exhaustion issue is fixed

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -127,15 +127,14 @@ type AciController struct {
 	snatNodeInfoCache    map[string]*nodeinfo.NodeInfo
 	istioCache           map[string]*istiov1.AciIstioOperator
 	// Node Name and Policy Name
-	snatGlobalInfoCache       map[string]map[string]*snatglobalinfo.GlobalInfo
-	nodeSyncEnabled           bool
-	serviceSyncEnabled        bool
-	snatSyncEnabled           bool
-	tunnelGetter              *tunnelState
-	syncQueue                 workqueue.RateLimitingInterface
-	syncProcessors            map[string]func() bool
-	snatPortExhaustedPolicies map[string]map[string]bool
-	serviceEndPoints          ServiceEndPointType
+	snatGlobalInfoCache map[string]map[string]*snatglobalinfo.GlobalInfo
+	nodeSyncEnabled     bool
+	serviceSyncEnabled  bool
+	snatSyncEnabled     bool
+	tunnelGetter        *tunnelState
+	syncQueue           workqueue.RateLimitingInterface
+	syncProcessors      map[string]func() bool
+	serviceEndPoints    ServiceEndPointType
 }
 
 type nodeServiceMeta struct {
@@ -271,16 +270,15 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 
 		nodeOpflexDevice: make(map[string]apicapi.ApicSlice),
 
-		nodeServiceMetaCache:      make(map[string]*nodeServiceMeta),
-		nodePodNetCache:           make(map[string]*nodePodNetMeta),
-		serviceMetaCache:          make(map[string]*serviceMeta),
-		snatPolicyCache:           make(map[string]*ContSnatPolicy),
-		snatServices:              make(map[string]bool),
-		tunnelIdBase:              defTunnelIdBase,
-		snatNodeInfoCache:         make(map[string]*nodeinfo.NodeInfo),
-		snatGlobalInfoCache:       make(map[string]map[string]*snatglobalinfo.GlobalInfo),
-		istioCache:                make(map[string]*istiov1.AciIstioOperator),
-		snatPortExhaustedPolicies: make(map[string]map[string]bool),
+		nodeServiceMetaCache: make(map[string]*nodeServiceMeta),
+		nodePodNetCache:      make(map[string]*nodePodNetMeta),
+		serviceMetaCache:     make(map[string]*serviceMeta),
+		snatPolicyCache:      make(map[string]*ContSnatPolicy),
+		snatServices:         make(map[string]bool),
+		tunnelIdBase:         defTunnelIdBase,
+		snatNodeInfoCache:    make(map[string]*nodeinfo.NodeInfo),
+		snatGlobalInfoCache:  make(map[string]map[string]*snatglobalinfo.GlobalInfo),
+		istioCache:           make(map[string]*istiov1.AciIstioOperator),
 	}
 	cont.syncProcessors = map[string]func() bool{
 		"snatGlobalInfo": cont.syncSnatGlobalInfo,

--- a/pkg/controller/snats.go
+++ b/pkg/controller/snats.go
@@ -213,10 +213,14 @@ func (cont *AciController) updateSnatPolicyCache(key string, snatpolicy *snatpol
 		}
 	}
 	cont.snatPolicyCache[key] = &policy
+	var nodeInfoKeys []string
 	if Update {
-		cont.handleSnatPoilcyUpdate(snatpolicy.ObjectMeta.Name)
+		nodeInfoKeys = cont.getNodeInfoKeys(snatpolicy.ObjectMeta.Name)
 	}
 	cont.indexMutex.Unlock()
+	for _, key := range nodeInfoKeys {
+		cont.queueNodeInfoUpdateByKey(key)
+	}
 }
 
 func (cont *AciController) snatPolicyDelete(snatobj interface{}) {


### PR DESCRIPTION
Edit the SnatOperator config map and make sure that snatPorts get exhausted.
and then bring down the portrange, here snatpolicy state should change back From IpPortsExhausted to Ready state,
which is not happening.
To fix this issue snatpolicy state is recomputed  when ever snatnodeinfo or snat configmap changes, by reading the snatpolicy state from snatpoilcy Indexstore
also caching of the PortsExhausted state is removed as it is not required with new changes