### PR TITLE
SnatPortExhaustion state is not changed after adding new SnatIp's

### DIFF
--- a/pkg/util/snat.go
+++ b/pkg/util/snat.go
@@ -46,7 +46,7 @@ func ExpandPortRanges(currPortRange []snatglobal.PortRange, step int) []snatglob
 	for _, item := range currPortRange {
 		temp := item.Start
 		for temp < item.End-1 {
-			if temp+step-1 < item.End-1 {
+			if temp+step-1 <= item.End-1 {
 				expandedPortRange = append(expandedPortRange, snatglobal.PortRange{Start: temp, End: temp + step - 1})
 			}
 			temp = temp + step


### PR DESCRIPTION
Fixed Snat Portrange allocation for boundary range 65000
and also Nodeinfo reconcile has an issue when the configmap changes,
if we have more than 2 snat policies. nodeinfo list is been
over written by second snatpolicy.

(cherry picked from commit 4660674956fd59b696704857b816bdc2d81104a4)