### PR TITLE
Add wide output for pods' logs

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -198,7 +198,7 @@ func clusterReport(cmd *cobra.Command, args []string) {
 		},
 		{
 			name: "cluster-report/status/pods_status.log",
-			args: []string{"get", "pods", "--all-namespaces"},
+			args: []string{"get", "pods", "--all-namespaces", "--output=wide"},
 		},
 		{
 			name: "cluster-report/status/services_status.log",


### PR DESCRIPTION
(cherry picked from commit a481055f6da4ceafec01daf5dfa3fced22a9f553)