### PR TITLE
SnatlocalInfo is not getting updated if the DestIP is changed and there is no changes to EPfile updates.

### DIFF
--- a/pkg/hostagent/snatlocalinfo.go
+++ b/pkg/hostagent/snatlocalinfo.go
@@ -41,8 +41,8 @@ func (agent *HostAgent) UpdateLocalInfoCr() bool {
 	agent.indexMutex.Lock()
 	ginfos, ok := agent.opflexSnatGlobalInfos[agent.config.NodeName]
 	if !ok {
-		return false
 		agent.indexMutex.Unlock()
+		return false
 	}
 
 	snatLocalInfo := make(map[string]SnatLocalInfo)


### PR DESCRIPTION

now localinfo update is moved from ep dependency.
unlock issue is fixed which previously not exposed becuase localinfo sync is called when there is a matching pods attached.
Calling the sync EP files if there are any pods attached to it.
removed some stale code to handle the deleting of the pod this code is left even though in previous commit moved pod  handling
code to common functioni along with othe resources.