### PR TITLE
Enabling the endpoint slices if the cluster supports

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -331,14 +331,17 @@ func (cont *AciController) Init() {
 
 	cont.log.Debug("Initializing IPAM")
 	cont.initIpam()
-	//@FIXME need to set this value based on feature capability supported by cluster
+	// check if the cluster supports endpoint slices
 	// if cluster doesn't have the support fallback to endpoints
-	if cont.config.EnabledEndpointSlice {
+	kubeClient := cont.env.(*K8sEnvironment).kubeClient
+	if util.IsEndPointSlicesSupported(kubeClient) {
 		cont.serviceEndPoints = &serviceEndpointSlice{}
 		cont.serviceEndPoints.(*serviceEndpointSlice).cont = cont
+		cont.log.Info("Initializing ServiceEndpointSlices")
 	} else {
 		cont.serviceEndPoints = &serviceEndpoint{}
 		cont.serviceEndPoints.(*serviceEndpoint).cont = cont
+		cont.log.Info("Initializing ServiceEndpoints")
 	}
 
 	err = cont.env.Init(cont)

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/noironetworks/aci-containers/pkg/ipam"
 	md "github.com/noironetworks/aci-containers/pkg/metadata"
 	snatpolicy "github.com/noironetworks/aci-containers/pkg/snatpolicy/apis/aci.snat/v1"
+	"github.com/noironetworks/aci-containers/pkg/util"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/time/rate"
@@ -270,13 +271,17 @@ func (agent *HostAgent) Init() {
 	}
 	agent.log.Info("Loaded cached endpoint CNI metadata: ", len(agent.epMetadata))
 	agent.buildUsedIPs()
-	//@TODO need to set this value based on feature capability currently turnedoff
-	if agent.config.EnabledEndpointSlice {
+	// check if the cluster supports endpoint slices
+	// if cluster doesn't have the support fallback to endpoints
+	kubeClient := agent.env.(*K8sEnvironment).kubeClient
+	if util.IsEndPointSlicesSupported(kubeClient) {
 		agent.serviceEndPoints = &serviceEndpointSlice{}
 		agent.serviceEndPoints.(*serviceEndpointSlice).agent = agent
+		agent.log.Info("Initializing ServiceEndpointSlices")
 	} else {
 		agent.serviceEndPoints = &serviceEndpoint{}
 		agent.serviceEndPoints.(*serviceEndpoint).agent = agent
+		agent.log.Info("Initializing ServiceEndpoints")
 	}
 	err = agent.env.Init(agent)
 	if err != nil {

--- a/pkg/util/common.go
+++ b/pkg/util/common.go
@@ -15,7 +15,10 @@
 package util
 
 import (
+	"context"
 	"encoding/json"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func DeepCopyObj(src, dst interface{}) error {
@@ -28,4 +31,13 @@ func DeepCopyObj(src, dst interface{}) error {
 		return err
 	}
 	return nil
+}
+
+// Checks if cluster supports endpointslices
+func IsEndPointSlicesSupported(kubeClient *kubernetes.Clientset) bool {
+	esobj, err := kubeClient.DiscoveryV1beta1().EndpointSlices("default").Get(context.TODO(), "kubernetes", metav1.GetOptions{})
+	if err == nil && esobj != nil {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
acc-provision should provision enable_endpointslices flag as true
enpoint slice Obj is retrived for default Kubernetes service
to verify cluster supports Endpoint slices.