### PR TITLE
Using base image for gbp and opflex containers

### DIFF
--- a/docker/Dockerfile-gbpserver
+++ b/docker/Dockerfile-gbpserver
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-base:${basetag}
 COPY dist-static/gbpserver /usr/local/bin/
 # Required OpenShift Labels
 LABEL name="ACI CNI gbpserver" \

--- a/docker/Dockerfile-gbpserver-batch
+++ b/docker/Dockerfile-gbpserver-batch
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-base:${basetag}
 COPY dist-static/gbpserver /usr/local/bin/
 # Required OpenShift Labels
 LABEL name="ACI CNI gbpserver" \

--- a/docker/Dockerfile-opflex
+++ b/docker/Dockerfile-opflex
@@ -1,4 +1,6 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+ARG basetag=latest
+ARG baserepo=quay.io/noirolabs
+FROM ${baserepo}/aci-containers-base:${basetag}
 RUN yum --disablerepo=\*ubi\* install -y --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
   --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms libstdc++ libuv \
   boost-program-options boost-system boost-date-time boost-filesystem \


### PR DESCRIPTION
Which was introduced in this commit:
8dff164c1c80e707fee616c6116553044f8e0047