### PR TITLE
Consolidate annotation and label selector Qos policies into single "qos-policy" key

### DIFF
--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -54,7 +54,6 @@ type opflexEndpoint struct {
 	EndpointGroup string                 `json:"endpoint-group-name,omitempty"`
 	SecurityGroup []metadata.OpflexGroup `json:"security-group,omitempty"`
 	QosPolicy     metadata.OpflexGroup   `json:"qos-policy,omitempty"`
-	QoSPolicies   []metadata.OpflexGroup `json:"qos-policies,omitempty"`
 
 	IpAddress  []string `json:"ip,omitempty"`
 	MacAddress string   `json:"mac,omitempty"`
@@ -488,15 +487,14 @@ func (agent *HostAgent) podChangedLocked(podobj interface{}) {
 	if epAttributes == nil {
 		epAttributes = make(map[string]string)
 	}
-	qosPolicies, _ := agent.assignqosPolicies(pod)
 	epAttributes["vm-name"] = pod.ObjectMeta.Name
 	epAttributes["namespace"] = pod.ObjectMeta.Namespace
 
-	agent.epChanged(&epUuid, &epMetaKey, &epGroup, secGroup, qpGroup, qosPolicies, epAttributes, logger)
+	agent.epChanged(&epUuid, &epMetaKey, &epGroup, secGroup, qpGroup, epAttributes, logger)
 }
 
 func (agent *HostAgent) epChanged(epUuid *string, epMetaKey *string, epGroup *metadata.OpflexGroup,
-	epSecGroups []metadata.OpflexGroup, epQosPolicy metadata.OpflexGroup, epQoSPolicies []metadata.OpflexGroup, epAttributes map[string]string,
+	epSecGroups []metadata.OpflexGroup, epQosPolicy metadata.OpflexGroup, epAttributes map[string]string,
 	logger *logrus.Entry) {
 	if logger == nil {
 		logger = agent.log.WithFields(logrus.Fields{})
@@ -556,7 +554,6 @@ func (agent *HostAgent) epChanged(epUuid *string, epMetaKey *string, epGroup *me
 			}
 			ep.SecurityGroup = epSecGroups
 			ep.QosPolicy = epQosPolicy
-			ep.QoSPolicies = epQoSPolicies
 
 			neweps = append(neweps, ep)
 		}

--- a/pkg/hostagent/pods_test.go
+++ b/pkg/hostagent/pods_test.go
@@ -158,8 +158,10 @@ func (agent *testHostAgent) doTestPod(t *testing.T, tempdir string,
 
 	eg := &metadata.OpflexGroup{}
 	sg := make([]metadata.OpflexGroup, 0)
+	qp := metadata.OpflexGroup{}
 	json.Unmarshal([]byte(pt.eg), eg)
 	json.Unmarshal([]byte(pt.sg), &sg)
+	json.Unmarshal([]byte(pt.qp), &qp)
 
 	epidstr := pt.uuid + "_" + pt.cont + "_" + pt.veth
 	assert.Equal(t, epidstr, ep.Uuid, desc, pt.name, "uuid")
@@ -168,6 +170,8 @@ func (agent *testHostAgent) doTestPod(t *testing.T, tempdir string,
 	assert.Equal(t, eg.AppProfile+"|"+eg.Name, ep.EndpointGroup,
 		desc, pt.name, "eg")
 	assert.Equal(t, sg, ep.SecurityGroup, desc, pt.name, "secgroup")
+	assert.Equal(t, qp, ep.QosPolicy, desc, pt.name, "qos")
+
 }
 
 func TestPodSync(t *testing.T) {


### PR DESCRIPTION
- Currently, an array of Qos policies is being written in the EP file. But, only a single qos policy can be enforced on an EP at a time.
- This patch merges the qos policies used for annotation and label selector. 
- When multiple label selectors match, annotation on a specific pod has the highest precedence.
- Datapath testing has been done for this use case. The Opflex agent resolves the policy and configures the ovsdb.
- Refer: noironetworks/support#1428
- Added UTs

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com