### PR TITLE
supporting the use case where l3out can be part of

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -503,12 +503,10 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 
 	cont.log.Debug("UseAPICInstTag set to:", cont.apicConn.UseAPICInstTag)
 	cont.log.Debug("SnatPbrFltrChain set to:", cont.apicConn.SnatPbrFltrChain)
-
-	// Make sure Pod/NodeBDs and AciL3Out are assoicated to same VRF.
+	// Make sure Pod/NodeBDs are assoicated to same VRF.
 	if len(cont.config.ApicHosts) != 0 && cont.config.AciPodBdDn != "" && cont.config.AciNodeBdDn != "" {
-		acil3outdn := "uni/tn-" + cont.config.AciVrfTenant + "/out-" + cont.config.AciL3Out
 		var expectedVrfRelations []string
-		expectedVrfRelations = append(expectedVrfRelations, acil3outdn, cont.config.AciPodBdDn, cont.config.AciNodeBdDn)
+		expectedVrfRelations = append(expectedVrfRelations, cont.config.AciPodBdDn, cont.config.AciNodeBdDn)
 		cont.log.Debug("expectedVrfRelations:", expectedVrfRelations)
 		err = cont.apicConn.ValidateAciVrfAssociation(cont.config.AciVrfDn, expectedVrfRelations)
 		if err != nil {


### PR DESCRIPTION
diffrent VRF as long as contract scope set accordingly,
and also verifying for only matching POD and Node BD's

(cherry picked from commit b727b6b77c59b0a9584d69f639a87faaa3aef0e5)