### PR TITLE
Adding the -trim-path to build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ DIST_FILE=aci-containers.tgz
 
 DOCKER_HUB_ID ?= noiro
 DOCKER_TAG ?=
-BUILD_CMD ?= go build -v
+BUILD_CMD ?= go build -v -trimpath
 TEST_CMD ?= go test -cover
 TEST_ARGS ?=
 INSTALL_CMD ?= go install -v


### PR DESCRIPTION
Currently in the stack trace for the panic we see the entire source path
to remove the complete path we are using the flag -trim-path