### PR TITLE
Build opflex artifacts without using copy

### DIFF
--- a/docker/Dockerfile-opflex-build
+++ b/docker/Dockerfile-opflex-build
@@ -2,17 +2,15 @@ FROM noiro/opflex-build-base
 ARG BUILDOPTS="--enable-grpc --enable-prometheus"
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/share/pkgconfig
 WORKDIR /opflex
-COPY libopflex /opflex/libopflex
-COPY genie /opflex/genie
-COPY agent-ovs /opflex/agent-ovs
+COPY opflex.tgz /opflex/opflex.tgz
 ARG make_args=-j4
-RUN cd /opflex/libopflex \
+RUN cd /opflex && tar xvfz opflex.tgz && cd /opflex/opflex/libopflex \
   && ./autogen.sh && ./configure --disable-assert \
   && make $make_args && make install && make clean \
-  && cd /opflex/genie/target/libmodelgbp \
+  && cd /opflex/opflex/genie/target/libmodelgbp \
   && sh autogen.sh && ./configure --disable-static \
   && make $make_args && make install && make clean \
-  && cd /opflex/agent-ovs \
+  && cd /opflex/opflex/agent-ovs \
   && export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH \
   && ./autogen.sh && ./configure $BUILDOPTS \
   && make $make_args && make install && make clean \


### PR DESCRIPTION
Hidden files are not copied into the container
so we lose .git and commit details

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>