### PR TITLE
Fixed Snallocalinfo Update and label based issue with Service

### DIFF
--- a/pkg/hostagent/snatlocalinfo.go
+++ b/pkg/hostagent/snatlocalinfo.go
@@ -40,8 +40,8 @@ func (agent *HostAgent) UpdateLocalInfoCr() bool {
 	agent.indexMutex.Lock()
 	ginfos, ok := agent.opflexSnatGlobalInfos[agent.config.NodeName]
 	if !ok {
-		return false
 		agent.indexMutex.Unlock()
+		return false
 	}
 
 	snatLocalInfo := make(map[string]SnatLocalInfo)


### PR DESCRIPTION
SnatlocalInfo is not getting updated if the DestIP is changed and there is no changes to EPfile updates.
Now localinfo update is moved from ep dependency.
Fixed issue with  label based policy on service resource
This issue is a corner case where snatpolicy is added on existing service and then modify the label on service
this causes Stale uids are present in the snatfile.
Added lable based UT for Service.

(cherry picked from commit a59e11bd90246c3f4c782ae90b554f114ef03bb1)