### PR TITLE
Add appropriate qos kubebuilder tags

### DIFF
--- a/cmd/crd-example/qos-CR.yaml
+++ b/cmd/crd-example/qos-CR.yaml
@@ -1,0 +1,17 @@
+apiVersion: aci.qos/v1
+kind: QosPolicy
+metadata:
+  name: test-qos
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: test
+  ingress:
+    policing_rate: 1000
+    policing_burst: 2000
+  egress:
+    policing_rate: 3000
+    policing_burst: 400
+  dscpmark: 25
+    

--- a/pkg/qospolicy/apis/aci.qos/v1/types.go
+++ b/pkg/qospolicy/apis/aci.qos/v1/types.go
@@ -22,13 +22,21 @@ type QosPolicySpec struct {
 	Selector PodSelector  `json:"selector,omitempty"`
 	Ingress  PolicingType `json:"ingress,omitempty"`
 	Egress   PolicingType `json:"egress,omitempty"`
-	Mark     int          `json:"dscpmark,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Maximum=63
+	// +kubebuilder:default:=0
+	// +optional
+	Mark int `json:"dscpmark,omitempty"`
 }
 
 //PolicingType
 type PolicingType struct {
-	PolicingRate  int `json:"policing_rate"`
-	PolicingBurst int `json:"policing_burst"`
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	PolicingRate int `json:"policing_rate,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	PolicingBurst int `json:"policing_burst,omitempty"`
 }
 
 // QosPolicyStatus defines the observed state of QosPolicy


### PR DESCRIPTION
- Add  appropriate kubebuilder validation tags for dscpmark, burst and rate attributes.
- Make the min/max and default values consistent with APIC documentation.
- Add a bad object check.
- Corresponding acc provision changes will be added to enable configuring dscpmark. 

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com