### PR TITLE
Fixed the crash seen while writing the service file

### DIFF
--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/noironetworks/aci-containers/pkg/metadata"
+	"github.com/noironetworks/aci-containers/pkg/util"
 	gouuid "github.com/nu7hatch/gouuid"
 )
 
@@ -276,7 +277,16 @@ func (agent *HostAgent) syncEps() bool {
 	agent.indexMutex.Lock()
 	opflexEps := make(map[string][]*opflexEndpoint)
 	for k, v := range agent.opflexEps {
-		opflexEps[k] = v
+		ep := []*opflexEndpoint{}
+		for _, op := range v {
+			val := &opflexEndpoint{}
+			err := util.DeepCopyObj(op, val)
+			if err != nil {
+				continue
+			}
+			ep = append(ep, val)
+		}
+		opflexEps[k] = ep
 	}
 	agent.indexMutex.Unlock()
 
@@ -619,7 +629,7 @@ func (agent *HostAgent) updateGbpServerInfo(pod *v1.Pod) {
 	if pod.ObjectMeta.Labels == nil {
 		return
 	}
-
+	agent.indexMutex.Lock()
 	nameVal := pod.ObjectMeta.Labels["name"]
 	if nameVal == "aci-containers-controller" {
 		if agent.gbpServerIP != pod.Status.PodIP {
@@ -628,4 +638,5 @@ func (agent *HostAgent) updateGbpServerInfo(pod *v1.Pod) {
 			agent.scheduleSyncOpflexServer()
 		}
 	}
+	agent.indexMutex.Unlock()
 }

--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/noironetworks/aci-containers/pkg/util"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
@@ -203,7 +204,12 @@ func (agent *HostAgent) syncServices() bool {
 	agent.indexMutex.Lock()
 	opflexServices := make(map[string]*opflexService)
 	for k, v := range agent.opflexServices {
-		opflexServices[k] = v
+		val := &opflexService{}
+		err := util.DeepCopyObj(v, val)
+		if err != nil {
+			continue
+		}
+		opflexServices[k] = val
 	}
 	agent.indexMutex.Unlock()
 
@@ -229,7 +235,6 @@ func (agent *HostAgent) syncServices() bool {
 		logger := agent.log.WithFields(
 			logrus.Fields{"Uuid": uuid},
 		)
-
 		existing, ok := opflexServices[uuid]
 		if ok {
 			wrote, err := writeAs(asfile, existing)

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+)
+
+func DeepCopyObj(src, dst interface{}) error {
+	bytes, err := json.MarshalIndent(src, "", "")
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(bytes, dst)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This is a Data race issue becuase of  concurrent map iteration and map write.
Reason for this issue is Opflex pointer is not deep copied.
And the same pointer is beeing used while writing the file.
it is observed in services and ep sync functions.

(cherry picked from commit 05c23840990a3617025fa470eee3fc7d71e08df8)