### PR TITLE
ACI CNI base images

### DIFF
--- a/docker/Dockerfile-aci-containers-base
+++ b/docker/Dockerfile-aci-containers-base
@@ -1,0 +1,3 @@
+FROM registry.access.redhat.com/ubi8/ubi:latest
+RUN yum --disablerepo=\*ubi\* install -y curl
+CMD ["/usr/bin/sh"]

--- a/docker/Dockerfile-cnideploy
+++ b/docker/Dockerfile-cnideploy
@@ -1,7 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf --disablerepo=\*ubi\* install wget ca-certificates tar gzip \
-  && microdnf clean all \
-  && mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz | tar xz -C /opt/cni/bin
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-cnideploy-base:${basetag}
 # Required OpenShift Labels
 LABEL name="ACI CNI cnideploy" \
 vendor="Cisco" \
@@ -10,6 +9,6 @@ release="1" \
 summary="This is an ACI CNI cnideploy." \
 description="This operator will deploy a single instance of ACI CNI cnideploy."
 # Required Licenses
-COPY licenses /licenses
-COPY launch-cnideploy.sh /usr/local/bin/
+COPY docker/licenses /licenses
+COPY docker/launch-cnideploy.sh /usr/local/bin/
 CMD ["/usr/local/bin/launch-cnideploy.sh"]

--- a/docker/Dockerfile-cnideploy-base
+++ b/docker/Dockerfile-cnideploy-base
@@ -1,0 +1,7 @@
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-base:${basetag}
+RUN yum --disablerepo=\*ubi\* install -y wget ca-certificates tar gzip \
+  && yum clean all \
+  && mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz | tar xz -C /opt/cni/bin
+CMD ["/usr/bin/sh"]

--- a/docker/Dockerfile-controller
+++ b/docker/Dockerfile-controller
@@ -1,11 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* install -y curl \
-  && yum clean all \
-  && curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
-  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl \
-  && curl -sL "https://github.com/istio/istio/releases/download/1.6.5/istioctl-1.6.5-linux-amd64.tar.gz" | tar xz \
-  && chmod u+x istioctl && mv istioctl /usr/local/bin/istioctl \
-  && mkdir -p /usr/local/var/lib/aci-cni
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-controller-base:${basetag}
 # Required OpenShift Labels
 LABEL name="ACI CNI Containers Controller" \
 vendor="Cisco" \

--- a/docker/Dockerfile-controller-base
+++ b/docker/Dockerfile-controller-base
@@ -1,0 +1,9 @@
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-base:${basetag}
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
+  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl \
+  && curl -sL "https://github.com/istio/istio/releases/download/1.6.5/istioctl-1.6.5-linux-amd64.tar.gz" | tar xz \
+  && chmod u+x istioctl && mv istioctl /usr/local/bin/istioctl \
+  && mkdir -p /usr/local/var/lib/aci-cni
+CMD ["/usr/bin/sh"]

--- a/docker/Dockerfile-host
+++ b/docker/Dockerfile-host
@@ -1,7 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
-  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms --enablerepo codeready-builder-for-rhel-8-x86_64-rpms install -y iproute nftables openvswitch libnetfilter_conntrack-devel \
-  && yum clean all
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-host-base:${basetag}
 # Required OpenShift Labels
 LABEL name="ACI CNI Host-Agent" \
 vendor="Cisco" \
@@ -9,40 +8,6 @@ version="v1.0.0" \
 release="1" \
 summary="This is an ACI CNI Host-Agent." \
 description="This will deploy a single instance of ACI CNI Host-Agent."
-COPY dist-static/iptables-libs.tar.gz dist-static/iptables-bin.tar.gz dist-static/iptables-wrapper-installer.sh /tmp/
-RUN tar -zxf /tmp/iptables-bin.tar.gz -C /usr/sbin \
-  && tar -zxf /tmp/iptables-libs.tar.gz -C /lib64
-RUN for i in iptables-legacy iptables-legacy-restore iptables-legacy-save iptables iptables-restore iptables-save; \
-  do \
-  ln -s -f xtables-legacy-multi "/sbin/$i"; \
-  done;
-RUN for i in ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save ip6tables ip6tables-restore ip6tables-save; \
-  do \
-  ln -s -f xtables-legacy-multi "/sbin/$i"; \
-  done;
-RUN for i in iptables-nft iptables-nft-restore iptables-nft-save ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
-  iptables-translate ip6tables-translate iptables-restore-translate ip6tables-restore-translate \
-  arptables-nft arptables arptables-nft-restore arptables-restore arptables-nft-save arptables-save \
-  ebtables-nft ebtables ebtables-nft-restore ebtables-restore ebtables-nft-save ebtables-save xtables-monitor; \
-  do \
-  ln -s -f xtables-nft-multi "/sbin/$i"; \
-  done;
-# Add iptables alternatives at lowst priority before running wrappers
-RUN alternatives --install /usr/sbin/iptables iptables /usr/sbin/iptables-legacy 1 \
-                 --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-legacy-restore \
-                 --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-legacy-save \
-                 --slave /usr/sbin/ip6tables ip6tables /usr/sbin/ip6tables-legacy \
-                 --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/ip6tables-legacy-restore \
-                 --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/ip6tables-legacy-save \
- && alternatives --install /usr/sbin/iptables iptables /usr/sbin/iptables-nft 1 \
-                 --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-nft-restore \
-                 --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-nft-save \
-                 --slave /usr/sbin/ip6tables ip6tables /usr/sbin/ip6tables-nft \
-                 --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/ip6tables-nft-restore \
-                 --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/ip6tables-nft-save
-# Add iptables-wrapper alternative at prio 100 that would
-# at run time use one of the above alternatives installed
-RUN /tmp/iptables-wrapper-installer.sh
 # Required Licenses
 COPY docker/licenses /licenses
 COPY dist-static/aci-containers-host-agent dist-static/opflex-agent-cni docker/launch-hostagent.sh docker/enable-hostacc.sh docker/enable-droplog.sh /usr/local/bin/

--- a/docker/Dockerfile-host-base
+++ b/docker/Dockerfile-host-base
@@ -1,0 +1,41 @@
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-base:${basetag}
+RUN yum --disablerepo=\*ubi\* --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms --enablerepo codeready-builder-for-rhel-8-x86_64-rpms install -y iproute nftables openvswitch libnetfilter_conntrack-devel \
+  && yum clean all
+COPY dist-static/iptables-libs.tar.gz dist-static/iptables-bin.tar.gz dist-static/iptables-wrapper-installer.sh /tmp/
+RUN tar -zxf /tmp/iptables-bin.tar.gz -C /usr/sbin \
+  && tar -zxf /tmp/iptables-libs.tar.gz -C /lib64
+RUN for i in iptables-legacy iptables-legacy-restore iptables-legacy-save iptables iptables-restore iptables-save; \
+  do \
+  ln -s -f xtables-legacy-multi "/sbin/$i"; \
+  done;
+RUN for i in ip6tables-legacy ip6tables-legacy-restore ip6tables-legacy-save ip6tables ip6tables-restore ip6tables-save; \
+  do \
+  ln -s -f xtables-legacy-multi "/sbin/$i"; \
+  done;
+RUN for i in iptables-nft iptables-nft-restore iptables-nft-save ip6tables-nft ip6tables-nft-restore ip6tables-nft-save \
+  iptables-translate ip6tables-translate iptables-restore-translate ip6tables-restore-translate \
+  arptables-nft arptables arptables-nft-restore arptables-restore arptables-nft-save arptables-save \
+  ebtables-nft ebtables ebtables-nft-restore ebtables-restore ebtables-nft-save ebtables-save xtables-monitor; \
+  do \
+  ln -s -f xtables-nft-multi "/sbin/$i"; \
+  done;
+# Add iptables alternatives at lowst priority before running wrappers
+RUN alternatives --install /usr/sbin/iptables iptables /usr/sbin/iptables-legacy 1 \
+                 --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-legacy-restore \
+                 --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-legacy-save \
+                 --slave /usr/sbin/ip6tables ip6tables /usr/sbin/ip6tables-legacy \
+                 --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/ip6tables-legacy-restore \
+                 --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/ip6tables-legacy-save \
+ && alternatives --install /usr/sbin/iptables iptables /usr/sbin/iptables-nft 1 \
+                 --slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-nft-restore \
+                 --slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-nft-save \
+                 --slave /usr/sbin/ip6tables ip6tables /usr/sbin/ip6tables-nft \
+                 --slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/ip6tables-nft-restore \
+                 --slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/ip6tables-nft-save
+# Add iptables-wrapper alternative at prio 100 that would
+# at run time use one of the above alternatives installed
+RUN /tmp/iptables-wrapper-installer.sh
+CMD ["/usr/bin/sh"]

--- a/docker/Dockerfile-openvswitch
+++ b/docker/Dockerfile-openvswitch
@@ -1,7 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
-  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms openvswitch2.13 logrotate conntrack-tools \
-  tcpdump curl strace ltrace iptables net-tools && yum clean all
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-openvswitch-base:${basetag}
 # Required OpenShift Labels
 LABEL name="ACI CNI Openvswitch" \
 vendor="Cisco" \

--- a/docker/Dockerfile-openvswitch-base
+++ b/docker/Dockerfile-openvswitch-base
@@ -1,0 +1,7 @@
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-base:${basetag}
+RUN yum install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+  --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms openvswitch2.13 logrotate conntrack-tools \
+  tcpdump curl strace ltrace iptables net-tools && yum clean all
+CMD ["/usr/bin/sh"]

--- a/docker/Dockerfile-operator
+++ b/docker/Dockerfile-operator
@@ -1,8 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* install -y curl git \
-  && yum clean all \
-  && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.6/bin/linux/amd64/kubectl \
-  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-operator-base:${basetag}
 # Required OpenShift Labels
 LABEL name="ACI CNI Operator" \
 vendor="Cisco" \

--- a/docker/Dockerfile-operator-base
+++ b/docker/Dockerfile-operator-base
@@ -1,0 +1,8 @@
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-base:${basetag}
+RUN yum --disablerepo=\*ubi\* install -y curl git \
+  && yum clean all \
+  && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.6/bin/linux/amd64/kubectl \
+  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
+CMD ["/usr/bin/sh"]


### PR DESCRIPTION
We are introducing the following layered hierarchy for
the ACI CNI images:

aci-containers-base
aci-containers-\<component\>-base
aci-containers-\<component\>

with the goal of:

a. Normalizing the ACI CNI common packages
of the current images into a common base, and
such additional packages can be added in one
common image layer as opposed to being added
independently in each component image (this goes
into the aci-containers-base image)

b. Identifying the static parts of the component-
specific images such that they are not required to
pulled everytime (this goes into the
aci-containers-\<component\>-base image which builds
on top of the aci-containers-base image)

The ACI CNI compiled artifacts go into the final
aci-containers-\<component\> image which builds
on top of the above two.

The base images need to be built less frequently
and can be cached thus substantially reducing the
final image build time in the CI setup.

This approach is similar to what has already been
adopted for the opflex container.

In this PR only the Dockerfiles for images used in the
on-prem deployment are being updated.