### PR TITLE
Check added for snat Port-range boundry condition.

### DIFF
--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -373,6 +373,9 @@ func (cont *AciController) getIpAndPortRange(nodename string, snatpolicy *ContSn
 
 func (cont *AciController) allocateIpSnatPortRange(snatIps []string, nodename string,
 	expandedsnatports []snatglobalinfo.PortRange) (string, snatglobalinfo.PortRange, bool) {
+	if len(expandedsnatports) < 1 {
+		return "", snatglobalinfo.PortRange{}, false
+	}
 	for _, snatip := range snatIps {
 		cont.indexMutex.Lock()
 		globalInfo, ok := cont.snatGlobalInfoCache[snatip]

--- a/pkg/controller/snatglobalinfo_test.go
+++ b/pkg/controller/snatglobalinfo_test.go
@@ -247,5 +247,15 @@ func TestSnatCfgChangeTest(t *testing.T) {
 		"node-1": snatglobalinfo.GlobalInfo{SnatIp: "10.1.1.9", PortRanges: []snatglobalinfo.PortRange{{Start: 10000, End: 14999}}},
 	}
 	snatWait(t, "snat test", expected, cont.AciController.snatGlobalInfoCache["10.1.1.9"])
+	modconfigmap = &v1.ConfigMap{
+		Data: map[string]string{"start": "5000", "end": "65000", "ports-per-node": "60000"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "snat-operator-config",
+			Namespace: "aci-containers-system",
+		},
+	}
+	cont.fakeSnatCfgSource.Modify(modconfigmap)
+	expected = map[string]snatglobalinfo.GlobalInfo{}
+	snatWait(t, "snat test", expected, cont.AciController.snatGlobalInfoCache["10.1.1.9"])
 	cont.stop()
 }

--- a/pkg/hostagent/snatlocalinfo.go
+++ b/pkg/hostagent/snatlocalinfo.go
@@ -82,7 +82,9 @@ func (agent *HostAgent) UpdateLocalInfoCr() bool {
 		}
 		localinfo.PodUid = uid
 		localinfo.SnatPolicies = policies
-		localInfos = append(localInfos, localinfo)
+		if len(policies) > 0 {
+			localInfos = append(localInfos, localinfo)
+		}
 	}
 	agent.indexMutex.Unlock()
 	snatLocalInfoCr, err := snatLocalInfoClient.AciV1().SnatLocalInfos(agent.config.AciSnatNamespace).Get(agent.config.NodeName, metav1.GetOptions{})

--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -250,7 +250,7 @@ func (agent *HostAgent) snatPolicyUpdated(oldobj interface{}, newobj interface{}
 			}
 		}
 		if !ok || !present {
-			agent.deletePolicy(newpolicyinfo, false)
+			agent.deletePolicy(newpolicyinfo)
 		}
 		return
 	}
@@ -309,7 +309,7 @@ func (agent *HostAgent) snatPolicyDeleted(obj interface{}) {
 	agent.indexMutex.Lock()
 	defer agent.indexMutex.Unlock()
 	policyinfo := obj.(*snatpolicy.SnatPolicy)
-	agent.deletePolicy(policyinfo, true)
+	agent.deletePolicy(policyinfo)
 	delete(agent.snatPolicyCache, policyinfo.ObjectMeta.Name)
 }
 
@@ -482,7 +482,7 @@ func (agent *HostAgent) syncSnatNodeInfo() bool {
 	return false
 }
 
-func (agent *HostAgent) deletePolicy(policy *snatpolicy.SnatPolicy, sync bool) {
+func (agent *HostAgent) deletePolicy(policy *snatpolicy.SnatPolicy) {
 	pods, ok := agent.snatPods[policy.GetName()]
 	var poduids []string
 	if !ok {
@@ -495,10 +495,7 @@ func (agent *HostAgent) deletePolicy(policy *snatpolicy.SnatPolicy, sync bool) {
 	agent.updateEpFiles(poduids)
 	delete(agent.snatPods, policy.GetName())
 	agent.log.Info("SnatPolicy deleted update Nodeinfo: ", policy.GetName())
-	if sync {
-		agent.scheduleSyncNodeInfo()
-	}
-
+	agent.scheduleSyncNodeInfo()
 	for key, v := range agent.snatPolicyLabels {
 		if _, ok := v[policy.GetName()]; ok {
 			delete(agent.snatPolicyLabels[key], policy.GetName())


### PR DESCRIPTION
In case of boundry condition hit expandedport range length is zero. so because of various events.
if we process the nodeinfo it causes crash. so added the lenght check
As previous commit removed the caching of port-exhaustion state in controller.
now every time hostgent sees the change in snatnode info because of snatpolicy state(IpPortExhasted)it has to push the updates.
UT is added just to cover the boundry checks.

(cherry picked from commit 23039831dc4524983272dd994276f92760e36a55)