### PR TITLE
Update goveralls to v.0.0.8

### DIFF
--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -309,7 +309,7 @@ github.com/magiconair/properties
 github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
-# github.com/mattn/goveralls v0.0.7
+# github.com/mattn/goveralls v0.0.8
 ## explicit
 # github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369
 github.com/matttproud/golang_protobuf_extensions/pbutil


### PR DESCRIPTION
- Travis builds were failing consistently with goveralls v0.0.0.7

Error seen "go: inconsistent vendoring in /home/travis/gopath/src/github.com/noironetworks/aci-containers:
github.com/mattn/goveralls@v0.0.8: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt"

- Update goveralls to v0.0.0.8

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com