### PR TITLE
Remove explicit default settings in netflow and erspan

### DIFF
--- a/cmd/crd-example/erspan-CR.yaml
+++ b/cmd/crd-example/erspan-CR.yaml
@@ -9,8 +9,8 @@ spec:
       app: consul
     namespace: default
   source:
-    admin_state: "start"
+    adminState: "start"
     direction: "both"
   destination:
-    destIp: "1.1.1.1"
-    flowId: 1
+    destIP: "1.1.1.1"
+    flowID: 1

--- a/pkg/controller/erspan.go
+++ b/pkg/controller/erspan.go
@@ -247,18 +247,10 @@ func (cont *AciController) buildErspanObjs(span *erspanpolicy.ErspanPolicy) apic
 	srcGrp := apicapi.NewSpanVSrcGrp(labelKey)
 	srcName := labelKey + "_Src"
 	apicSlice := apicapi.ApicSlice{srcGrp}
-	if span.Spec.Source.AdminState != "" {
-		srcGrp.SetAttr("adminSt", span.Spec.Source.AdminState)
-	} else {
-		srcGrp.SetAttr("adminSt", "start")
-	}
+	srcGrp.SetAttr("adminSt", span.Spec.Source.AdminState)
 	src := apicapi.NewSpanVSrc(srcGrp.GetDn(), srcName)
 	srcGrp.AddChild(src)
-	if span.Spec.Source.Direction != "" {
-		src.SetAttr("dir", span.Spec.Source.Direction)
-	} else {
-		src.SetAttr("dir", "both")
-	}
+	src.SetAttr("dir", span.Spec.Source.Direction)
 
 	// Build fvCEp for matching pods
 	cont.indexMutex.Lock()
@@ -287,11 +279,7 @@ func (cont *AciController) buildErspanObjs(span *erspanpolicy.ErspanPolicy) apic
 	destSummary := apicapi.NewSpanVEpgSummary(dest.GetDn())
 	dest.AddChild(destSummary)
 	destSummary.SetAttr("dstIp", span.Spec.Dest.DestIP)
-	if span.Spec.Dest.FlowID != 0 {
-		destSummary.SetAttr("flowId", strconv.Itoa(span.Spec.Dest.FlowID))
-	} else {
-		destSummary.SetAttr("flowId", "1")
-	}
+	destSummary.SetAttr("flowId", strconv.Itoa(span.Spec.Dest.FlowID))
 	apicSlice = append(apicSlice, destGrp)
 
 	// Erspan policy binding to Virtual Port Channels.

--- a/pkg/controller/netflow_test.go
+++ b/pkg/controller/netflow_test.go
@@ -122,11 +122,7 @@ func TestNetflowPolicy(t *testing.T) {
 
 	var flowSamplingPolicy1 netflowpolicy.NetflowType
 	flowSamplingPolicy1.DstAddr = "172.51.1.2"
-	flowSamplingPolicy1.DstPort = 0
 	flowSamplingPolicy1.FlowType = "ipfix"
-	flowSamplingPolicy1.ActiveFlowTimeOut = 0
-	flowSamplingPolicy1.IdleFlowTimeOut = 0
-	flowSamplingPolicy1.SamplingRate = 0
 
 	var flowSamplingPolicy2 netflowpolicy.NetflowType
 	flowSamplingPolicy2.DstAddr = "172.51.1.2"
@@ -140,7 +136,7 @@ func TestNetflowPolicy(t *testing.T) {
 		{testnetflowpolicy("testnf", flowSamplingPolicy0),
 			makeNf(name, "172.51.1.2", 2055, "v5", 5, 5, 400), nil, "test1", false, true},
 		{testnetflowpolicy("testnf", flowSamplingPolicy1),
-			makeNf(name, "172.51.1.2", 2055, "v9", 60, 15, 0), nil, "test2", false, true},
+			makeNf(name, "172.51.1.2", 0, "v9", 0, 0, 0), nil, "test2", false, true},
 		{testnetflowpolicy("testnf", flowSamplingPolicy2),
 			makeNf(name, "172.51.1.2", 2056, "v5", 60, 15, 0), nil, "test3", false, true},
 	}

--- a/pkg/erspanpolicy/apis/aci.erspan/v1alpha/types.go
+++ b/pkg/erspanpolicy/apis/aci.erspan/v1alpha/types.go
@@ -31,10 +31,12 @@ type ErspanSourceType struct {
 	// +kubebuilder:validation:Enum=start,stop
 	// Administrative state.
 	// +optional
+	// +kubebuilder:default:=start
 	AdminState string `json:"adminState,omitempty"`
 	// +kubebuilder:validation:Enum=in,out,both
 	// The direction of the packets to monitor.
 	// +optional
+	// +kubebuilder:default:=both
 	Direction string `json:"direction,omitempty"`
 }
 
@@ -46,6 +48,7 @@ type ErspanDestType struct {
 	// +kubebuilder:validation:Maximum=1023
 	// The unique flow ID of the ERSPAN packet.
 	// +optional
+	// +kubebuilder:default:=1
 	FlowID int `json:"flowID,omitempty"`
 }
 


### PR DESCRIPTION
- The default values are set in the CRD and there is no need to set it explicitly in the code.
- Updated ERSPAN CR example

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com