### PR TITLE
defer file close in case there's an error on write

### DIFF
--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -242,6 +242,8 @@ func (agent *HostAgent) writeConfigFile(name string,
 	if err != nil {
 		return err
 	}
+	// in case there's an error in the write
+	defer f.Close()
 	_, err = f.Write(buffer.Bytes())
 	if err != nil {
 		return err


### PR DESCRIPTION
Issue was introduced by previous commit as errors
from calls to write were being ignored. Deferring
the close and potentially calling it twice seems
to be the preferred pattern

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>