### PR TITLE
Using filter-chain for SNAT PBR contract

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -86,14 +86,15 @@ type ApicConnection struct {
 	user      string
 	password  string
 	prefix    string
-	version   float64 // APIC version
+	version   string // APIC version
 
-	CachedVersion       float64
+	CachedVersion       string
 	ReconnectInterval   time.Duration
 	RefreshInterval     time.Duration
 	RefreshTickerAdjust time.Duration
 	RetryInterval       time.Duration
 	UseAPICInstTag      bool // use old-style APIC tags rather than annotations
+	SnatPbrFltrChain    bool // Configure SNAT PBR to use filter-chain
 	FullSyncHook        func()
 
 	dialer        *websocket.Dialer
@@ -504,7 +505,7 @@ func NewTagAnnotation(parentDn string, key string) ApicObject {
 	dn := ""
 	ret := newApicObject("tagAnnotation")
 	ret["tagAnnotation"].Attributes["key"] = key
-	if ApicVersion >= 4.1 {
+	if ApicVersion >= "4.1" {
 		dn = fmt.Sprintf("%s/annotationKey-[%s]", parentDn, key)
 	} else {
 		dn = fmt.Sprintf("%s/annotationKey-%s", parentDn, key)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -416,14 +416,22 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		cont.apicConn.CachedVersion = version
 		apicapi.ApicVersion = version
 		// APIC version 3.2 introduced tagAnnotation support for better scalability.
-		if version >= 3.2 {
+		if version >= "3.2" {
 			cont.apicConn.UseAPICInstTag = false
 		} else {
 			cont.apicConn.UseAPICInstTag = true
 		}
+		if version >= "4.2(4i)" {
+			cont.apicConn.SnatPbrFltrChain = true
+		} else {
+			cont.apicConn.SnatPbrFltrChain = false
+		}
+	} else { // For unit-tests
+		cont.apicConn.SnatPbrFltrChain = true
 	}
 
 	cont.log.Debug("UseAPICInstTag set to:", cont.apicConn.UseAPICInstTag)
+	cont.log.Debug("SnatPbrFltrChain set to:", cont.apicConn.SnatPbrFltrChain)
 
 	// Make sure Pod/NodeBDs and AciL3Out are assoicated to same VRF.
 	if len(cont.config.ApicHosts) != 0 && cont.config.AciPodBdDn != "" && cont.config.AciNodeBdDn != "" {

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -285,7 +285,7 @@ func (cont *AciController) writeApicNode(node *v1.Node) {
 	aobj.SetAttr("mgmtIp", getNodeIP(node, v1.NodeInternalIP))
 	aobj.SetAttr("os", node.Status.NodeInfo.OSImage)
 	aobj.SetAttr("kernelVer", node.Status.NodeInfo.KernelVersion)
-    if apicapi.ApicVersion >= 5.0 {
+	if apicapi.ApicVersion >= "5.0" {
 		aobj.SetAttr("id", fmt.Sprintf("%v", tunnelID))
 	}
 	cont.apicConn.WriteApicObjects(key, apicapi.ApicSlice{aobj})

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -392,14 +392,14 @@ func validScope(scope string) bool {
 }
 
 func apicContract(conName string, tenantName string,
-	graphName string, scopeName string, isSnat bool) apicapi.ApicObject {
+	graphName string, scopeName string, isSnatPbrFltrChain bool) apicapi.ApicObject {
 	con := apicapi.NewVzBrCP(tenantName, conName)
 	if scopeName != "" && scopeName != "context" {
 		con.SetAttr("scope", scopeName)
 	}
 	cs := apicapi.NewVzSubj(con.GetDn(), "loadbalancedservice")
 	csDn := cs.GetDn()
-	if isSnat {
+	if isSnatPbrFltrChain {
 		cs.SetAttr("revFltPorts", "no")
 		inTerm := apicapi.NewVzInTerm(csDn)
 		outTerm := apicapi.NewVzOutTerm(csDn)
@@ -418,7 +418,7 @@ func apicContract(conName string, tenantName string,
 }
 
 func apicDevCtx(name string, tenantName string,
-	graphName string, bdName string, rpDn string, isSnat bool) apicapi.ApicObject {
+	graphName string, bdName string, rpDn string, isSnatPbrFltrChain bool) apicapi.ApicObject {
 
 	cc := apicapi.NewVnsLDevCtx(tenantName, name, graphName, "loadbalancer")
 	ccDn := cc.GetDn()
@@ -429,7 +429,7 @@ func apicDevCtx(name string, tenantName string,
 	rpDnBase := rpDn
 	for _, ctxConn := range []string{"consumer", "provider"} {
 		lifCtx := apicapi.NewVnsLIfCtx(ccDn, ctxConn)
-		if isSnat {
+		if isSnatPbrFltrChain {
 			if ctxConn == "consumer" {
 				rpDn = rpDnBase + "_Cons"
 			} else {
@@ -437,8 +437,7 @@ func apicDevCtx(name string, tenantName string,
 			}
 		}
 		lifCtxDn := lifCtx.GetDn()
-		lifCtx.AddChild(apicapi.NewVnsRsLIfCtxToSvcRedirectPol(lifCtxDn,
-			rpDn))
+		lifCtx.AddChild(apicapi.NewVnsRsLIfCtxToSvcRedirectPol(lifCtxDn, rpDn))
 		lifCtx.AddChild(apicapi.NewVnsRsLIfCtxToBD(lifCtxDn, bdDn))
 		lifCtx.AddChild(apicapi.NewVnsRsLIfCtxToLIf(lifCtxDn, lifDn))
 		cc.AddChild(lifCtx)
@@ -692,18 +691,26 @@ func (cont *AciController) updateServiceDeviceInstanceSnat(key string) error {
 		// The service redirect policy contains the MAC address
 		// and IP address of each of the service endpoints for
 		// each node that hosts a pod for this service.
-		// For SNAT with introuction of filter-chain usage, to work-around
+		// For SNAT with the introduction of filter-chain usage, to work-around
 		// an APIC limitation, creating two PBR policies with same nodes.
-		rpCons, rpDnCons :=
-			apicRedirectPol(name+"_Cons", cont.config.AciVrfTenant, nodes,
-				nodeMap, cont.staticMonPolDn(), true)
-		serviceObjs = append(serviceObjs, rpCons)
-		rpProv, _ :=
-			apicRedirectPol(name+"_Prov", cont.config.AciVrfTenant, nodes,
-				nodeMap, cont.staticMonPolDn(), true)
-		serviceObjs = append(serviceObjs, rpProv)
-		rpDn := strings.TrimSuffix(rpDnCons, "_Cons")
-
+		var rpDn string
+		var rp apicapi.ApicObject
+		if cont.apicConn.SnatPbrFltrChain {
+			rpCons, rpDnCons :=
+				apicRedirectPol(name+"_Cons", cont.config.AciVrfTenant, nodes,
+					nodeMap, cont.staticMonPolDn(), true)
+			serviceObjs = append(serviceObjs, rpCons)
+			rpProv, _ :=
+				apicRedirectPol(name+"_Prov", cont.config.AciVrfTenant, nodes,
+					nodeMap, cont.staticMonPolDn(), true)
+			serviceObjs = append(serviceObjs, rpProv)
+			rpDn = strings.TrimSuffix(rpDnCons, "_Cons")
+		} else {
+			rp, rpDn =
+				apicRedirectPol(name, cont.config.AciVrfTenant, nodes,
+					nodeMap, cont.staticMonPolDn(), true)
+			serviceObjs = append(serviceObjs, rp)
+		}
 		// 2. Service graph contract and external network
 		// The service graph contract must be bound to the
 		// service
@@ -720,7 +727,7 @@ func (cont *AciController) updateServiceDeviceInstanceSnat(key string) error {
 					cont.config.AciL3Out, ingresses, sharedSecurity, true))
 		}
 
-		contract := apicContract(name, cont.config.AciVrfTenant, graphName, conScope, true)
+		contract := apicContract(name, cont.config.AciVrfTenant, graphName, conScope, cont.apicConn.SnatPbrFltrChain)
 		serviceObjs = append(serviceObjs, contract)
 
 		for _, net := range cont.config.AciExtNetworks {
@@ -732,18 +739,22 @@ func (cont *AciController) updateServiceDeviceInstanceSnat(key string) error {
 		defaultPortRange := portRangeSnat{start: cont.config.SnatDefaultPortRangeStart,
 			end: cont.config.SnatDefaultPortRangeEnd}
 		portSpec := []portRangeSnat{defaultPortRange}
-		filterIn := apicFilterSnat(name+"_fromCons-toProv", cont.config.AciVrfTenant, portSpec, false)
-		serviceObjs = append(serviceObjs, filterIn)
-		filterOut := apicFilterSnat(name+"_fromProv-toCons", cont.config.AciVrfTenant, portSpec, true)
-		serviceObjs = append(serviceObjs, filterOut)
-
+		if cont.apicConn.SnatPbrFltrChain {
+			filterIn := apicFilterSnat(name+"_fromCons-toProv", cont.config.AciVrfTenant, portSpec, false)
+			serviceObjs = append(serviceObjs, filterIn)
+			filterOut := apicFilterSnat(name+"_fromProv-toCons", cont.config.AciVrfTenant, portSpec, true)
+			serviceObjs = append(serviceObjs, filterOut)
+		} else {
+			filter := apicFilterSnat(name, cont.config.AciVrfTenant, portSpec, false)
+			serviceObjs = append(serviceObjs, filter)
+		}
 		// 3. Device cluster context
 		// The logical device context binds the service contract
 		// to the redirect policy and the device cluster and
 		// bridge domain for the device cluster.
 		serviceObjs = append(serviceObjs,
 			apicDevCtx(name, cont.config.AciVrfTenant, graphName,
-				cont.aciNameForKey("bd", cont.env.ServiceBd()), rpDn, true))
+				cont.aciNameForKey("bd", cont.env.ServiceBd()), rpDn, cont.apicConn.SnatPbrFltrChain))
 	}
 	cont.apicConn.WriteApicObjects(name, serviceObjs)
 	return nil


### PR DESCRIPTION
+ To keep up with ACI CNI backward compatibility, filter-chain config for SNAT SG is triggered only for APIC versions 4.2(4i) and above.

(cherry picked from commit 03e0d669d004120d87f959dbec4a1e5b9df317d8)