### PR TITLE
Remove usage of tagInst

### DIFF
--- a/pkg/apicapi/apic_sync.go
+++ b/pkg/apicapi/apic_sync.go
@@ -205,26 +205,22 @@ func getTagFromKey(prefix string, key string) string {
 }
 
 func PrepareApicSlice(objects ApicSlice, prefix string, key string) ApicSlice {
-	return prepareApicSliceTag(objects, getTagFromKey(prefix, key), false)
+	return prepareApicSliceTag(objects, getTagFromKey(prefix, key))
 }
 
-func prepareApicSliceTag(objects ApicSlice, tag string,
-	useAPICInstTag bool) ApicSlice {
-
+func prepareApicSliceTag(objects ApicSlice, tag string) ApicSlice {
 	sort.Sort(objects)
 	for _, obj := range objects {
 		for class, body := range obj {
 			if class != "tagInst" && class != "tagAnnotation" {
-				obj.SetTag(tag, useAPICInstTag)
-				if !useAPICInstTag {
-					if body.Attributes == nil {
-						body.Attributes = make(map[string]interface{})
-					}
-					body.Attributes["annotation"] =
-						aciContainersOwnerAnnotation
+				obj.SetTag(tag)
+				if body.Attributes == nil {
+					body.Attributes = make(map[string]interface{})
 				}
+				body.Attributes["annotation"] =
+					aciContainersOwnerAnnotation
 			}
-			prepareApicSliceTag(body.Children, tag, useAPICInstTag)
+			prepareApicSliceTag(body.Children, tag)
 
 			if md, ok := metadata[class]; ok {
 				if md.normalizer != nil {
@@ -334,7 +330,7 @@ func (conn *ApicConnection) removeFromDnIndex(dn string) {
 func (conn *ApicConnection) doWriteApicObjects(key string, objects ApicSlice,
 	container bool) {
 	tag := getTagFromKey(conn.prefix, key)
-	prepareApicSliceTag(objects, tag, conn.UseAPICInstTag)
+	prepareApicSliceTag(objects, tag)
 
 	conn.indexMutex.Lock()
 	updates, deletes := conn.diffApicState(conn.desiredState[key], objects)

--- a/pkg/apicapi/apicapi_test.go
+++ b/pkg/apicapi/apicapi_test.go
@@ -235,11 +235,7 @@ func (h *retryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 func TestGetSetTag(t *testing.T) {
 	bd := NewFvBD("common", "testbd1")
-	bd.SetTag("tagTest", false)
-	assert.Equal(t, "tagTest", bd.GetTag())
-
-	bd = NewFvBD("common", "testbd2")
-	bd.SetTag("tagTest", true)
+	bd.SetTag("tagTest")
 	assert.Equal(t, "tagTest", bd.GetTag())
 
 	bd = NewFvBD("common", "testbd3")
@@ -247,16 +243,6 @@ func TestGetSetTag(t *testing.T) {
 	bd.AddChild(NewTagAnnotation(bd.GetDn(), aciContainersAnnotKey).
 		SetAttr("value", "anotherTest"))
 	assert.Equal(t, "anotherTest", bd.GetTag())
-
-	bd = NewFvBD("common", "testbd4")
-	bd.SetTag("tagTest", true)
-	bd.SetTag("tagTest2", false)
-	assert.Equal(t, "tagTest2", bd.GetTag())
-
-	bd = NewFvBD("common", "testbd5")
-	bd.SetTag("tagTest", false)
-	bd.SetTag("tagTest2", true)
-	assert.Equal(t, "tagTest2", bd.GetTag())
 }
 
 func TestIsSyncTag(t *testing.T) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -494,12 +494,6 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		}
 		cont.apicConn.CachedVersion = version
 		apicapi.ApicVersion = version
-		// APIC version 3.2 introduced tagAnnotation support for better scalability.
-		if version >= "3.2" {
-			cont.apicConn.UseAPICInstTag = false
-		} else {
-			cont.apicConn.UseAPICInstTag = true
-		}
 		if version >= "4.2(4i)" {
 			cont.apicConn.SnatPbrFltrChain = true
 		} else {
@@ -509,7 +503,6 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		cont.apicConn.SnatPbrFltrChain = true
 	}
 
-	cont.log.Debug("UseAPICInstTag set to:", cont.apicConn.UseAPICInstTag)
 	cont.log.Debug("SnatPbrFltrChain set to:", cont.apicConn.SnatPbrFltrChain)
 	// Make sure Pod/NodeBDs are assoicated to same VRF.
 	if len(cont.config.ApicHosts) != 0 && cont.config.AciPodBdDn != "" && cont.config.AciNodeBdDn != "" {


### PR DESCRIPTION
tagInst usage was replaced with tagAnnotation in APIC 3.2
We kept around tagInst to support customers who hadn't
upgraded. At this point we should only support tagAnnotation

Remove explicit APIC version checks for versions < 3.2

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>