### PR TITLE
Network Policy issue for Namedport is fixed for egress  direction

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -144,8 +144,10 @@ type AciController struct {
 	serviceEndPoints    ServiceEndPointType
 	crdHandlers         map[string]func(*AciController, <-chan struct{})
 	stopCh              <-chan struct{}
-	//index of containername to ctrPortNameEntry
+	//index of containerportname to ctrPortNameEntry
 	ctrPortNameCache map[string]*ctrPortNameEntry
+	// named networkPolicies
+	nmPortNp map[string]bool
 }
 
 type nodeServiceMeta struct {
@@ -298,6 +300,7 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 		istioCache:           make(map[string]*istiov1.AciIstioOperator),
 		crdHandlers:          make(map[string]func(*AciController, <-chan struct{})),
 		ctrPortNameCache:     make(map[string]*ctrPortNameEntry),
+		nmPortNp:             make(map[string]bool),
 	}
 	cont.syncProcessors = map[string]func() bool{
 		"snatGlobalInfo": cont.syncSnatGlobalInfo,

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -542,7 +542,7 @@ func TestNetworkPolicy(t *testing.T) {
 			}, nil, allPolicyTypes),
 			makeNp(apicapi.ApicSlice{rule_8_0, rule_8_1}, nil, name),
 			nil, "multiple-from"},
-		{netpol("testns", "np1", &metav1.LabelSelector{},
+		{netpol("testns", "np1", &metav1.LabelSelector{MatchLabels: map[string]string{"l1": "v1"}},
 			[]v1net.NetworkPolicyIngressRule{
 				ingressRule([]v1net.NetworkPolicyPort{
 					{


### PR DESCRIPTION
Added changes to reconcile for endpoints matching the Wildcard namedport port of neworkPolicies in the egress direction
Optimized processing of the Wilcard networkpolicesi, enqued the polcies matching names of container port