### PR TITLE
Removing the disabling of the ubi8 repo

### DIFF
--- a/docker/Dockerfile-aci-containers-base
+++ b/docker/Dockerfile-aci-containers-base
@@ -1,3 +1,3 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
-RUN yum --disablerepo=\*ubi\* install -y curl
+RUN yum install -y curl
 CMD ["/usr/bin/sh"]

--- a/docker/Dockerfile-cnideploy-base
+++ b/docker/Dockerfile-cnideploy-base
@@ -1,7 +1,7 @@
 ARG basetag=latest
 ARG baserepo=quay.io/noirolabs
 FROM ${baserepo}/aci-containers-base:${basetag}
-RUN yum --disablerepo=\*ubi\* install -y wget ca-certificates tar gzip \
+RUN yum install -y wget ca-certificates tar gzip \
   && yum clean all \
   && mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz | tar xz -C /opt/cni/bin
 CMD ["/usr/bin/sh"]

--- a/docker/Dockerfile-host-base
+++ b/docker/Dockerfile-host-base
@@ -1,7 +1,7 @@
 ARG basetag=latest
 ARG baserepo=quay.io/noirolabs
 FROM ${baserepo}/aci-containers-base:${basetag}
-RUN yum --disablerepo=\*ubi\* --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+RUN yum --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
   --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms --enablerepo codeready-builder-for-rhel-8-x86_64-rpms install -y iproute nftables openvswitch libnetfilter_conntrack-devel \
   && yum clean all
 COPY dist-static/iptables-libs.tar.gz dist-static/iptables-bin.tar.gz dist-static/iptables-wrapper-installer.sh /tmp/

--- a/docker/Dockerfile-operator-base
+++ b/docker/Dockerfile-operator-base
@@ -1,7 +1,7 @@
 ARG basetag=latest
 ARG baserepo=quay.io/noirolabs
 FROM ${baserepo}/aci-containers-base:${basetag}
-RUN yum --disablerepo=\*ubi\* install -y curl git \
+RUN yum install -y git \
   && yum clean all \
   && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.14.6/bin/linux/amd64/kubectl \
   && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl

--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -1,7 +1,7 @@
 ARG basetag=latest
 ARG baserepo=quay.io/noirolabs
 FROM ${baserepo}/aci-containers-base:${basetag}
-RUN yum --disablerepo=\*ubi\* install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
+RUN yum install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
   --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms libstdc++ libuv \
   boost-program-options boost-system boost-date-time boost-filesystem \
   boost-iostreams libnetfilter_conntrack openssl net-tools procps-ng ca-certificates \


### PR DESCRIPTION
It was disabled earlier due to issues with reachability
but this has been fixed with the relevant subscription-manager
configuration on the build hosts and also ensuring the correct
setting of the proxy args.

Enabling the repo allows pulling the relevant packages from the
ubi8 repo.