### PR TITLE
Adding OSP-4.6-openstack flavor to aci-containers-operator

### DIFF
--- a/pkg/controller/acicontainersoperator.go
+++ b/pkg/controller/acicontainersoperator.go
@@ -88,6 +88,7 @@ var Version = map[string]bool{
 	"openshift-4.4-esx":       true,
 	"openshift-4.4-openstack": true,
 	"openshift-4.5-openstack": true,
+	"openshift-4.6-openstack": true,
 	"openshift-4.5-esx":       true,
 }
 var Dnsoper = map[string]bool{


### PR DESCRIPTION
(cherry picked from commit 3d67878caa36d30cc56a36cfadbd12ca0e6da0b3)