### PR TITLE
Use the passed timeout instead of ignoring

### DIFF
--- a/cmd/opflexagentcni/main.go
+++ b/cmd/opflexagentcni/main.go
@@ -115,7 +115,7 @@ func waitForAllNetwork(result *current.Result, id string,
 		if err != nil {
 			log.Error("Could not open netns: ", err)
 		} else {
-			waitForNetwork(netns, result, id, index, 10*time.Second)
+			waitForNetwork(netns, result, id, index, timeout)
 			netns.Close()
 		}
 	}


### PR DESCRIPTION
All callers pass the same timeout anyway
so this doesn't change the existing behavior

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>