### PR TITLE
Added support for session Affinity for services.

### DIFF
--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -49,8 +49,9 @@ type opflexServiceMapping struct {
 	NextHopIps  []string `json:"next-hop-ips"`
 	NextHopPort uint16   `json:"next-hop-port,omitempty"`
 
-	Conntrack bool   `json:"conntrack-enabled"`
-	NodePort  uint16 `json:"node-port,omitempty"`
+	Conntrack       bool                         `json:"conntrack-enabled"`
+	NodePort        uint16                       `json:"node-port,omitempty"`
+	SessionAffinity *opflexSessionAffinityConfig `json:"session-affinity,omitempty"`
 }
 
 type opflexService struct {
@@ -70,6 +71,22 @@ type opflexService struct {
 
 	Attributes map[string]string `json:"attributes,omitempty"`
 }
+
+type opflexSessionAffinityConfig struct {
+	// clientIP contains the configurations of Client IP based session affinity.
+	ClientIP opflexClientIPConfig `json:"client-ip,omitempty"`
+}
+
+// ClientIPConfig represents the configurations of Client IP based session affinity.
+type opflexClientIPConfig struct {
+	// timeoutSeconds specifies the seconds of ClientIP type session sticky time.
+	// The value must be >0 && <=86400(for 1 day) if ServiceAffinity == "ClientIP".
+	// Default value is 10800(for 3 hours).
+	TimeoutSeconds int32 `json:"timeout-seconds,omitempty"`
+}
+
+// Default Session value is 10800(for 3 hours)
+const DefaultSessionAffinityTimer = 10800
 
 // Name of the Openshift Service
 const (
@@ -601,6 +618,9 @@ func (sep *serviceEndpoint) SetOpflexService(ofas *opflexService, as *v1.Service
 			} else {
 				sm.ServiceIp = as.Spec.ClusterIP
 			}
+			if as.Spec.SessionAffinityConfig != nil && as.Spec.SessionAffinity == "ClientIP" {
+				sm.SessionAffinity = getSessionAffinity(as.Spec.SessionAffinityConfig)
+			}
 			for _, a := range e.Addresses {
 				if !external ||
 					(a.NodeName != nil && *a.NodeName == agent.config.NodeName) {
@@ -616,7 +636,15 @@ func (sep *serviceEndpoint) SetOpflexService(ofas *opflexService, as *v1.Service
 	return hasValidMapping
 }
 
-func CheckKeyMatch(topology, nodelabels map[string]string, key string) bool {
+func getSessionAffinity(config *v1.SessionAffinityConfig) *opflexSessionAffinityConfig {
+	if config.ClientIP != nil && config.ClientIP.TimeoutSeconds != nil {
+		return &opflexSessionAffinityConfig{ClientIP: opflexClientIPConfig{TimeoutSeconds: *config.ClientIP.TimeoutSeconds}}
+	} else {
+		return &opflexSessionAffinityConfig{ClientIP: opflexClientIPConfig{TimeoutSeconds: DefaultSessionAffinityTimer}}
+	}
+}
+
+func checkKeyMatch(topology, nodelabels map[string]string, key string) bool {
 	val1, ok1 := topology[key]
 	val2, ok2 := nodelabels[key]
 	if ok1 && ok2 {
@@ -686,7 +714,7 @@ func (seps *serviceEndpointSlice) SetOpflexService(ofas *opflexService, as *v1.S
 							nexthops["any"] = append(nexthops["any"], a)
 						} else {
 							for _, key := range as.Spec.TopologyKeys {
-								if CheckKeyMatch(e.Topology, node.ObjectMeta.Labels, key) {
+								if checkKeyMatch(e.Topology, node.ObjectMeta.Labels, key) {
 									nexthops[key] = append(nexthops[key], a)
 								}
 							}
@@ -709,6 +737,9 @@ func (seps *serviceEndpointSlice) SetOpflexService(ofas *opflexService, as *v1.S
 			}
 			if sm.ServiceIp != "" && len(sm.NextHopIps) > 0 {
 				hasValidMapping = true
+			}
+			if as.Spec.SessionAffinityConfig != nil && as.Spec.SessionAffinity == "ClientIP" {
+				sm.SessionAffinity = getSessionAffinity(as.Spec.SessionAffinityConfig)
 			}
 			ofas.ServiceMappings = append(ofas.ServiceMappings, *sm)
 		}


### PR DESCRIPTION
Session affinity always directs traffic from a client to the same pod.
It is typically used as an optimization to ensure that the same pod receives traffic from the same user so that you can leverage session caching