### PR TITLE
Changes done to move to grpc v1.31.0

### DIFF
--- a/build-priv.sh
+++ b/build-priv.sh
@@ -86,6 +86,13 @@ docker run -w /usr/local $DOCKER_HUB_ID/opflex-build$DOCKER_TAG /bin/sh -c 'find
 	 -name '\''libsflow*so*'\'' -o \
 	 -name '\''libofproto*so*'\'' -o \
 	 -name '\''libgrpc*so*'\'' -o \
+	 -name '\''libproto*so*'\'' -o \
+	 -name '\''libre2*so*'\'' -o \
+	 -name '\''libupb*so*'\'' -o \
+	 -name '\''libabsl*so*'\'' -o \
+	 -name '\''libssl*so*'\'' -o \
+	 -name '\''libcrypto*so*'\'' -o \
+	 -name '\''libaddress_sorting*so*'\'' -o \
 	 -name '\''libgpr*so*'\'' \
            \) ! -name '\''*debug'\'' \
            | xargs tar -c ' \

--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -13,6 +13,7 @@ RUN cd /opflex/libopflex \
   && sh autogen.sh && ./configure --disable-static \
   && make $make_args && make install && make clean \
   && cd /opflex/agent-ovs \
+  && export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH \
   && ./autogen.sh && ./configure $BUILDOPTS \
   && make $make_args && make install && make clean \
   && for p in `find /usr/local/lib/ /usr/local/bin/ -type f \(\

--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -26,6 +26,13 @@ RUN cd /opflex/libopflex \
     -name 'libsflow*so*' -o \
     -name 'libprometheus-cpp-*so*' -o \
     -name 'libgrpc*so*' -o \
+    -name 'libproto*so*' -o \
+    -name 'libre2*so*' -o \
+    -name 'libupb*so*' -o \
+    -name 'libabsl*so*' -o \
+    -name 'libssl*so*' -o \
+    -name 'libcrypto*so*' -o \
+    -name 'libaddress_sorting*so*' -o \
     -name 'libgpr*so*' -o \
     -name 'libofproto*so*' \
     \)`; do \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -38,9 +38,9 @@ RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
   && cd / \
   && rm -rf 3rdparty-debian \
   && rm -rf prometheus-cpp \
-  && cmake --version \
-  && git clone --recurse-submodules -b v1.31.0 https://github.com/grpc/grpc \
+  && git clone -b v1.31.0 https://github.com/grpc/grpc --config submodule.third_party/re2.url=https://github.com/google/re2.git --config submodule.third_party/re2.active=true \
   && cd grpc \
+  && git submodule update --init \
   && wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.sh \
   && mkdir -p cmake-tmp \
   && sh cmake-linux.sh -- --skip-license --prefix=cmake-tmp \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -38,15 +38,20 @@ RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
   && cd / \
   && rm -rf 3rdparty-debian \
   && rm -rf prometheus-cpp \
-  && git clone https://github.com/grpc/grpc \
+  && cmake --version \
+  && git clone --recurse-submodules -b v1.31.0 https://github.com/grpc/grpc \
   && cd grpc \
-  && git checkout 5052efd666ab6fdda2a4b3045569f70ce0c5fa57 \
-  && git submodule update --init \
+  && wget -q -O cmake-linux.sh https://github.com/Kitware/CMake/releases/download/v3.17.0/cmake-3.17.0-Linux-x86_64.sh \
+  && mkdir -p cmake-tmp \
+  && sh cmake-linux.sh -- --skip-license --prefix=cmake-tmp \
+  && rm cmake-linux.sh \
+  && mkdir -p cmake/build \
+  && cd cmake/build \
+  && ../../cmake-tmp/bin/cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local \
+                               -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_CSHARP_EXT=OFF -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
+                               -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+                               -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF ../.. \
   && make $make_args && make install \
-  && cd third_party/protobuf \
-  && ./autogen.sh \
-  && ./configure \
-  && make $make_args && make install && make clean \
   && cd / \
   && rm -rf grpc
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -50,7 +50,8 @@ RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
   && ../../cmake-tmp/bin/cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local \
                                -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_CSHARP_EXT=OFF -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
                                -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
-                               -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF ../.. \
+                               -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
+                               -DgRPC_SSL_PROVIDER=package -DOPENSSL_ROOT_DIR=/usr/lib/ssl ../.. \
   && make $make_args && make install \
   && mv /usr/local/lib64/pkgconfig/proto* /usr/local/lib/pkgconfig/ \
   && mv /usr/local/lib64/libproto* /usr/local/lib/ \

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -52,6 +52,9 @@ RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
                                -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
                                -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF ../.. \
   && make $make_args && make install \
+  && mv /usr/local/lib64/pkgconfig/proto* /usr/local/lib/pkgconfig/ \
+  && mv /usr/local/lib64/libproto* /usr/local/lib/ \
+  && mv /usr/local/lib64/libre2* /usr/local/lib/ \
   && cd / \
   && rm -rf grpc
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'

--- a/docker/dev/alpine/Dockerfile-opflex-build
+++ b/docker/dev/alpine/Dockerfile-opflex-build
@@ -25,6 +25,13 @@ RUN for p in `find /usr/local/lib/ /usr/local/bin/ -type f \(\
     -name 'libsflow*so*' -o \
     -name 'libprometheus-cpp-*so*' -o \
     -name 'libgrpc*so*' -o \
+    -name 'libproto*so*' -o \
+    -name 'libre2*so*' -o \
+    -name 'libupb*so*' -o \
+    -name 'libabsl*so*' -o \
+    -name 'libssl*so*' -o \
+    -name 'libcrypto*so*' -o \
+    -name 'libaddress_sorting*so*' -o \
     -name 'libgpr*so*' -o \
     -name 'libofproto*so*' \
     \)`; do \

--- a/docker/dev/alpine/Dockerfile-opflex-build-base
+++ b/docker/dev/alpine/Dockerfile-opflex-build-base
@@ -1,4 +1,4 @@
-FROM alpine:3.11.5
+FROM alpine:3.12.0
 ARG ROOT=/usr/local
 #COPY ovs-musl.patch /
 COPY ovsdb-idlc.in-fix-dict-change-during-iteration.patch /
@@ -19,15 +19,15 @@ RUN git clone https://github.com/jupp0r/prometheus-cpp.git \
   && cmake .. -DBUILD_SHARED_LIBS=ON \
   && make $make_args && make install && make clean \
   && mv /usr/local/lib64/libprometheus-cpp-* /usr/local/lib/
-RUN git clone https://github.com/grpc/grpc \
+RUN git clone --recurse-submodules -b v1.31.0 https://github.com/grpc/grpc \
   && cd grpc \
-  && git checkout 5052efd666ab6fdda2a4b3045569f70ce0c5fa57 \
-  && git submodule update --init \
-  && make $make_args && make install \
-  && cd third_party/protobuf \
-  && ./autogen.sh \
-  && ./configure \
-  && make $make_args && make install && make clean
+  && mkdir -p cmake/build \
+  && cd cmake/build \
+  && cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local \
+           -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_CSHARP_EXT=OFF -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
+           -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+           -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF ../.. \
+  && make $make_args && make install
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'

--- a/docker/dev/alpine/Dockerfile-opflex-build-base
+++ b/docker/dev/alpine/Dockerfile-opflex-build-base
@@ -1,4 +1,4 @@
-FROM alpine:3.12.0
+FROM alpine:3.11.5
 ARG ROOT=/usr/local
 #COPY ovs-musl.patch /
 COPY ovsdb-idlc.in-fix-dict-change-during-iteration.patch /
@@ -19,15 +19,19 @@ RUN git clone https://github.com/jupp0r/prometheus-cpp.git \
   && cmake .. -DBUILD_SHARED_LIBS=ON \
   && make $make_args && make install && make clean \
   && mv /usr/local/lib64/libprometheus-cpp-* /usr/local/lib/
-RUN git clone --recurse-submodules -b v1.31.0 https://github.com/grpc/grpc \
+RUN git clone -b v1.31.0 https://github.com/grpc/grpc --config submodule.third_party/re2.url=https://github.com/google/re2.git --config submodule.third_party/re2.active=true \
   && cd grpc \
+  && git submodule update --init \
   && mkdir -p cmake/build \
   && cd cmake/build \
   && cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=/usr/local \
            -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_CSHARP_EXT=OFF -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
            -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
            -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=OFF -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF ../.. \
-  && make $make_args && make install
+  && make $make_args && make install \
+  && mv /usr/local/lib64/pkgconfig/proto* /usr/local/lib/pkgconfig/ \
+  && mv /usr/local/lib64/libproto* /usr/local/lib/ \
+  && mv /usr/local/lib64/libre2* /usr/local/lib/
 ENV CFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV CXXFLAGS='-fPIE -D_FORTIFY_SOURCE=2  -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security'
 ENV LDFLAGS='-pie -Wl,-z,now -Wl,-z,relro'


### PR DESCRIPTION
- turning off tests and non-cpp specific plugin code (travis cache decreased by 400m)
- Manually copying libs and pkgconfig from lib64 to lib in both UBI and alpine
- package more .so's that are needed by libgrpc v1.31.0
- re2 package uses git instead of https. Supplying git config during git clone since jenkins doesnt pick host gitconfig settings    - In UBI image: boringssl (default in grpc) leads to build failures in libopflex. Using already built openssl libs while building grpc.
- During UBI build: protoc unable to load shared libs in /usr/local/lib. Explicitly setting ld_lib_path.
- Alpine specific: sticking to cmake 3.15 in alpine 3.11.5. (alpine 3.12.0 that has cmake 3.17.2 causes issues with libboost 1.72 leading to agent/server crash).
- Both alpine and UBI images have passed opflex-cni-tests