### PR TITLE
ERSPAN sync with opflex devices

### DIFF
--- a/pkg/controller/erspan.go
+++ b/pkg/controller/erspan.go
@@ -217,6 +217,9 @@ func (cont *AciController) erspanPolicyDeleted(obj interface{}) {
 }
 
 func (cont *AciController) erspanSyncOpflexDev() {
+	if cont.erspanIndexer == nil {
+		return
+	}
 	cache.ListAll(cont.erspanIndexer, labels.Everything(),
 		func(spanObj interface{}) {
 			cont.queueErspanUpdate(spanObj.(*erspanpolicy.ErspanPolicy))

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -984,6 +984,7 @@ func (cont *AciController) opflexDeviceChanged(obj apicapi.ApicObject) {
 
 		for _, node := range nodeUpdates {
 			cont.env.NodeServiceChanged(node)
+			cont.erspanSyncOpflexDev()
 		}
 		cont.updateDeviceCluster()
 
@@ -1017,6 +1018,7 @@ func (cont *AciController) opflexDeviceDeleted(dn string) {
 		cont.updateDeviceCluster()
 		for _, node := range nodeUpdates {
 			cont.env.NodeServiceChanged(node)
+			cont.erspanSyncOpflexDev()
 		}
 	}
 }


### PR DESCRIPTION
- ERSPAN object needs to sync with every opflex device change, since it uses the vpcs to build Rs objects.
- Added error checking when erspanIndexer is nil.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com