### PR TITLE
SnatPortExhaustion state is not changed after adding new SnatIp's

### DIFF
--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -122,15 +122,15 @@ func (cont *AciController) snatCfgUpdate(obj interface{}) {
 	portRange.End = end
 	var currPortRange []snatglobalinfo.PortRange
 	currPortRange = append(currPortRange, portRange)
-	var nodeInfoKeys []string
 	cont.indexMutex.Lock()
+	nodeInfoKeys := make(map[string]bool)
 	for name, info := range cont.snatPolicyCache {
 		cont.clearSnatGlobalCache(name, "")
 		info.ExpandedSnatPorts = util.ExpandPortRanges(currPortRange, portsPerNode)
-		nodeInfoKeys = cont.getNodeInfoKeys(name)
+		cont.getNodeInfoKeys(name, nodeInfoKeys)
 	}
 	cont.indexMutex.Unlock()
-	for _, key := range nodeInfoKeys {
+	for key := range nodeInfoKeys {
 		cont.queueNodeInfoUpdateByKey(key)
 	}
 }
@@ -467,19 +467,16 @@ func (cont *AciController) clearSnatGlobalCache(policyName string, nodename stri
 	}
 }
 
-func (cont *AciController) getNodeInfoKeys(policyName string) []string {
-	var nodeinfokeys []string
+func (cont *AciController) getNodeInfoKeys(policyName string, nodeinfokeys map[string]bool) {
 	for _, nodeinfo := range cont.snatNodeInfoCache {
 		if _, ok := nodeinfo.Spec.SnatPolicyNames[policyName]; ok {
 			nodeinfokey, err := cache.MetaNamespaceKeyFunc(nodeinfo)
 			if err != nil {
 				continue
 			}
-			cont.log.Debug("handleSnatPoilcyUpdate Queu the Key: ")
-			nodeinfokeys = append(nodeinfokeys, (nodeinfokey))
+			nodeinfokeys[nodeinfokey] = true
 		}
 	}
-	return nodeinfokeys
 }
 
 func (cont *AciController) setSnatPoliciesState(names map[string]bool, status snatv1.PolicyState) bool {

--- a/pkg/util/snat.go
+++ b/pkg/util/snat.go
@@ -47,7 +47,7 @@ func ExpandPortRanges(currPortRange []snatglobal.PortRange, step int) []snatglob
 	for _, item := range currPortRange {
 		temp := item.Start
 		for temp < item.End-1 {
-			if temp+step-1 < item.End-1 {
+			if temp+step-1 <= item.End-1 {
 				expandedPortRange = append(expandedPortRange, snatglobal.PortRange{Start: temp, End: temp + step - 1})
 			}
 			temp = temp + step


### PR DESCRIPTION
Fixed Snat Portrange allocation for boundary range 65000
and also Nodeinfo reconcile has an issue when the configmap changes,
if we have more than 2 snat policies. nodeinfo list is been
over written by second snatpolicy.