### PR TITLE
Added Support for Namedport based networkpolicy

### DIFF
--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -257,6 +257,16 @@ func podLabel(namespace string, name string, labels map[string]string) *v1.Pod {
 	return &v1.Pod{
 		Spec: v1.PodSpec{
 			NodeName: "test-node",
+			Containers: []v1.Container{
+				{
+					Ports: []v1.ContainerPort{
+						{
+							Name:          "serve-80",
+							ContainerPort: int32(80),
+						},
+					},
+				},
+			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1244,7 +1244,7 @@ func getServiceTargetPorts(service *v1.Service) map[string]targetPort {
 		key := portProto(&port.Protocol) + "-num-" + strconv.Itoa(int(portNum))
 		ports[key] = targetPort{
 			proto: port.Protocol,
-			port:  portNum,
+			ports: []int{portNum},
 		}
 	}
 	return ports


### PR DESCRIPTION
Namedport is instead of numeric port, it gives another layer of indirection and maps to diffrent numeric ports for an endpoint.
example multiple http servers can expose target ports as 80 or 8080.
now in that case all egress direction  services matching the network policy needs to match all the ports matching the name.
Added UT's to cover the above cases. And verifed all the upstream testcases