### PR TITLE
Pod Cache sync is done before starting the Service informers.

### DIFF
--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -162,6 +162,7 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 	env.agent.log.Debug("Starting remaining informers")
 	env.agent.log.Debug("Exporting node info: ", env.agent.config.NodeName)
 	go env.agent.podInformer.Run(stopCh)
+	cache.WaitForCacheSync(stopCh, env.agent.podInformer.HasSynced)
 	go env.agent.controllerInformer.Run(stopCh)
 	go env.agent.endpointsInformer.Run(stopCh)
 	go env.agent.serviceInformer.Run(stopCh)
@@ -173,8 +174,7 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 	go env.agent.snatPolicyInformer.Run(stopCh)
 	go env.agent.rdConfigInformer.Run(stopCh)
 	env.agent.log.Info("Waiting for cache sync for remaining objects")
-	cache.WaitForCacheSync(stopCh,
-		env.agent.podInformer.HasSynced, env.agent.endpointsInformer.HasSynced,
+	cache.WaitForCacheSync(stopCh, env.agent.endpointsInformer.HasSynced,
 		env.agent.serviceInformer.HasSynced, env.agent.snatGlobalInformer.HasSynced,
 		env.agent.snatPolicyInformer.HasSynced, env.agent.rdConfigInformer.HasSynced)
 	env.agent.log.Info("Cache sync successful")


### PR DESCRIPTION
so that all the Pod related cache will be populated before accessing it.

(cherry picked from commit bc822d7d4d0b667c53aaf43d3998f2d7a7cd942a)