### PR TITLE
Handle APIC version < 5.0 - netflow CRD

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -860,7 +860,6 @@ var metadata = map[string]*apicMeta{
 	"netflowVmmExporterPol": {
 		attributes: map[string]interface{}{
 			"name":    "",
-			"ver":     "v5",
 			"dstAddr": "",
 			"dstPort": "unspecified",
 		},

--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -860,8 +860,9 @@ var metadata = map[string]*apicMeta{
 	"netflowVmmExporterPol": {
 		attributes: map[string]interface{}{
 			"name":    "",
+			"ver":     "v5",
 			"dstAddr": "",
-			"dstPort": "unspecified",
+			"dstPort": "2055",
 		},
 		children: []string{},
 	},

--- a/pkg/controller/netflow.go
+++ b/pkg/controller/netflow.go
@@ -202,6 +202,7 @@ func (cont *AciController) handleNetflowPolUpdate(obj interface{}) bool {
 	}
 	labelKey := cont.aciNameForKey("nfp", key)
 	cont.apicConn.WriteApicObjects(labelKey, cont.netflowPolObjs(nfp))
+	cont.log.Debug("netflow object: ", nfp)
 
 	return false
 }

--- a/pkg/controller/netflow.go
+++ b/pkg/controller/netflow.go
@@ -183,7 +183,7 @@ func (cont *AciController) netflowPolObjs(nfp *netflowpolicy.NetflowPolicy) apic
 
 	cont.log.Info("Netflow ApicSlice: ", apicSlice)
 
-	return apicapi.ApicSlice{nf, RsVmmVSwitch}
+	return apicapi.ApicSlice{nf, VmmVSwitch}
 
 }
 

--- a/pkg/controller/netflow.go
+++ b/pkg/controller/netflow.go
@@ -150,15 +150,17 @@ func (cont *AciController) netflowPolObjs(nfp *netflowpolicy.NetflowPolicy) apic
 	} else {
 		nf.SetAttr("dstPort", "2055")
 	}
-	// Ability to set netflow "version" attribute is available only for APIC versions >= 5.0(x)
-	if apicapi.ApicVersion >= "5.0" {
-		if nfp.Spec.FlowSamplingPolicy.Version == "netflow" {
-			nf.SetAttr("ver", "v5")
-		} else if nfp.Spec.FlowSamplingPolicy.Version == "ipfix" {
-			nf.SetAttr("ver", "v9")
-		} else {
-			nf.SetAttr("ver", "v5")
-		}
+	// Ability to configure Netflow Policy is available only in APIC versions >= 5.0(x).
+	// In APIC versions < 5.0(x), Netflow VMM Exporter Policy can be associated with VMware domains only.
+	if apicapi.ApicVersion < "5.0" {
+		cont.log.Error("Cannot create Netflow Policy in APIC versions < 5.0(x). Actual APIC version: ", apicapi.ApicVersion)
+	}
+	if nfp.Spec.FlowSamplingPolicy.Version == "netflow" {
+		nf.SetAttr("ver", "v5")
+	} else if nfp.Spec.FlowSamplingPolicy.Version == "ipfix" {
+		nf.SetAttr("ver", "v9")
+	} else {
+		nf.SetAttr("ver", "v5")
 	}
 
 	VmmVSwitch := apicapi.NewVmmVSwitchPolicyCont(cont.vmmDomainProvider(), cont.config.AciVmmDomain)
@@ -202,7 +204,6 @@ func (cont *AciController) handleNetflowPolUpdate(obj interface{}) bool {
 	}
 	labelKey := cont.aciNameForKey("nfp", key)
 	cont.apicConn.WriteApicObjects(labelKey, cont.netflowPolObjs(nfp))
-	cont.log.Debug("netflow object: ", nfp)
 
 	return false
 }

--- a/pkg/controller/netflow_test.go
+++ b/pkg/controller/netflow_test.go
@@ -62,7 +62,7 @@ func makeNf(name string, dstAddr string, dstPort int,
 	nf1RsVmmVSwitch.SetAttr("idleFlowTimeOut", strconv.Itoa(idleFlowTimeOut))
 	nf1RsVmmVSwitch.SetAttr("samplingRate", strconv.Itoa(samplingRate))
 
-	apicSlice = append(apicSlice, nf1RsVmmVSwitch)
+	apicSlice = append(apicSlice, nf1VmmVSwitch)
 
 	return apicSlice
 }

--- a/pkg/controller/netflow_test.go
+++ b/pkg/controller/netflow_test.go
@@ -50,9 +50,7 @@ func makeNf(name string, dstAddr string, dstPort int,
 	apicSlice := apicapi.ApicSlice{nf1}
 	nf1.SetAttr("dstAddr", dstAddr)
 	nf1.SetAttr("dstPort", strconv.Itoa(dstPort))
-	if apicapi.ApicVersion >= "5.0" {
-		nf1.SetAttr("ver", ver)
-	}
+	nf1.SetAttr("ver", ver)
 	nf1VmmVSwitch :=
 		apicapi.NewVmmVSwitchPolicyCont("Kubernetes", "")
 	nf1RsVmmVSwitch :=

--- a/pkg/netflowpolicy/apis/aci.netflow/v1alpha/types.go
+++ b/pkg/netflowpolicy/apis/aci.netflow/v1alpha/types.go
@@ -32,18 +32,22 @@ type NetflowType struct {
 	DstPort int `json:"destPort"`
 	// +kubebuilder:validation:Enum=netflow,ipfix
 	// The Cisco Discovery Protocol (CDP) version supported by the device.
-	Version string `json:"flowType"`
+	// +optional
+	Version string `json:"flowType,omitempty"`
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=3600
 	// Specifies the timeout for an active flow.
-	ActiveFlowTimeOut int `json:"activeFlowTimeOut"`
+	// +optional
+	ActiveFlowTimeOut int `json:"activeFlowTimeOut,omitempty"`
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=600
 	// Specifies the timeout for an idle flow.
-	IdleFlowTimeOut int `json:"idleFlowTimeOut"`
+	// +optional
+	IdleFlowTimeOut int `json:"idleFlowTimeOut,omitempty"`
 	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=1000
-	SamplingRate int `json:"samplingRate"`
+	// +optional
+	SamplingRate int `json:"samplingRate,omitempty"`
 }
 
 // NetflowPolicyStatus defines the observed state of NetflowPolicy

--- a/pkg/netflowpolicy/clientset/versioned/fake/register.go
+++ b/pkg/netflowpolicy/clientset/versioned/fake/register.go
@@ -28,7 +28,7 @@ import (
 
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
-var parameterCodec = runtime.NewParameterCodec(scheme)
+
 var localSchemeBuilder = runtime.SchemeBuilder{
 	aciv1alpha.AddToScheme,
 }

--- a/pkg/netflowpolicy/listers/aci.netflow/v1alpha/netflowpolicy.go
+++ b/pkg/netflowpolicy/listers/aci.netflow/v1alpha/netflowpolicy.go
@@ -25,10 +25,13 @@ import (
 )
 
 // NetflowPolicyLister helps list NetflowPolicies.
+// All objects returned here must be treated as read-only.
 type NetflowPolicyLister interface {
 	// List lists all NetflowPolicies in the indexer.
+	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1alpha.NetflowPolicy, err error)
 	// Get retrieves the NetflowPolicy from the index for a given name.
+	// Objects returned here must be treated as read-only.
 	Get(name string) (*v1alpha.NetflowPolicy, error)
 	NetflowPolicyListerExpansion
 }


### PR DESCRIPTION
- For APIC version <5.0, the Netflow attribute "version" is not present. This patch removes "ver" from apic_metadata so that it does not use that attribute to build the netflow object.
- Added omitempty struct tag for optional attributes to mark that a field should be omitted from serialization when empty.
- Also added vmmVSwitchPolicyCont in the POST to APIC, since it does not always get created automatically.

- UPDATE: In APIC versions < 5.0(x), Netflow VMM Exporter Policy can be associated with VMware domains only.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com