### PR TITLE
Using filter-chain for SNAT PBR contract based on ACI version

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -86,14 +86,15 @@ type ApicConnection struct {
 	user      string
 	password  string
 	prefix    string
-	version   float64 // APIC version
+	version   string // APIC version
 
-	CachedVersion       float64
+	CachedVersion       string
 	ReconnectInterval   time.Duration
 	RefreshInterval     time.Duration
 	RefreshTickerAdjust time.Duration
 	RetryInterval       time.Duration
 	UseAPICInstTag      bool // use old-style APIC tags rather than annotations
+	SnatPbrFltrChain    bool // Configure SNAT PBR to use filter-chain
 	FullSyncHook        func()
 
 	dialer        *websocket.Dialer
@@ -504,7 +505,7 @@ func NewTagAnnotation(parentDn string, key string) ApicObject {
 	dn := ""
 	ret := newApicObject("tagAnnotation")
 	ret["tagAnnotation"].Attributes["key"] = key
-	if ApicVersion >= 4.1 {
+	if ApicVersion >= "4.1" {
 		dn = fmt.Sprintf("%s/annotationKey-[%s]", parentDn, key)
 	} else {
 		dn = fmt.Sprintf("%s/annotationKey-%s", parentDn, key)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -480,14 +480,22 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		cont.apicConn.CachedVersion = version
 		apicapi.ApicVersion = version
 		// APIC version 3.2 introduced tagAnnotation support for better scalability.
-		if version >= 3.2 {
+		if version >= "3.2" {
 			cont.apicConn.UseAPICInstTag = false
 		} else {
 			cont.apicConn.UseAPICInstTag = true
 		}
+		if version >= "4.2(4i)" {
+			cont.apicConn.SnatPbrFltrChain = true
+		} else {
+			cont.apicConn.SnatPbrFltrChain = false
+		}
+	} else { // For unit-tests
+		cont.apicConn.SnatPbrFltrChain = true
 	}
 
 	cont.log.Debug("UseAPICInstTag set to:", cont.apicConn.UseAPICInstTag)
+	cont.log.Debug("SnatPbrFltrChain set to:", cont.apicConn.SnatPbrFltrChain)
 
 	// Make sure Pod/NodeBDs and AciL3Out are assoicated to same VRF.
 	if len(cont.config.ApicHosts) != 0 && cont.config.AciPodBdDn != "" && cont.config.AciNodeBdDn != "" {

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -292,7 +292,7 @@ func (cont *AciController) writeApicNode(node *v1.Node) {
 	aobj.SetAttr("mgmtIp", getNodeIP(node, v1.NodeInternalIP))
 	aobj.SetAttr("os", node.Status.NodeInfo.OSImage)
 	aobj.SetAttr("kernelVer", node.Status.NodeInfo.KernelVersion)
-	if apicapi.ApicVersion >= 5.0 {
+	if apicapi.ApicVersion >= "5.0" {
 		aobj.SetAttr("id", fmt.Sprintf("%v", tunnelID))
 	}
 	cont.apicConn.WriteApicObjects(key, apicapi.ApicSlice{aobj})


### PR DESCRIPTION
+ To keep up with ACI CNI backward compatibility, filter-chain config for SNAT SG is triggered only for APIC versions 4.2(4i) and above.