### PR TITLE
Port Exhaustion issue is fixed

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -124,14 +124,13 @@ type AciController struct {
 	snatNodeInfoCache    map[string]*nodeinfo.NodeInfo
 	istioCache           map[string]*istiov1.AciIstioOperator
 	// Node Name and Policy Name
-	snatGlobalInfoCache       map[string]map[string]*snatglobalinfo.GlobalInfo
-	nodeSyncEnabled           bool
-	serviceSyncEnabled        bool
-	snatSyncEnabled           bool
-	tunnelGetter              *tunnelState
-	syncQueue                 workqueue.RateLimitingInterface
-	syncProcessors            map[string]func() bool
-	snatPortExhaustedPolicies map[string]map[string]bool
+	snatGlobalInfoCache map[string]map[string]*snatglobalinfo.GlobalInfo
+	nodeSyncEnabled     bool
+	serviceSyncEnabled  bool
+	snatSyncEnabled     bool
+	tunnelGetter        *tunnelState
+	syncQueue           workqueue.RateLimitingInterface
+	syncProcessors      map[string]func() bool
 }
 
 type nodeServiceMeta struct {
@@ -220,16 +219,15 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 
 		nodeOpflexDevice: make(map[string]apicapi.ApicSlice),
 
-		nodeServiceMetaCache:      make(map[string]*nodeServiceMeta),
-		nodePodNetCache:           make(map[string]*nodePodNetMeta),
-		serviceMetaCache:          make(map[string]*serviceMeta),
-		snatPolicyCache:           make(map[string]*ContSnatPolicy),
-		snatServices:              make(map[string]bool),
-		tunnelIdBase:              defTunnelIdBase,
-		snatNodeInfoCache:         make(map[string]*nodeinfo.NodeInfo),
-		snatGlobalInfoCache:       make(map[string]map[string]*snatglobalinfo.GlobalInfo),
-		istioCache:                make(map[string]*istiov1.AciIstioOperator),
-		snatPortExhaustedPolicies: make(map[string]map[string]bool),
+		nodeServiceMetaCache: make(map[string]*nodeServiceMeta),
+		nodePodNetCache:      make(map[string]*nodePodNetMeta),
+		serviceMetaCache:     make(map[string]*serviceMeta),
+		snatPolicyCache:      make(map[string]*ContSnatPolicy),
+		snatServices:         make(map[string]bool),
+		tunnelIdBase:         defTunnelIdBase,
+		snatNodeInfoCache:    make(map[string]*nodeinfo.NodeInfo),
+		snatGlobalInfoCache:  make(map[string]map[string]*snatglobalinfo.GlobalInfo),
+		istioCache:           make(map[string]*istiov1.AciIstioOperator),
 	}
 	cont.syncProcessors = map[string]func() bool{
 		"snatGlobalInfo": cont.syncSnatGlobalInfo,

--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -117,17 +117,21 @@ func (cont *AciController) snatCfgUpdate(obj interface{}) {
 		start < 5000 || end > 65000 || start > end || portsPerNode > end-start+1 {
 		return
 	}
-	cont.indexMutex.Lock()
 	portRange.Start = start
 	portRange.End = end
 	var currPortRange []snatglobalinfo.PortRange
 	currPortRange = append(currPortRange, portRange)
+	var nodeInfoKeys []string
+	cont.indexMutex.Lock()
 	for name, info := range cont.snatPolicyCache {
 		cont.clearSnatGlobalCache(name, "")
 		info.ExpandedSnatPorts = util.ExpandPortRanges(currPortRange, portsPerNode)
-		cont.handleSnatPoilcyUpdate(name)
+		nodeInfoKeys = cont.getNodeInfoKeys(name)
 	}
 	cont.indexMutex.Unlock()
+	for _, key := range nodeInfoKeys {
+		cont.queueNodeInfoUpdateByKey(key)
+	}
 }
 
 func (cont *AciController) snatNodeInfoAdded(obj interface{}) {
@@ -204,17 +208,31 @@ func (cont *AciController) isSnatNodeInfoPresent(nodeName string) bool {
 	cont.indexMutex.Unlock()
 	return ok
 }
+
+func (cont *AciController) checksnatPolicyPortExhausted(name string) bool {
+	snatobj, exists, err := cont.snatIndexer.GetByKey(name)
+	if err == nil && exists && snatobj != nil {
+		snatpolicy := snatobj.(*snatv1.SnatPolicy)
+		if snatpolicy.Status.State == snatv1.IpPortsExhausted {
+			return true
+		}
+	}
+	return false
+}
+
 func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool {
 	cont.log.Debug("handle Node Info: ", nodeinfo)
 	updated := false
-	allocfailed := make(map[string]bool)
 	nodename := nodeinfo.ObjectMeta.Name
+	ret := false
 	// Cache needs to be updated
 	if !cont.isSnatNodeInfoPresent(nodename) || len(nodeinfo.Spec.SnatPolicyNames) == 0 {
-		cont.deleteNodeinfoFromGlInfoCache(nodename)
+		ret = cont.deleteNodeinfoFromGlInfoCache(nodename)
 		updated = true
 	} else {
-		for name, _ := range nodeinfo.Spec.SnatPolicyNames {
+		allocfailed := make(map[string]bool)
+		markready := make(map[string]bool)
+		for name := range nodeinfo.Spec.SnatPolicyNames {
 			cont.indexMutex.Lock()
 			snatpolicy, ok := cont.snatPolicyCache[name]
 			cont.indexMutex.Unlock()
@@ -229,6 +247,10 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 					cont.log.Error("Port Range Exhausted: ", name)
 					allocfailed[name] = true
 					continue
+				} else {
+					if cont.checksnatPolicyPortExhausted(name) {
+						markready[name] = true
+					}
 				}
 				cont.updateGlobalInfoforPolicy(portrange, snatIp, nodename,
 					nodeinfo.Spec.Macaddress, name)
@@ -243,6 +265,10 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 						cont.log.Error("Port Range Exhausted: ", name)
 						allocfailed[name] = true
 						continue
+					} else {
+						if cont.checksnatPolicyPortExhausted(name) {
+							markready[name] = true
+						}
 					}
 					cont.updateGlobalInfoforPolicy(portrange, snatIp, nodename,
 						nodeinfo.Spec.Macaddress, name)
@@ -250,14 +276,14 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 				}
 			}
 		}
+		ret = cont.setSnatPoliciesState(allocfailed, snatv1.IpPortsExhausted)
+		ret = cont.setSnatPoliciesState(markready, snatv1.Ready)
 	}
+
 	if updated {
 		cont.scheduleSyncGlobalInfo()
 	}
-	if len(allocfailed) > 0 {
-		return cont.handleSnatPolicyPortAllocFailures(allocfailed, nodename)
-	}
-	return false
+	return ret
 }
 
 func (cont *AciController) syncSnatGlobalInfo() bool {
@@ -349,11 +375,11 @@ func (cont *AciController) allocateIpSnatPortRange(snatIps []string, nodename st
 	expandedsnatports []snatglobalinfo.PortRange) (string, snatglobalinfo.PortRange, bool) {
 	for _, snatip := range snatIps {
 		cont.indexMutex.Lock()
-		if _, ok := cont.snatGlobalInfoCache[snatip]; !ok {
+		globalInfo, ok := cont.snatGlobalInfoCache[snatip]
+		if !ok {
 			cont.indexMutex.Unlock()
 			return snatip, expandedsnatports[0], true
-		} else if len(cont.snatGlobalInfoCache[snatip]) < len(expandedsnatports) {
-			globalInfo, _ := cont.snatGlobalInfoCache[snatip]
+		} else if len(globalInfo) < len(expandedsnatports) {
 			if _, ok := globalInfo[nodename]; !ok {
 				seen := make(map[int]int)
 				for _, val := range globalInfo {
@@ -370,22 +396,28 @@ func (cont *AciController) allocateIpSnatPortRange(snatIps []string, nodename st
 				return globalInfo[nodename].SnatIp, globalInfo[nodename].PortRanges[0], true
 			}
 		}
+		cont.indexMutex.Unlock()
 	}
 	return "", snatglobalinfo.PortRange{}, false
 }
 
-func (cont *AciController) deleteNodeinfoFromGlInfoCache(nodename string) {
+func (cont *AciController) deleteNodeinfoFromGlInfoCache(nodename string) bool {
 	cont.indexMutex.Lock()
+	defer cont.indexMutex.Unlock()
 	for snatip, glinfos := range cont.snatGlobalInfoCache {
-		if _, ok := glinfos[nodename]; ok {
+		if v, ok := glinfos[nodename]; ok {
+			if cont.checksnatPolicyPortExhausted(v.SnatPolicyName) {
+				if cont.setSnatPolicyStaus(v.SnatPolicyName, snatv1.Ready) == true {
+					return true
+				}
+			}
 			delete(glinfos, nodename)
 			if len(glinfos) == 0 {
 				delete(cont.snatGlobalInfoCache, snatip)
 			}
 		}
 	}
-	delete(cont.snatPortExhaustedPolicies, nodename)
-	cont.indexMutex.Unlock()
+	return false
 }
 
 func (cont *AciController) getServiceIps(policy *ContSnatPolicy) (serviceIps []string) {
@@ -403,7 +435,6 @@ func (cont *AciController) updateSnatIpandPorts(oldPolicyNames map[string]struct
 	for oldkey, _ := range oldPolicyNames {
 		if _, ok := newPolicynames[oldkey]; !ok {
 			cont.clearSnatGlobalCache(oldkey, nodename)
-			//cont.setSnatPolicyStaus(oldkey, snatv1.Ready)
 		}
 	}
 }
@@ -432,8 +463,8 @@ func (cont *AciController) clearSnatGlobalCache(policyName string, nodename stri
 	}
 }
 
-func (cont *AciController) handleSnatPoilcyUpdate(policyName string) {
-	cont.log.Debug("clear Global cache: ")
+func (cont *AciController) getNodeInfoKeys(policyName string) []string {
+	var nodeinfokeys []string
 	for _, nodeinfo := range cont.snatNodeInfoCache {
 		if _, ok := nodeinfo.Spec.SnatPolicyNames[policyName]; ok {
 			nodeinfokey, err := cache.MetaNamespaceKeyFunc(nodeinfo)
@@ -441,40 +472,19 @@ func (cont *AciController) handleSnatPoilcyUpdate(policyName string) {
 				continue
 			}
 			cont.log.Debug("handleSnatPoilcyUpdate Queu the Key: ")
-			cont.queueNodeInfoUpdateByKey(nodeinfokey)
+			nodeinfokeys = append(nodeinfokeys, (nodeinfokey))
 		}
 	}
+	return nodeinfokeys
 }
 
-func (cont *AciController) handleSnatPolicyPortAllocFailures(allocfailed map[string]bool, nodename string) bool {
+func (cont *AciController) setSnatPoliciesState(names map[string]bool, status snatv1.PolicyState) bool {
 	// Any alloc failures mark the policy with Status IpPortsExhausted
-	cont.indexMutex.Lock()
-	for name, _ := range allocfailed {
-		if _, ok := cont.snatPortExhaustedPolicies[nodename]; !ok {
-			cont.snatPortExhaustedPolicies[nodename] = make(map[string]bool)
-			cont.snatPortExhaustedPolicies[nodename][name] = true
-		} else {
-			cont.snatPortExhaustedPolicies[nodename][name] = true
-		}
-		cont.log.Debug("Allocation Failed: ", allocfailed)
-		if cont.setSnatPolicyStaus(name, snatv1.IpPortsExhausted) == true {
-			cont.indexMutex.Unlock()
-			return true
+	ret := false
+	for name := range names {
+		if cont.setSnatPolicyStaus(name, status) == true {
+			ret = true
 		}
 	}
-	// if there is no allocc failure and check Policy present in snatPortExhaustedPolicie
-	// Mark the Policy Ready
-	if len(cont.snatPortExhaustedPolicies[nodename]) != 0 {
-		for name, _ := range cont.snatPortExhaustedPolicies[nodename] {
-			if _, ok := allocfailed[name]; !ok {
-				if cont.setSnatPolicyStaus(name, snatv1.Ready) == true {
-					cont.indexMutex.Unlock()
-					return true
-				}
-				delete(cont.snatPortExhaustedPolicies[nodename], name)
-			}
-		}
-	}
-	cont.indexMutex.Unlock()
-	return false
+	return ret
 }

--- a/pkg/controller/snats.go
+++ b/pkg/controller/snats.go
@@ -213,10 +213,14 @@ func (cont *AciController) updateSnatPolicyCache(key string, snatpolicy *snatpol
 		}
 	}
 	cont.snatPolicyCache[key] = &policy
+	var nodeInfoKeys []string
 	if Update {
-		cont.handleSnatPoilcyUpdate(snatpolicy.ObjectMeta.Name)
+		nodeInfoKeys = cont.getNodeInfoKeys(snatpolicy.ObjectMeta.Name)
 	}
 	cont.indexMutex.Unlock()
+	for _, key := range nodeInfoKeys {
+		cont.queueNodeInfoUpdateByKey(key)
+	}
 }
 
 func (cont *AciController) snatPolicyDelete(snatobj interface{}) {


### PR DESCRIPTION
Edit the SnatOperator config map and make sure that snatPorts get exhausted.
and then bring down the portrange, here snatpolicy state should change back From IpPortsExhausted to Ready state,
which is not happening.
To fix this issue snatpolicy state is recomputed  when ever snatnodeinfo or snat configmap changes, by reading the snatpolicy state from snatpoilcy Indexstore
also caching of the PortsExhausted state is removed as it is not required with new changes

(cherry picked from commit d9272daa76f40b4a6547cced564171771aad0d43)