### PR TITLE
Scale down of Node leaving the Stale Snat nodeInfoCR  entry

### DIFF
--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -39,6 +39,7 @@ import (
 	"github.com/noironetworks/aci-containers/pkg/gbpserver/watchers"
 	"github.com/noironetworks/aci-containers/pkg/ipam"
 	"github.com/noironetworks/aci-containers/pkg/metadata"
+	"github.com/noironetworks/aci-containers/pkg/util"
 )
 
 const (
@@ -454,12 +455,18 @@ func (cont *AciController) nodeDeleted(obj interface{}) {
 	cont.snatFullSync()
 	if _, ok := cont.snatNodeInfoCache[node.ObjectMeta.Name]; ok {
 		nodeinfo := cont.snatNodeInfoCache[node.ObjectMeta.Name]
-		nodeinfokey, err := cache.MetaNamespaceKeyFunc(nodeinfo)
-		if err != nil {
-			return
-		}
 		delete(cont.snatNodeInfoCache, node.ObjectMeta.Name)
+		nodeinfokey, _ := cache.MetaNamespaceKeyFunc(nodeinfo)
 		cont.queueNodeInfoUpdateByKey(nodeinfokey)
+	}
+	env := cont.env.(*K8sEnvironment)
+	nodeinfocl := env.nodeInfoClient
+	//TODO Add reconcile here on failure
+	if nodeinfocl != nil {
+		err := util.DeleteNodeInfoCR(*nodeinfocl, node.ObjectMeta.Name)
+		if err != nil {
+			cont.log.Error("Could not delete the NodeInfo", node.ObjectMeta.Name)
+		}
 	}
 }
 

--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -231,6 +231,12 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 		ret = cont.deleteNodeinfoFromGlInfoCache(nodename)
 		updated = true
 	} else {
+		// This case ignores any stale entry is present in nodeinfo
+		_, _, err := cont.nodeIndexer.GetByKey(nodename)
+		if err != nil {
+			cont.log.Info("Could not lookup node: ", err, "nodeName: ", nodename)
+			return false
+		}
 		allocfailed := make(map[string]bool)
 		markready := make(map[string]bool)
 		for name := range nodeinfo.Spec.SnatPolicyNames {

--- a/pkg/util/snat.go
+++ b/pkg/util/snat.go
@@ -124,6 +124,17 @@ func UpdateNodeInfoCR(c nodeinfoclset.Clientset, nodeinfo nodeinfo.NodeInfo) err
 	}
 	return nil
 }
+
+// UpdateNodeInfoCR Updates a UpdateNodeInfoInfo CR
+func DeleteNodeInfoCR(c nodeinfoclset.Clientset, name string) error {
+	ns := os.Getenv("ACI_SNAT_NAMESPACE")
+	err := c.AciV1().NodeInfos(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func GetPortRangeFromConfigMap(c *kubernetes.Clientset) (snatglobal.PortRange, int) {
 	cMap, err := c.CoreV1().ConfigMaps("aci-containers-system").Get(context.TODO(), "snat-operator-config", metav1.GetOptions{})
 	var resultPortRange snatglobal.PortRange


### PR DESCRIPTION
after bringing down the nodes, snat Nodeinfo CR is not cleaned up.
Now added a explicit call to delete the Nodeinfo upon the delete of Node