### PR TITLE
Fixed the crash seen while writing the service file

### DIFF
--- a/pkg/hostagent/integ_test.go
+++ b/pkg/hostagent/integ_test.go
@@ -633,7 +633,7 @@ func TestNPGroupAssign(t *testing.T) {
 	it.checkEpGroups(0, "defaultEPG", emptyJSON)
 	it.checkEpGroups(1, "test-prof|ann-ns-eg", sgAnnotNP1)
 	it.checkEpGroups(2, "test-prof|ann-ns-eg", sgAnnotNP2)
-
+	time.Sleep(10 * time.Millisecond)
 	it.cniDelParallel(1, 3)
 	it.testNS = testPodNS
 	it.cniDelParallel(0, 1)

--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 
 	"github.com/noironetworks/aci-containers/pkg/metadata"
+	"github.com/noironetworks/aci-containers/pkg/util"
 	gouuid "github.com/nu7hatch/gouuid"
 )
 
@@ -150,7 +151,16 @@ func (agent *HostAgent) syncEps() bool {
 	agent.indexMutex.Lock()
 	opflexEps := make(map[string][]*opflexEndpoint)
 	for k, v := range agent.opflexEps {
-		opflexEps[k] = v
+		ep := []*opflexEndpoint{}
+		for _, op := range v {
+			val := &opflexEndpoint{}
+			err := util.DeepCopyObj(op, val)
+			if err != nil {
+				continue
+			}
+			ep = append(ep, val)
+		}
+		opflexEps[k] = ep
 	}
 	agent.indexMutex.Unlock()
 

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"encoding/json"
+)
+
+func DeepCopyObj(src, dst interface{}) error {
+	bytes, err := json.MarshalIndent(src, "", "")
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(bytes, dst)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
This is a Data race issue becuase of  concurrent map iteration and map write.
Reason for this issue is Opflex pointer is not deep copied.
And the same pointer is beeing used while writing the file.
it is observed in services and ep sync functions.

(cherry picked from commit 05c23840990a3617025fa470eee3fc7d71e08df8)