### PR TITLE
Fixed Snallocalinfo Update and label based issue with Service

### DIFF
--- a/pkg/hostagent/snatlocalinfo.go
+++ b/pkg/hostagent/snatlocalinfo.go
@@ -41,8 +41,8 @@ func (agent *HostAgent) UpdateLocalInfoCr() bool {
 	agent.indexMutex.Lock()
 	ginfos, ok := agent.opflexSnatGlobalInfos[agent.config.NodeName]
 	if !ok {
-		return false
 		agent.indexMutex.Unlock()
+		return false
 	}
 
 	snatLocalInfo := make(map[string]SnatLocalInfo)

--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	snatglobal "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/apis/aci.snat/v1"
 	snatglobalclset "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/clientset/versioned"
-	snatlocal "github.com/noironetworks/aci-containers/pkg/snatlocalinfo/apis/aci.snat/v1"
 	snatpolicy "github.com/noironetworks/aci-containers/pkg/snatpolicy/apis/aci.snat/v1"
 	snatpolicyclset "github.com/noironetworks/aci-containers/pkg/snatpolicy/clientset/versioned"
 	"github.com/noironetworks/aci-containers/pkg/util"
@@ -151,14 +150,6 @@ func writeSnat(snatfile string, snat *OpflexSnatIp) (bool, error) {
 
 func (agent *HostAgent) FormSnatFilePath(uuid string) string {
 	return filepath.Join(agent.config.OpFlexSnatDir, uuid+".snat")
-}
-
-func SnatLocalInfoLogger(log *logrus.Logger, snat *snatlocal.SnatLocalInfo) *logrus.Entry {
-	return log.WithFields(logrus.Fields{
-		"namespace": snat.ObjectMeta.Namespace,
-		"name":      snat.ObjectMeta.Name,
-		"spec":      snat.Spec,
-	})
 }
 
 func SnatGlobalInfoLogger(log *logrus.Logger, snat *snatglobal.SnatGlobalInfo) *logrus.Entry {
@@ -347,6 +338,13 @@ func (agent *HostAgent) handleSnatUpdate(policy *snatpolicy.SnatPolicy) {
 		for _, service := range services {
 			uids, _ := agent.getPodsMatchingObjet(service, policy.ObjectMeta.Name)
 			poduids = append(poduids, uids...)
+			key, err := cache.MetaNamespaceKeyFunc(service)
+			if err == nil {
+				_, ok := agent.snatPolicyLabels[key]
+				if ok && len(policy.Spec.Selector.Labels) > 0 {
+					agent.snatPolicyLabels[key][policy.ObjectMeta.Name] = SERVICE
+				}
+			}
 		}
 		uids[SERVICE] = poduids
 	case reflect.DeepEqual(policy.Spec.Selector, snatpolicy.PodSelector{}):
@@ -500,6 +498,12 @@ func (agent *HostAgent) deletePolicy(policy *snatpolicy.SnatPolicy, sync bool) {
 	agent.log.Info("SnatPolicy deleted update Nodeinfo: ", policy.GetName())
 	if sync {
 		agent.scheduleSyncNodeInfo()
+	}
+
+	for key, v := range agent.snatPolicyLabels {
+		if _, ok := v[policy.GetName()]; ok {
+			delete(agent.snatPolicyLabels[key], policy.GetName())
+		}
 	}
 	return
 }
@@ -930,8 +934,8 @@ func (agent *HostAgent) updateEpFiles(poduids []string) {
 	}
 	if syncEp {
 		agent.scheduleSyncEps()
-		agent.scheduleSyncLocalInfo()
 	}
+	agent.scheduleSyncLocalInfo()
 }
 
 func (agent *HostAgent) compare(plcy1, plcy2 string) bool {
@@ -1076,7 +1080,9 @@ func (agent *HostAgent) handleObjectUpdateForSnat(obj interface{}) {
 					agent.applyPolicy(poduids, res, name)
 					agent.snatPolicyLabels[objKey][name] = res
 				}
-				sync = true
+				if len(poduids) > 0 {
+					sync = true
+				}
 			}
 		}
 
@@ -1094,11 +1100,11 @@ func (agent *HostAgent) handleObjectUpdateForSnat(obj interface{}) {
 				delpodlist = append(delpodlist, poduids...)
 				delete(agent.snatPolicyLabels[objKey], name)
 			}
-			sync = true
 			seen[name] = true
 		}
 		if len(delpodlist) > 0 {
 			agent.updateEpFiles(delpodlist)
+			sync = true
 		}
 		for name, resources := range matchnames {
 			if seen[name] == true {
@@ -1157,7 +1163,6 @@ func (agent *HostAgent) handleObjectDeleteForSnat(obj interface{}) {
 			sync = true
 		}
 	}
-
 	if sync {
 		agent.scheduleSyncNodeInfo()
 		if getResourceType(obj) == SERVICE {


### PR DESCRIPTION
SnatlocalInfo is not getting updated if the DestIP is changed and there is no changes to EPfile updates.
Now localinfo update is moved from ep dependency.
removed some stale code to handle the deleting of the pod resource
Fixed issue with  label based policy on service resource
This issue is a corner case where snatpolicy is added on existing service and then modify the label on service
this causes Stale uids are present in the snatfile.
Added lable based UT for Service.