### PR TITLE
Check APIC version for netflow policy

### DIFF
--- a/pkg/controller/netflow.go
+++ b/pkg/controller/netflow.go
@@ -150,12 +150,15 @@ func (cont *AciController) netflowPolObjs(nfp *netflowpolicy.NetflowPolicy) apic
 	} else {
 		nf.SetAttr("dstPort", "2055")
 	}
-	if nfp.Spec.FlowSamplingPolicy.Version == "netflow" {
-		nf.SetAttr("ver", "v5")
-	} else if nfp.Spec.FlowSamplingPolicy.Version == "ipfix" {
-		nf.SetAttr("ver", "v9")
-	} else {
-		nf.SetAttr("ver", "v5")
+	// Ability to set netflow "version" attribute is available only for APIC versions >= 5.0(x)
+	if apicapi.ApicVersion >= "5.0" {
+		if nfp.Spec.FlowSamplingPolicy.Version == "netflow" {
+			nf.SetAttr("ver", "v5")
+		} else if nfp.Spec.FlowSamplingPolicy.Version == "ipfix" {
+			nf.SetAttr("ver", "v9")
+		} else {
+			nf.SetAttr("ver", "v5")
+		}
 	}
 
 	VmmVSwitch := apicapi.NewVmmVSwitchPolicyCont(cont.vmmDomainProvider(), cont.config.AciVmmDomain)

--- a/pkg/controller/netflow_test.go
+++ b/pkg/controller/netflow_test.go
@@ -50,7 +50,9 @@ func makeNf(name string, dstAddr string, dstPort int,
 	apicSlice := apicapi.ApicSlice{nf1}
 	nf1.SetAttr("dstAddr", dstAddr)
 	nf1.SetAttr("dstPort", strconv.Itoa(dstPort))
-	nf1.SetAttr("ver", ver)
+	if apicapi.ApicVersion >= "5.0" {
+		nf1.SetAttr("ver", ver)
+	}
 	nf1VmmVSwitch :=
 		apicapi.NewVmmVSwitchPolicyCont("Kubernetes", "")
 	nf1RsVmmVSwitch :=


### PR DESCRIPTION
Ability to set netflow "version" attribute is available only for APIC versions >= 5.0(x). This patch adds the APIC version check.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com