### PR TITLE
Update Netflow MO POST to APIC

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -1095,11 +1095,10 @@ func NewVmmVSwitchPolicyCont(domainType string, domainName string) ApicObject {
 	return ret
 }
 
-func NewVmmRsVswitchExporterPol(domainType string, domainName string, tDn string) ApicObject {
+func NewVmmRsVswitchExporterPol(parentDn string, tDn string) ApicObject {
 	ret := newApicObject("vmmRsVswitchExporterPol")
 	ret["vmmRsVswitchExporterPol"].Attributes["tDn"] = tDn
 	ret["vmmRsVswitchExporterPol"].Attributes["dn"] =
-		fmt.Sprintf("uni/vmmp-%s/dom-%s/vswitchpolcont/rsvswitchExporterPol-[%s]",
-			domainType, domainName, tDn)
+		fmt.Sprintf("%s/rsvswitchExporterPol-[%s]", parentDn, tDn)
 	return ret
 }

--- a/pkg/apicapi/apic_types_test.go
+++ b/pkg/apicapi/apic_types_test.go
@@ -192,6 +192,6 @@ func TestTypes(t *testing.T) {
 		NewNetflowVmmExporterPol("testTan").GetDn())
 	assert.Equal(t, "uni/vmmp-Kubernetes/dom-k8s/vswitchpolcont",
 		NewVmmVSwitchPolicyCont("Kubernetes", "k8s").GetDn())
-	assert.Equal(t, "uni/vmmp-Kubernetes/dom-k8s/vswitchpolcont/rsvswitchExporterPol-[uni/infra/vmmexporterpol-testTan]",
-		NewVmmRsVswitchExporterPol("Kubernetes", "k8s", "uni/infra/vmmexporterpol-testTan").GetDn())
+	assert.Equal(t, "fake/dn/rsvswitchExporterPol-[uni/infra/vmmexporterpol-testTan]",
+		NewVmmRsVswitchExporterPol("fake/dn", "uni/infra/vmmexporterpol-testTan").GetDn())
 }

--- a/pkg/controller/netflow.go
+++ b/pkg/controller/netflow.go
@@ -148,7 +148,7 @@ func (cont *AciController) netflowPolObjs(nfp *netflowpolicy.NetflowPolicy) apic
 	if nfp.Spec.FlowSamplingPolicy.DstPort != 0 {
 		nf.SetAttr("dstPort", strconv.Itoa(nfp.Spec.FlowSamplingPolicy.DstPort))
 	} else {
-		nf.SetAttr("dstPort", "unspecified")
+		nf.SetAttr("dstPort", "2055")
 	}
 	if nfp.Spec.FlowSamplingPolicy.Version == "netflow" {
 		nf.SetAttr("ver", "v5")
@@ -159,7 +159,7 @@ func (cont *AciController) netflowPolObjs(nfp *netflowpolicy.NetflowPolicy) apic
 	}
 
 	VmmVSwitch := apicapi.NewVmmVSwitchPolicyCont(cont.vmmDomainProvider(), cont.config.AciVmmDomain)
-	RsVmmVSwitch := apicapi.NewVmmRsVswitchExporterPol(cont.vmmDomainProvider(), cont.config.AciVmmDomain, nfDn)
+	RsVmmVSwitch := apicapi.NewVmmRsVswitchExporterPol(VmmVSwitch.GetDn(), nfDn)
 	VmmVSwitch.AddChild(RsVmmVSwitch)
 	if nfp.Spec.FlowSamplingPolicy.ActiveFlowTimeOut != 0 {
 		RsVmmVSwitch.SetAttr("activeFlowTimeOut", strconv.Itoa(nfp.Spec.FlowSamplingPolicy.ActiveFlowTimeOut))
@@ -180,7 +180,7 @@ func (cont *AciController) netflowPolObjs(nfp *netflowpolicy.NetflowPolicy) apic
 
 	cont.log.Info("Netflow ApicSlice: ", apicSlice)
 
-	return apicapi.ApicSlice{nf, VmmVSwitch}
+	return apicapi.ApicSlice{nf, RsVmmVSwitch}
 
 }
 

--- a/pkg/controller/netflow_test.go
+++ b/pkg/controller/netflow_test.go
@@ -54,13 +54,13 @@ func makeNf(name string, dstAddr string, dstPort int,
 	nf1VmmVSwitch :=
 		apicapi.NewVmmVSwitchPolicyCont("Kubernetes", "")
 	nf1RsVmmVSwitch :=
-		apicapi.NewVmmRsVswitchExporterPol("Kubernetes", "", nf1.GetDn())
+		apicapi.NewVmmRsVswitchExporterPol(nf1VmmVSwitch.GetDn(), nf1.GetDn())
 	nf1VmmVSwitch.AddChild(nf1RsVmmVSwitch)
 	nf1RsVmmVSwitch.SetAttr("activeFlowTimeOut", strconv.Itoa(activeFlowTimeOut))
 	nf1RsVmmVSwitch.SetAttr("idleFlowTimeOut", strconv.Itoa(idleFlowTimeOut))
 	nf1RsVmmVSwitch.SetAttr("samplingRate", strconv.Itoa(samplingRate))
 
-	apicSlice = append(apicSlice, nf1VmmVSwitch)
+	apicSlice = append(apicSlice, nf1RsVmmVSwitch)
 
 	return apicSlice
 }
@@ -122,7 +122,7 @@ func TestNetflowPolicy(t *testing.T) {
 
 	var flowSamplingPolicy1 netflowpolicy.NetflowType
 	flowSamplingPolicy1.DstAddr = "172.51.1.2"
-	flowSamplingPolicy1.DstPort = 2055
+	flowSamplingPolicy1.DstPort = 0
 	flowSamplingPolicy1.Version = "ipfix"
 	flowSamplingPolicy1.ActiveFlowTimeOut = 0
 	flowSamplingPolicy1.IdleFlowTimeOut = 0

--- a/pkg/netflowpolicy/apis/aci.netflow/v1alpha/types.go
+++ b/pkg/netflowpolicy/apis/aci.netflow/v1alpha/types.go
@@ -23,19 +23,23 @@ type NetflowPolicySpec struct {
 	FlowSamplingPolicy NetflowType `json:"flowSamplingPolicy,omitempty"`
 }
 
-//NetflowType
+// NetflowType contains all the attrbutes of Netflow Policy.
 type NetflowType struct {
+	// Remote node destination IP address.
 	DstAddr string `json:"destIp"`
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=65535
 	DstPort int `json:"destPort"`
 	// +kubebuilder:validation:Enum=netflow,ipfix
+	// The Cisco Discovery Protocol (CDP) version supported by the device.
 	Version string `json:"flowType"`
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=3600
+	// Specifies the timeout for an active flow.
 	ActiveFlowTimeOut int `json:"activeFlowTimeOut"`
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=600
+	// Specifies the timeout for an idle flow.
 	IdleFlowTimeOut int `json:"idleFlowTimeOut"`
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
@@ -54,7 +58,7 @@ type NetflowPolicyStatus struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Policy is the Schema for the netflowpolicies API
+// NetflowPolicy is the Schema for the netflowpolicies API
 type NetflowPolicy struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
- POST only the child MO vmmRsVswitchExporterPol when writing to APIC.
- Set destination port to 2055 as a default.
- Add attribute descriptions in types.go

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com