### PR TITLE
Service interfaceIP is not udated properly

### DIFF
--- a/pkg/hostagent/nodes.go
+++ b/pkg/hostagent/nodes.go
@@ -115,6 +115,12 @@ func (agent *HostAgent) nodeChanged(obj interface{}) {
 				"epval": epval,
 			}).Info("Updated service endpoint")
 			agent.serviceEp = newServiceEp
+			// this case can be posible when there is a default snatpolicy present
+			// And nodeinfo service EP is not annotated
+			if _, ok := agent.opflexServices[SnatService]; ok {
+				agent.opflexServices[SnatService].InterfaceIp = agent.serviceEp.Ipv4.String()
+				agent.log.Infof("Updated Snat service-ext file: %s", agent.serviceEp.Ipv4.String())
+			}
 			updateServices = true
 		}
 	}


### PR DESCRIPTION
if the default snatpolicy is present and  node gets added  and
the node is still not annonted with ServiceEP data. then we are setting the
Snat external file with nil IP.
to handle the above scenario we are setting the explicitly if we see node annotation changes