### PR TITLE
Stop sending topRoot directly to opflex-server

### DIFF
--- a/pkg/gbpserver/gbp.go
+++ b/pkg/gbpserver/gbp.go
@@ -725,7 +725,9 @@ func getSnapShot(vtep string) []*GBPObject {
 
 	var keys []string
 	for k := range moMap {
-		keys = append(keys, k)
+		if len(k) > 1 { // skip topRoot
+			keys = append(keys, k)
+		}
 	}
 
 	sort.Strings(keys)
@@ -759,8 +761,6 @@ func DoAll() {
 	}
 
 	saveDBToFile()
-
-	//	fmt.Printf("policy.json: %s", policyJson)
 }
 func invToCommon(vtep string) map[string]*gbpCommonMo {
 	moMap := make(map[string]*gbpCommonMo)

--- a/pkg/gbpserver/gbp_common.go
+++ b/pkg/gbpserver/gbp_common.go
@@ -547,8 +547,6 @@ func CreateRoot(config *GBPServerConfig) {
 	}
 
 	rootChildren := []string{
-		"RelatorUniverse",
-		"GbpeVMUniverse",
 		"DomainConfig",
 		"InvUniverse",
 		"PolicyUniverse",

--- a/pkg/gbpserver/grpc_server.go
+++ b/pkg/gbpserver/grpc_server.go
@@ -99,7 +99,7 @@ func (gw *gbpWatch) ListObjects(v *Version, ss GBP_ListObjectsServer) error {
 		for _, url := range urls {
 			if strings.Contains(url, "InvRemoteInventoryEp") {
 				moList = append(moList, getInvSubTree(url, peerVtep)...)
-			} else {
+			} else if len(url) > 1 { // skip topRoot
 				moList = append(moList, getMoSubTree(url)...)
 			}
 		}

--- a/pkg/gbpserver/integ_test.go
+++ b/pkg/gbpserver/integ_test.go
@@ -828,8 +828,13 @@ func verifyPolicy(t *testing.T, moMap map[string]*GBPObject) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, len(moList), len(moMap))
+	// we explicitly remove topRoot from map returned to clients
+	assert.Equal(t, len(moList)-1, len(moMap))
 	for _, m := range moList {
+		if len(m.Uri) <= 1 {
+			// skip topRoot
+			continue
+		}
 		n, found := moMap[m.Uri]
 		if !found {
 			t.Fatal(fmt.Errorf("Object %s not found in received policy", m.Uri))

--- a/pkg/gbpserver/testPolicy.json
+++ b/pkg/gbpserver/testPolicy.json
@@ -3,8 +3,6 @@
         "subject": "DmtreeRoot",
         "uri": "/",
         "children": [
-            "/RelatorUniverse/",
-            "/GbpeVMUniverse/",
             "/DomainConfig/",
             "/InvUniverse/",
             "/PolicyUniverse/"
@@ -52,13 +50,6 @@
         "parent_subject": "DomainConfig",
         "parent_uri": "/DomainConfig/",
         "parent_relation": "DomainConfigToRemoteEndpointInventoryRSrc"
-    },
-    {
-        "subject": "GbpeVMUniverse",
-        "uri": "/GbpeVMUniverse/",
-        "parent_subject": "DmtreeRoot",
-        "parent_uri": "/",
-        "parent_relation": "GbpeVMUniverse"
     },
     {
         "subject": "InvUniverse",
@@ -2159,12 +2150,5 @@
                 "data": 6443
             }
         ]
-    },
-    {
-        "subject": "RelatorUniverse",
-        "uri": "/RelatorUniverse/",
-        "parent_subject": "DmtreeRoot",
-        "parent_uri": "/",
-        "parent_relation": "RelatorUniverse"
     }
 ]


### PR DESCRIPTION
topRoot did not have all children and was causing stats to be
removed on the opflex-server. Instead of sending topRoot, just
send the child Unis that gbp-server populates

Signed-off-by: Tom Flynn <tom.flynn@gmail.com>