### PR TITLE
Add coveralls support to aci-containers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,14 @@ matrix:
     - language: go
       sudo: false
       go: "1.13"
+      before_install:
+        - go get github.com/mattn/goveralls
       install:
         - export PATH=$PATH:$GOPATH/bin
       script:
         - make goinstall
         - make check >& /tmp/check.log
+        - $GOPATH/bin/goveralls -coverprofile=covprof-ipam,covprof-index,covprof-apicapi,covprof-hostagent,covprof-controller,covprof-gbpserver,covprof-keyvalueservice -service=travis-ci
       after_failure:
         - grep -C 200 FAIL /tmp/check.log
         - tail -200 /tmp/check.log


### PR DESCRIPTION
A separate coverage file is generated per component and
then merged together by goveralls before submitting.

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>