### PR TITLE
Allocating multiple IPv6 addrs per pod

### DIFF
--- a/pkg/hostagent/ipam.go
+++ b/pkg/hostagent/ipam.go
@@ -154,19 +154,10 @@ func (agent *HostAgent) allocateIps(iface *metadata.ContainerIfaceMd, podKey str
 
 	for _, nc := range agent.config.NetConfig {
 		if nc.Subnet.IP != nil {
-			var ip net.IP
 			if nc.Subnet.IP.To4() != nil {
 				allocIP(true, &nc)
 			} else if nc.Subnet.IP.To16() != nil {
 				allocIP(false, &nc)
-				ip, err = agent.podIps.AllocateIp(false)
-				if err != nil {
-					result =
-						fmt.Errorf("Could not allocate IPv6 address: %v", err)
-				} else {
-					iface.IPs =
-						append(iface.IPs, makeIFaceIp(&nc, ip))
-				}
 			}
 		}
 	}


### PR DESCRIPTION
Issue was introduced by an earlier refactoring. IPv4 allocation
was updated correctly but IPv6 allocation uses both new/old styles

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>