### PR TITLE
Scale down of Node leaving the Stale Snat nodeInfoCR  entry

### DIFF
--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -230,6 +230,12 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 		ret = cont.deleteNodeinfoFromGlInfoCache(nodename)
 		updated = true
 	} else {
+		// This case ignores any stale entry is present in nodeinfo
+		_, _, err := cont.nodeIndexer.GetByKey(nodename)
+		if err != nil {
+			cont.log.Info("Could not lookup node: ", err, "nodeName: ", nodename)
+			return false
+		}
 		allocfailed := make(map[string]bool)
 		markready := make(map[string]bool)
 		for name := range nodeinfo.Spec.SnatPolicyNames {

--- a/pkg/util/snat.go
+++ b/pkg/util/snat.go
@@ -124,6 +124,17 @@ func UpdateNodeInfoCR(c nodeinfoclset.Clientset, nodeinfo nodeinfo.NodeInfo) err
 	}
 	return nil
 }
+
+// UpdateNodeInfoCR Updates a UpdateNodeInfoInfo CR
+func DeleteNodeInfoCR(c nodeinfoclset.Clientset, name string) error {
+	ns := os.Getenv("ACI_SNAT_NAMESPACE")
+	err := c.AciV1().NodeInfos(ns).Delete(name, &metav1.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func GetPortRangeFromConfigMap(c *kubernetes.Clientset) (snatglobal.PortRange, int) {
 	var options metav1.GetOptions
 	cMap, err := c.CoreV1().ConfigMaps("aci-containers-system").Get("snat-operator-config", options)


### PR DESCRIPTION
after bringing down the nodes, snat Nodeinfo CR is not cleaned up.
Now added a explicit call to delete the Nodeinfo upon the delete of Node

(cherry picked from commit 0b4587a7c3e212fd6956c7a998a160d02e2c43cb)