### PR TITLE
Fixed the crash seen while writing the service file

### DIFF
--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/noironetworks/aci-containers/pkg/util"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -238,7 +239,12 @@ func (agent *HostAgent) syncServices() bool {
 	agent.indexMutex.Lock()
 	opflexServices := make(map[string]*opflexService)
 	for k, v := range agent.opflexServices {
-		opflexServices[k] = v
+		val := &opflexService{}
+		err := util.DeepCopyObj(v, val)
+		if err != nil {
+			continue
+		}
+		opflexServices[k] = val
 	}
 	agent.indexMutex.Unlock()
 
@@ -264,7 +270,6 @@ func (agent *HostAgent) syncServices() bool {
 		logger := agent.log.WithFields(
 			logrus.Fields{"Uuid": uuid},
 		)
-
 		existing, ok := opflexServices[uuid]
 		if ok {
 			wrote, err := writeAs(asfile, existing)
@@ -447,7 +452,6 @@ func (agent *HostAgent) serviceChanged(obj interface{}) {
 			Error("Could not create key:" + err.Error())
 		return
 	}
-	agent.log.Info("Service Changed#####: ", key)
 	agent.doUpdateService(key)
 	agent.handleObjectUpdateForSnat(obj)
 }

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+)
+
+func DeepCopyObj(src, dst interface{}) error {
+	bytes, err := json.MarshalIndent(src, "", "")
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(bytes, dst)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This is a Data race issue becuase of  concurrent map iteration and map write.
Reason for this issue is Opflex pointer is not deep copied.
And the same pointer is beeing used while writing the file.
it is observed in services and ep sync functions.