### PR TITLE
Raise fault on opflex agent if requested MTU exceeds fabric uplink MTU

### DIFF
--- a/docker/launch-hostagent.sh
+++ b/docker/launch-hostagent.sh
@@ -44,6 +44,7 @@ if [ -w ${PREFIX} ]; then
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/reboot-conf.d
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/ids
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/droplog
+    mkdir -p ${VARDIR}/lib/opflex-agent-ovs/faults
 fi
 
 if [ "$OPFLEX_MODE" == "overlay" ]; then

--- a/docker/launch-opflexagent.sh
+++ b/docker/launch-opflexagent.sh
@@ -21,6 +21,7 @@ if [ -w ${PREFIX} ]; then
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/snats
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/reboot-conf.d
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/droplog
+    mkdir -p ${VARDIR}/lib/opflex-agent-ovs/faults
 fi
 
 if [ -d ${OPFLEXAGENT_CONF_PATH} ]; then

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -17,8 +17,6 @@ package hostagent
 import (
 	"fmt"
 	"net"
-	"os"
-	"path/filepath"
 	"sync"
 	"time"
 
@@ -387,14 +385,6 @@ func (agent *HostAgent) Run(stopCh <-chan struct{}) {
 		}
 		go agent.processSyncQueue(agent.syncQueue, stopCh)
 	}
-	if agent.config.OpFlexFaultDir == "" {
-		agent.log.Warn("OpFlex Faults directories not set")
-	} else {
-		err = removeAllFiles(agent.config.OpFlexFaultDir)
-		if err != nil {
-			agent.log.Warn("Not able to clear faults files on agent: ", err.Error())
-		}
-	}
 	agent.log.Info("Starting endpoint RPC")
 	err = agent.runEpRPC(stopCh)
 	if err != nil {
@@ -402,23 +392,4 @@ func (agent *HostAgent) Run(stopCh <-chan struct{}) {
 	}
 
 	agent.cleanupSetup()
-}
-
-func removeAllFiles(dir string) error {
-	d, err := os.Open(dir)
-	if err != nil {
-		return err
-	}
-	defer d.Close()
-	names, err := d.Readdirnames(-1)
-	if err != nil {
-		return err
-	}
-	for _, name := range names {
-		err = os.RemoveAll(filepath.Join(dir, name))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -385,6 +385,7 @@ func (agent *HostAgent) Run(stopCh <-chan struct{}) {
 		}
 		go agent.processSyncQueue(agent.syncQueue, stopCh)
 	}
+
 	agent.log.Info("Starting endpoint RPC")
 	err = agent.runEpRPC(stopCh)
 	if err != nil {

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -379,7 +379,6 @@ func (agent *HostAgent) Run(stopCh <-chan struct{}) {
 	if agent.config.OpFlexEndpointDir == "" ||
 		agent.config.OpFlexServiceDir == "" ||
 		agent.config.OpFlexSnatDir == "" {
-		//		agent.config.OpFlexFaultDir == "" {
 		agent.log.Warn("OpFlex endpoint,service or snat directories not set")
 
 	} else {

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -387,9 +387,13 @@ func (agent *HostAgent) Run(stopCh <-chan struct{}) {
 		}
 		go agent.processSyncQueue(agent.syncQueue, stopCh)
 	}
-	err = RemoveAllFiles(agent.config.OpFlexFaultDir)
-	if err != nil {
-		fmt.Println(err)
+	if agent.config.OpFlexFaultDir == "" {
+		agent.log.Warn("OpFlex Faults directories not set")
+	} else {
+		err = removeAllFiles(agent.config.OpFlexFaultDir)
+		if err != nil {
+			agent.log.Warn("Not able to clear faults files on agent: ", err.Error())
+		}
 	}
 	agent.log.Info("Starting endpoint RPC")
 	err = agent.runEpRPC(stopCh)
@@ -400,7 +404,7 @@ func (agent *HostAgent) Run(stopCh <-chan struct{}) {
 	agent.cleanupSetup()
 }
 
-func RemoveAllFiles(dir string) error {
+func removeAllFiles(dir string) error {
 	d, err := os.Open(dir)
 	if err != nil {
 		return err

--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -123,6 +123,9 @@ type HostAgentConfig struct {
 	// Directory for writing OpFlex snat metadata
 	OpFlexSnatDir string `json:"opflex-snat-dir,omitempty"`
 
+	// Directory for writing OpFlex fault metadata
+	OpFlexFaultDir string `json:"opflex-fault-dir,omitempty"`
+
 	// OpFlex agent's flow-ID cache directory
 	OpFlexFlowIdCacheDir string `json:"opflex-flowid-cache-dir,omitempty"`
 
@@ -244,6 +247,7 @@ func (config *HostAgentConfig) InitFlags() {
 	flag.StringVar(&config.OpFlexEndpointDir, "opflex-endpoint-dir", "/usr/local/var/lib/opflex-agent-ovs/endpoints/", "Directory for writing OpFlex endpoint metadata")
 	flag.StringVar(&config.OpFlexServiceDir, "opflex-service-dir", "/usr/local/var/lib/opflex-agent-ovs/services/", "Directory for writing OpFlex anycast service metadata")
 	flag.StringVar(&config.OpFlexSnatDir, "opflex-snat-dir", "/usr/local/var/lib/opflex-agent-ovs/snats/", "Directory for writing OpFlex snat metadata")
+	flag.StringVar(&config.OpFlexFaultDir, "opflex-fault-dir", "/usr/local/var/lib/opflex-agent-ovs/faults/", "Directory for writing OpFlex fault metadata")
 	flag.StringVar(&config.OpFlexFlowIdCacheDir, "opflex-flowid-cache-dir",
 		"/usr/local/var/lib/opflex-agent-ovs/ids/",
 		"OpFlex agent's flow-ID cache directory")

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -53,11 +53,10 @@ func writeFault(faultfile string, ep *opflexFault) (bool, error) {
 
 func (agent *HostAgent) createMtuFault(description string) {
 	uuid, _ := gouuid.NewV4()
-	fmt.Print("uuid " + uuid.String())
 	FaultFilePath := filepath.Join(agent.config.OpFlexFaultDir, description+".fs")
 	faultFileExists := fileExists(FaultFilePath)
 	if faultFileExists {
-		fmt.Print("fault file exist")
+		agent.log.Debug("fault file exist")
 		return
 	}
 	fault := &opflexFault{
@@ -66,7 +65,6 @@ func (agent *HostAgent) createMtuFault(description string) {
 		Description: description,
 		FaultCode:   "3",
 	}
-	fmt.Print("writing to file")
 	wrote, err := writeFault(FaultFilePath, fault)
 	if err != nil {
 		agent.log.Debug("Unable to write fault file")

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -53,10 +53,10 @@ func writeFault(faultfile string, ep *opflexFault) (bool, error) {
 
 func (agent *HostAgent) createFaultOnAgent(description string, faultCode int) {
 	Uuid := uuid.New().String()
-	FaultFilePath := filepath.Join(agent.config.OpFlexFaultDir, description+".fs")
-	faultFileExists := fileExists(FaultFilePath)
+	faultFilePath := filepath.Join(agent.config.OpFlexFaultDir, description+".fs")
+	faultFileExists := fileExists(faultFilePath)
 	if faultFileExists {
-		agent.log.Debug("fault file exist")
+		agent.log.Debug("fault file exist at: ", faultFilePath)
 		return
 	}
 	desc := strings.Replace(description, "_", " ", -1)
@@ -66,11 +66,11 @@ func (agent *HostAgent) createFaultOnAgent(description string, faultCode int) {
 		Description: desc,
 		FaultCode:   faultCode,
 	}
-	wrote, err := writeFault(FaultFilePath, fault)
+	wrote, err := writeFault(faultFilePath, fault)
 	if err != nil {
-		agent.log.Debug("Unable to write fault file")
+		agent.log.Warn("Unable to write fault file: ", err.Error())
 	} else if wrote {
-		agent.log.Debug("Created fault file")
+		agent.log.Debug("Created fault file at the location: ", faultFilePath)
 	}
 	return
 }

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -332,13 +332,13 @@ func (agent *HostAgent) updateOpflexConfig() {
 		return
 	}
 	if agent.config.OpFlexFaultDir == "" {
-		agent.log.Warn("OpFlex Faults directories not set")
+		agent.log.Warn("OpFlex Fault directory not set")
 	} else {
-		err := removeAllFiles(agent.config.OpFlexFaultDir)
+		err := agent.removeAllFiles(agent.config.OpFlexFaultDir)
 		if err != nil {
-			agent.log.Error("Not able to clear faults files on agent: ", err.Error())
+			agent.log.Error("Not able to clear Fault files on agent: ", err.Error())
 		}
-		agent.log.Debug("Cleared existig Faults files at the location ", agent.config.OpFlexFaultDir)
+		agent.log.Debug("Cleared existig Fault files at the location ", agent.config.OpFlexFaultDir)
 	}
 
 	newNodeConfig := agent.discoverHostConfig()
@@ -397,7 +397,7 @@ func (agent *HostAgent) writeOpflexConfig() error {
 	return nil
 }
 
-func removeAllFiles(dir string) error {
+func (agent *HostAgent) removeAllFiles(dir string) error {
 	d, err := os.Open(dir)
 	if err != nil {
 		return err
@@ -410,6 +410,7 @@ func removeAllFiles(dir string) error {
 	for _, name := range names {
 		err = os.RemoveAll(filepath.Join(dir, name))
 		if err != nil {
+			agent.log.Error("Not able to clear the Fault files  ",err)
 			return err
 		}
 	}

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -52,11 +52,15 @@ func writeFault(faultfile string, ep *opflexFault) (bool, error) {
 }
 
 func (agent *HostAgent) createFaultOnAgent(description string, faultCode int) {
+        if agent.config.OpFlexFaultDir == "" {
+                agent.log.Error("OpFlex Fault directory not set")
+                return
+        }
 	Uuid := uuid.New().String()
 	faultFilePath := filepath.Join(agent.config.OpFlexFaultDir, description+".fs")
 	faultFileExists := fileExists(faultFilePath)
 	if faultFileExists {
-		agent.log.Debug("fault file exist at: ", faultFilePath)
+	       	agent.log.Debug("Fault file exist at: ", faultFilePath)
 		return
 	}
 	desc := strings.Replace(description, "_", " ", -1)
@@ -332,8 +336,9 @@ func (agent *HostAgent) updateOpflexConfig() {
 	} else {
 		err := removeAllFiles(agent.config.OpFlexFaultDir)
 		if err != nil {
-			agent.log.Warn("Not able to clear faults files on agent: ", err.Error())
-		}
+			agent.log.Error("Not able to clear faults files on agent: ", err.Error())
+                }
+                agent.log.Debug("Cleared existig Faults files at the location ",agent.config.OpFlexFaultDir)
 	}
 
 	newNodeConfig := agent.discoverHostConfig()

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -52,15 +52,15 @@ func writeFault(faultfile string, ep *opflexFault) (bool, error) {
 }
 
 func (agent *HostAgent) createFaultOnAgent(description string, faultCode int) {
-        if agent.config.OpFlexFaultDir == "" {
-                agent.log.Error("OpFlex Fault directory not set")
-                return
-        }
+	if agent.config.OpFlexFaultDir == "" {
+		agent.log.Error("OpFlex Fault directory not set")
+		return
+	}
 	Uuid := uuid.New().String()
 	faultFilePath := filepath.Join(agent.config.OpFlexFaultDir, description+".fs")
 	faultFileExists := fileExists(faultFilePath)
 	if faultFileExists {
-	       	agent.log.Debug("Fault file exist at: ", faultFilePath)
+		agent.log.Debug("Fault file exist at: ", faultFilePath)
 		return
 	}
 	desc := strings.Replace(description, "_", " ", -1)
@@ -74,7 +74,7 @@ func (agent *HostAgent) createFaultOnAgent(description string, faultCode int) {
 	if err != nil {
 		agent.log.Warn("Unable to write fault file: ", err.Error())
 	} else if wrote {
-		agent.log.Debug("Created fault file at the location: ", faultFilePath)
+		agent.log.Debug("Created fault files at the location: ", faultFilePath)
 	}
 	return
 }
@@ -337,8 +337,8 @@ func (agent *HostAgent) updateOpflexConfig() {
 		err := removeAllFiles(agent.config.OpFlexFaultDir)
 		if err != nil {
 			agent.log.Error("Not able to clear faults files on agent: ", err.Error())
-                }
-                agent.log.Debug("Cleared existig Faults files at the location ",agent.config.OpFlexFaultDir)
+		}
+		agent.log.Debug("Cleared existig Faults files at the location ", agent.config.OpFlexFaultDir)
 	}
 
 	newNodeConfig := agent.discoverHostConfig()

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -327,6 +327,14 @@ func (agent *HostAgent) updateOpflexConfig() {
 		agent.log.Debug("OpFlex agent configuration path not set")
 		return
 	}
+	if agent.config.OpFlexFaultDir == "" {
+		agent.log.Warn("OpFlex Faults directories not set")
+	} else {
+		err := removeAllFiles(agent.config.OpFlexFaultDir)
+		if err != nil {
+			agent.log.Warn("Not able to clear faults files on agent: ", err.Error())
+		}
+	}
 
 	newNodeConfig := agent.discoverHostConfig()
 	if newNodeConfig == nil {
@@ -380,6 +388,25 @@ func (agent *HostAgent) writeOpflexConfig() error {
 	err = agent.writeConfigFile("10-renderer.conf", rtempl)
 	if err != nil {
 		return err
+	}
+	return nil
+}
+
+func removeAllFiles(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+	names, err := d.Readdirnames(-1)
+	if err != nil {
+		return err
+	}
+	for _, name := range names {
+		err = os.RemoveAll(filepath.Join(dir, name))
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -25,7 +25,6 @@ import (
 	"text/template"
 
 	"encoding/json"
-	"fmt"
 	gouuid "github.com/nu7hatch/gouuid"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -410,7 +410,7 @@ func (agent *HostAgent) removeAllFiles(dir string) error {
 	for _, name := range names {
 		err = os.RemoveAll(filepath.Join(dir, name))
 		if err != nil {
-			agent.log.Error("Not able to clear the Fault files  ",err)
+			agent.log.Error("Not able to clear the Fault Files  ", err)
 			return err
 		}
 	}

--- a/pkg/hostagent/opflex_test.go
+++ b/pkg/hostagent/opflex_test.go
@@ -108,32 +108,32 @@ func TestDiscoverHostConfigMTUMismtach(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	agent := testAgent()
 	//assigning user defined MTU to be greater than the uplink MTU
-	agent.config.OpFlexFaultDir =  tempdir
+	agent.config.OpFlexFaultDir = tempdir
 	agent.config.InterfaceMtu = 2000
 	config := agent.discoverHostConfig()
 	assert.Nil(t, config, "Host config is not nil")
 }
 
 func TestOpFlexFaultDirRemoveAll(t *testing.T) {
-        tempdir, err := ioutil.TempDir("", "faultdir_test_")
-        if err != nil {
-                panic(err)
-        }
-        defer os.RemoveAll(tempdir)
-        agent := testAgent()
-        agent.config.OpFlexFaultDir = tempdir
-        agent.removeAllFiles(tempdir)
+	tempdir, err := ioutil.TempDir("", "faultdir_test_")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tempdir)
+	agent := testAgent()
+	agent.config.OpFlexFaultDir = tempdir
+	agent.removeAllFiles(tempdir)
 }
 
 func TestDiscoverHostIPNotSetForLink(t *testing.T) {
-        tempdir, err := ioutil.TempDir("", "faultdir_test_")
-        if err != nil {
-                panic(err)
-        }
-        defer os.RemoveAll(tempdir)
-        agent := testAgent()
-        agent.config.OpFlexFaultDir =  tempdir
-        agent.config.InterfaceMtu = 200
-        config := agent.discoverHostConfig()
-        assert.Nil(t, config, "Host config is not nil")
+	tempdir, err := ioutil.TempDir("", "faultdir_test_")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tempdir)
+	agent := testAgent()
+	agent.config.OpFlexFaultDir = tempdir
+	agent.config.InterfaceMtu = 200
+	config := agent.discoverHostConfig()
+	assert.Nil(t, config, "Host config is not nil")
 }

--- a/pkg/hostagent/opflex_test.go
+++ b/pkg/hostagent/opflex_test.go
@@ -99,3 +99,16 @@ func TestDiscoverHostConfigInvalidVlan(t *testing.T) {
 	config := agent.discoverHostConfig()
 	assert.Nil(t, config, "Host config is not nil")
 }
+
+func TestDiscoverHostConfigMTUMismtach(t *testing.T) {
+        tempdir, err := ioutil.TempDir("", "hostagent_test_")
+        if err != nil {
+                panic(err)
+        }
+        defer os.RemoveAll(tempdir)
+        agent := testAgent()
+        //assigning user defined MTU to be greater than the uplink MTU
+        agent.config.InterfaceMtu = 2000
+        config := agent.discoverHostConfig()
+        assert.Nil(t, config, "Host config is not nil")
+}

--- a/pkg/hostagent/opflex_test.go
+++ b/pkg/hostagent/opflex_test.go
@@ -101,14 +101,39 @@ func TestDiscoverHostConfigInvalidVlan(t *testing.T) {
 }
 
 func TestDiscoverHostConfigMTUMismtach(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "hostagent_test_")
+	tempdir, err := ioutil.TempDir("", "faultdir_test_")
 	if err != nil {
 		panic(err)
 	}
 	defer os.RemoveAll(tempdir)
 	agent := testAgent()
 	//assigning user defined MTU to be greater than the uplink MTU
+	agent.config.OpFlexFaultDir =  tempdir
 	agent.config.InterfaceMtu = 2000
 	config := agent.discoverHostConfig()
 	assert.Nil(t, config, "Host config is not nil")
+}
+
+func TestOpFlexFaultDirRemoveAll(t *testing.T) {
+        tempdir, err := ioutil.TempDir("", "faultdir_test_")
+        if err != nil {
+                panic(err)
+        }
+        defer os.RemoveAll(tempdir)
+        agent := testAgent()
+        agent.config.OpFlexFaultDir = tempdir
+        agent.removeAllFiles(tempdir)
+}
+
+func TestDiscoverHostIPNotSetForLink(t *testing.T) {
+        tempdir, err := ioutil.TempDir("", "faultdir_test_")
+        if err != nil {
+                panic(err)
+        }
+        defer os.RemoveAll(tempdir)
+        agent := testAgent()
+        agent.config.OpFlexFaultDir =  tempdir
+        agent.config.InterfaceMtu = 200
+        config := agent.discoverHostConfig()
+        assert.Nil(t, config, "Host config is not nil")
 }

--- a/pkg/hostagent/opflex_test.go
+++ b/pkg/hostagent/opflex_test.go
@@ -101,14 +101,14 @@ func TestDiscoverHostConfigInvalidVlan(t *testing.T) {
 }
 
 func TestDiscoverHostConfigMTUMismtach(t *testing.T) {
-        tempdir, err := ioutil.TempDir("", "hostagent_test_")
-        if err != nil {
-                panic(err)
-        }
-        defer os.RemoveAll(tempdir)
-        agent := testAgent()
-        //assigning user defined MTU to be greater than the uplink MTU
-        agent.config.InterfaceMtu = 2000
-        config := agent.discoverHostConfig()
-        assert.Nil(t, config, "Host config is not nil")
+	tempdir, err := ioutil.TempDir("", "hostagent_test_")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(tempdir)
+	agent := testAgent()
+	//assigning user defined MTU to be greater than the uplink MTU
+	agent.config.InterfaceMtu = 2000
+	config := agent.discoverHostConfig()
+	assert.Nil(t, config, "Host config is not nil")
 }


### PR DESCRIPTION
also added support to raise the fault if IP address not set for OpFlex link, not able to find suitable host uplink interface for vlan, not able to find parent link for OpFlex interface and Could not enumerate link addresses
Verified the changes on fabric if MTU exceeds fabric uplink MTU