### PR TITLE
podifs should always be created now

### DIFF
--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -186,20 +186,17 @@ func NewHostAgent(config *HostAgentConfig, env Environment, log *logrus.Logger) 
 		"rdconfig":      ha.syncRdConfig,
 		"snatLocalInfo": ha.UpdateLocalInfoCr}
 
-	if ha.config.EPRegistry == "k8s" {
-		cfg, err := rest.InClusterConfig()
-		if err != nil {
-			log.Errorf("ERROR getting cluster config: %v", err)
-			return ha
-		}
-		aciawClient, err := crdclientset.NewForConfig(cfg)
-		if err != nil {
-			log.Errorf("ERROR getting crd client for registry: %v", err)
-			return ha
-		}
-
-		ha.crdClient = aciawClient.AciV1()
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		log.Errorf("ERROR getting cluster config: %v", err)
+		return ha
 	}
+	aciawClient, err := crdclientset.NewForConfig(cfg)
+	if err != nil {
+		log.Errorf("ERROR getting crd client for registry: %v", err)
+		return ha
+	}
+	ha.crdClient = aciawClient.AciV1()
 	return ha
 }
 


### PR DESCRIPTION
Originally podifs were only used in overlay cases
to help populate the EP registry. Now it's used
to enable on-prem features like ERSPAN as well
so remove the guard.

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>