### PR TITLE
Add support to compile iptables from sources

### DIFF
--- a/docker/Dockerfile-host
+++ b/docker/Dockerfile-host
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 RUN yum --disablerepo=\*ubi\* --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
-  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms install -y iproute nftables openvswitch \
+  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms --enablerepo codeready-builder-for-rhel-8-x86_64-rpms install -y iproute nftables openvswitch libnetfilter_conntrack-devel \
   && yum clean all
 # Required OpenShift Labels
 LABEL name="ACI CNI Host-Agent" \
@@ -9,6 +9,40 @@ version="v1.0.0" \
 release="1" \
 summary="This is an ACI CNI Host-Agent." \
 description="This will deploy a single instance of ACI CNI Host-Agent."
+COPY dist-static/iptables-libs.tar.gz dist-static/iptables-bin.tar.gz dist-static/iptables-wrapper-installer.sh /tmp/
+RUN tar -zxf /tmp/iptables-bin.tar.gz -C /usr/sbin \
+  && tar -zxf /tmp/iptables-libs.tar.gz -C /lib64
+RUN for i in iptables-legacy iptables-legacy-restore iptables-legacy-save iptables iptables-restore iptables-save; \
+  do \
+  ln -s -f xtables-legacy-multi "/sbin/$i"; \
+  done;
+RUN for i in ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save ip6tables ip6tables-restore ip6tables-save; \
+  do \
+  ln -s -f xtables-legacy-multi "/sbin/$i"; \
+  done;
+RUN for i in iptables-nft iptables-nft-restore iptables-nft-save ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
+  iptables-translate ip6tables-translate iptables-restore-translate ip6tables-restore-translate \
+  arptables-nft arptables arptables-nft-restore arptables-restore arptables-nft-save arptables-save \
+  ebtables-nft ebtables ebtables-nft-restore ebtables-restore ebtables-nft-save ebtables-save xtables-monitor; \
+  do \
+  ln -s -f xtables-nft-multi "/sbin/$i"; \
+  done;
+# Add iptables alternatives at lowst priority before running wrappers
+RUN alternatives --install /usr/sbin/iptables iptables /usr/sbin/iptables-legacy 1 \
+                 --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-legacy-restore \
+                 --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-legacy-save \
+                 --slave /usr/sbin/ip6tables ip6tables /usr/sbin/ip6tables-legacy \
+                 --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/ip6tables-legacy-restore \
+                 --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/ip6tables-legacy-save \
+ && alternatives --install /usr/sbin/iptables iptables /usr/sbin/iptables-nft 1 \
+                 --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-nft-restore \
+                 --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-nft-save \
+                 --slave /usr/sbin/ip6tables ip6tables /usr/sbin/ip6tables-nft \
+                 --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/ip6tables-nft-restore \
+                 --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/ip6tables-nft-save
+# Add iptables-wrapper alternative at prio 100 that would
+# at run time use one of the above alternatives installed
+RUN /tmp/iptables-wrapper-installer.sh
 # Required Licenses
 COPY docker/licenses /licenses
 COPY dist-static/aci-containers-host-agent dist-static/opflex-agent-cni docker/launch-hostagent.sh docker/enable-hostacc.sh docker/enable-droplog.sh /usr/local/bin/

--- a/docker/Dockerfile-opflex-build-base
+++ b/docker/Dockerfile-opflex-build-base
@@ -5,13 +5,30 @@ RUN microdnf install --enablerepo codeready-builder-for-rhel-8-x86_64-rpms \
     libtool pkgconfig autoconf automake make cmake file python2-six \
     openssl-devel git gcc gcc-c++ boost-devel diffutils python2-devel \
     libnetfilter_conntrack-devel wget which curl-devel procps zlib-devel \
+    libmnl-devel vi \
     && microdnf clean all
-RUN wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
+RUN git clone -b libnftnl-1.1.7 https://git.netfilter.org/libnftnl \
+  && cd libnftnl \
+  && ./autogen.sh \
+  && ./configure \
+  && make $make_args \
+  && make install && cp libnftnl.pc /usr/lib64/pkgconfig && make clean \
+  && cd / \
+  && rm -Rf libnftnl \
+  && git clone -b v1.8.5 https://git.netfilter.org/iptables \
+  && cd iptables \
+  && ./autogen.sh \
+  && ./configure --prefix=/usr --sbindir=/sbin \
+  && make $make_args \
+  && make install && make clean \
+  && cd / \
+  && rm -Rf iptables \
+  && wget https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz \
   && tar xvfz v1.1.0.tar.gz \
   && cd rapidjson-1.1.0 \
   && cmake CMakeLists.txt \
   && cp -R include/rapidjson/ /usr/local/include/ \
-  && mkdir /usr/local/lib/pkgconfig \
+  && mkdir -p /usr/local/lib/pkgconfig \
   && cp RapidJSON.pc /usr/local/lib/pkgconfig/ \
   && cd / \
   && rm -rf v1.1.0.tar.gz \

--- a/docker/copy_iptables.sh
+++ b/docker/copy_iptables.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# This script is intended to be used from jenkins script or
+# from build_priv.sh, it would copy iptables binaries and
+# libraries from opflex-build-base into dist-static to be
+# used by consumers of iptables like the host agent container
+# use copy_iptables.sh <opflex-build-base-image> <target-dir>
+
+set -x
+
+BASE_IMAGE=$1
+TARGET_DIR=$2
+
+parent_path="$( dirname "${BASH_SOURCE[0]}" )"
+mkdir -p ${TARGET_DIR}
+
+docker run -w /usr/sbin ${BASE_IMAGE} tar -cz -C /usr/sbin \
+  nfnl_osf xtables-legacy-multi xtables-nft-multi iptables-apply \
+  > ${TARGET_DIR}/iptables-bin.tar.gz
+
+docker run -w /lib64 ${BASE_IMAGE} /bin/sh -c 'find . \(\
+ -name '\''libxtables*.so*'\'' -o \
+ -name '\''libip6tc*.so*'\'' -o \
+ -name '\''libip4tc*.so*'\'' \
+\)  \
+| xargs tar -cz ' > ${TARGET_DIR}/iptables-libs.tar.gz
+
+cp ${parent_path}/iptables-wrapper-installer.sh ${TARGET_DIR}

--- a/docker/dev/ubi/Dockerfile-ubibase-opflex-build-base
+++ b/docker/dev/ubi/Dockerfile-ubibase-opflex-build-base
@@ -3,5 +3,6 @@ RUN microdnf install --enablerepo codeready-builder-for-rhel-8-x86_64-rpms \
     libtool pkgconfig autoconf automake make cmake file python2-six \
     openssl-devel git gcc gcc-c++ boost-devel diffutils python2-devel \
     libnetfilter_conntrack-devel wget which curl-devel procps zlib-devel \
+    libmnl-devel vi \
     && microdnf clean all
 CMD ["/usr/bin/sh"]

--- a/docker/dev/ubi/build.sh
+++ b/docker/dev/ubi/build.sh
@@ -2,11 +2,15 @@
 
 set -x
 
-docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy --build-arg NO_PROXY=$no_proxy -t noirolabs/ubibase-opflex-build-base -f Dockerfile-ubibase-opflex-build-base
-docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy --build-arg NO_PROXY=$no_proxy -t noirolabs/ubibase-opflex -f Dockerfile-ubibase-opflex
-docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy --build-arg NO_PROXY=$no_proxy -t noirolabs/ubibase-aci -f Dockerfile-ubibase-aci
+export http_proxy=http://proxy.esl.cisco.com:80
+export https_proxy=http://proxy.esl.cisco.com:80
+export no_proxy=engci-jenkins-sjc.cisco.com,172.28.184.12
 
-docker push noirolabs/ubibase-opflex-build-base
-docker push noirolabs/ubibase-opflex
-docker push noirolabs/ubibase-aci
+docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy --build-arg NO_PROXY=$no_proxy -t registry.hub.docker.com/noirolabs/ubibase-opflex-build-base -f Dockerfile-ubibase-opflex-build-base
+docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy --build-arg NO_PROXY=$no_proxy -t registry.hub.docker.com/noirolabs/ubibase-opflex -f Dockerfile-ubibase-opflex
+docker build --build-arg HTTP_PROXY=$http_proxy --build-arg HTTPS_PROXY=$https_proxy --build-arg NO_PROXY=$no_proxy -t registry.hub.docker.com/noirolabs/ubibase-aci -f Dockerfile-ubibase-aci
+
+docker push registry.hub.docker.com/noirolabs/ubibase-opflex-build-base
+docker push registry.hub.docker.com/noirolabs/ubibase-opflex
+docker push registry.hub.docker.com/noirolabs/ubibase-aci
 

--- a/docker/iptables-wrapper-installer.sh
+++ b/docker/iptables-wrapper-installer.sh
@@ -1,0 +1,218 @@
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage:
+#
+#   iptables-wrapper-installer.sh [--no-sanity-check]
+#
+# Installs a wrapper iptables script in a container that will figure out
+# whether iptables-legacy or iptables-nft is in use on the host and then
+# replaces itself with the correct underlying iptables version.
+#
+# Unless "--no-sanity-check" is passed, it will first verify that the
+# container already contains a suitable version of iptables.
+
+# NOTE: This can only use POSIX /bin/sh features; the build container
+# might not contain bash.
+
+set -eu
+
+# Find iptables binary location
+if [ -d /usr/sbin -a -e /usr/sbin/iptables ]; then
+    sbin="/usr/sbin"
+elif [ -d /sbin -a -e /sbin/iptables ]; then
+    sbin="/sbin"
+else
+    echo "ERROR: iptables is not present in either /usr/sbin or /sbin" 1>&2
+    exit 1
+fi
+
+# Determine how the system selects between iptables-legacy and iptables-nft
+if [ -x /usr/sbin/alternatives ]; then
+    # Fedora/SUSE style alternatives
+    altstyle="fedora"
+elif [ -x /usr/sbin/update-alternatives ]; then
+    # Debian style alternatives
+    altstyle="debian"
+else
+    # No alternatives system
+    altstyle="none"
+fi
+
+if [ "${1:-}" != "--no-sanity-check" ]; then
+    # Ensure dependencies are installed
+    if ! version=$("${sbin}/iptables-nft" --version 2> /dev/null); then
+        echo "ERROR: iptables-nft is not installed" 1>&2
+        exit 1
+    fi
+    if ! "${sbin}/iptables-legacy" --version > /dev/null 2>&1; then
+        echo "ERROR: iptables-legacy is not installed" 1>&2
+        exit 1
+    fi
+
+    case "${version}" in
+    *v1.8.[012]\ *)
+        echo "ERROR: iptables 1.8.0 - 1.8.2 have compatibility bugs." 1>&2
+        echo "       Upgrade to 1.8.3 or newer." 1>&2
+        exit 1
+        ;;
+    *v1.8.3\ *)
+	# 1.8.3 mostly works but can get stuck in an infinite loop if the nft
+	# kernel modules are unavailable
+	need_timeout=1
+	;;
+    *)
+        # 1.8.4+ are OK
+        ;;
+    esac
+fi
+
+# Start creating the wrapper...
+rm -f "${sbin}/iptables-wrapper"
+cat > "${sbin}/iptables-wrapper" <<EOF
+#!/bin/sh
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: This can only use POSIX /bin/sh features; the container image
+# might not contain bash.
+
+set -eu
+
+# Detect whether the base system is using iptables-legacy or
+# iptables-nft. This assumes that some non-containerized process (eg
+# kubelet) has already created some iptables rules.
+EOF
+
+if [ "${need_timeout:-0}" = 0 ]; then
+    # Write out the simpler version of legacy-vs-nft detection
+    cat >> "${sbin}/iptables-wrapper" <<EOF
+num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+num_nft_lines=\$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+if [ "\${num_legacy_lines}" -ge "\${num_nft_lines}" ]; then
+    mode=legacy
+else
+    mode=nft
+fi
+EOF
+else
+    # Write out the version of legacy-vs-nft detection with an nft timeout
+    cat >> "${sbin}/iptables-wrapper" <<EOF
+# The iptables-nft binary in this image can get stuck in an infinite
+# loop if nft is not available so we need to wrap a timeout around it
+# (and to avoid that, we don't even bother calling iptables-nft if it
+# looks like iptables-legacy is going to win).
+num_legacy_lines=\$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+if [ "\${num_legacy_lines}" -ge 10 ]; then
+    mode=legacy
+else
+    num_nft_lines=\$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l)
+    if [ "\${num_legacy_lines}" -ge "\${num_nft_lines}" ]; then
+        mode=legacy
+    else
+        mode=nft
+    fi
+fi
+EOF
+fi
+
+# Write out the appropriate alternatives-selection commands
+case "${altstyle}" in
+    fedora)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    debian)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+update-alternatives --set iptables "/usr/sbin/iptables-\${mode}" > /dev/null || failed=1
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-\${mode}" > /dev/null || failed=1
+EOF
+    ;;
+
+    *)
+cat >> "${sbin}/iptables-wrapper" <<EOF
+# Update links to point to the selected binaries
+for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+    rm -f "${sbin}/\${cmd}"
+    ln -s "${sbin}/xtables-\${mode}-multi" "${sbin}/\${cmd}"
+done 2>/dev/null || failed=1
+EOF
+    ;;
+esac
+
+# Write out the post-alternatives-selection error checking and final wrap-up
+cat >> "${sbin}/iptables-wrapper" <<EOF
+if [ "\${failed:-0}" = 1 ]; then
+    echo "Unable to redirect iptables binaries. (Are you running in an unprivileged pod?)" 1>&2
+    # fake it, though this will probably also fail if they aren't root
+    exec "${sbin}/xtables-\${mode}-multi" "\$0" "\$@"
+fi
+
+# Now re-exec the original command with the newly-selected alternative
+exec "\$0" "\$@"
+EOF
+chmod +x "${sbin}/iptables-wrapper"
+
+# Now back in the installer script, point the iptables binaries at our
+# wrapper
+case "${altstyle}" in
+    fedora)
+	alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+	;;
+
+    debian)
+	update-alternatives \
+            --install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+	update-alternatives \
+            --install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+            --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+            --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper
+	;;
+
+    *)
+	for cmd in iptables iptables-save iptables-restore ip6tables ip6tables-save ip6tables-restore; do
+            rm -f "${sbin}/${cmd}"
+            ln -s "${sbin}/iptables-wrapper" "${sbin}/${cmd}"
+	done
+	;;
+esac
+
+# Cleanup
+rm -f "$0"


### PR DESCRIPTION
- For ubi containers we do not have a iptables-legacy package
- To work around this compile iptables from sources in base image
- Copy iptables artifacts from base image into dist-static
  (done in jenkins scripts)
- Dockerfile-host will pick the artifacts and install it locally
  in its container
- Install iptables alternatives to
  - /usr/sbin/iptables-legacy
  - /usr/sbin/iptables-nft
- Run wrapper that will set initial alternative to
  - /usr/sbin/iptables-wrapper
- At run time depending on which rules are used by kubelet
  the alternative will be modfied to use iptables-legacy
  or iptables-nft

Signed-off-by: Madhu Challa <challa@gmail.com>