### PR TITLE
Openshift cluster Pod mac address is set to default.

### DIFF
--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -291,12 +291,10 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 				return nil, err
 			}
 		}
-
 		for _, ip := range iface.IPs {
 			//There are 4 cases: IPv4-only, IPv6-only, dual stack with either IPv4 or IPv6 as the first address.
-			//We are guaranteed to derive the MAC address from the IPv4 address in the IPv4-only case.
-
-			if ip.Address.IP != nil {
+			//We are guaranteed to derive the MAC address from IPv4 if it is assigned
+			if ip.Address.IP != nil && ip.Address.IP.To4() != nil {
 				iface.HostVethName, iface.Mac, err =
 					runSetupVeth(iface.Sandbox, iface.Name, mtu, ip.Address.IP)
 				if err != nil {
@@ -304,6 +302,14 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 				} else {
 					break
 				}
+			}
+		}
+		// if no mac is assigned, set it to the default Mac.
+		if len(iface.Mac) == 0 {
+			iface.HostVethName, iface.Mac, err =
+				runSetupVeth(iface.Sandbox, iface.Name, agent.config.InterfaceMtu, nil)
+			if err != nil {
+				return nil, err
 			}
 		}
 


### PR DESCRIPTION
Pod is coming up with link-local ipv6 address along with V4 address
allocated by ACICNI, due to that when mac address is getting allocated V6 chosen as choice sometimes,
so that the default mac address is set

(cherry picked from commit 2b0ded14458b2f52dbb697f234744148685938bc)