### PR TITLE
SCTP protocol filter support added in ACI controller

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -56,6 +56,7 @@ var protoNormalizations = map[string]string{
 	"89":  "ospfigp",
 	"103": "pim",
 	"115": "l2tp",
+	"132": "sctp",
 }
 
 func normalizePort(port string) string {

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -750,6 +750,8 @@ func portProto(protocol *v1.Protocol) string {
 	proto := "tcp"
 	if protocol != nil && *protocol == v1.ProtocolUDP {
 		proto = "udp"
+	} else if protocol != nil && *protocol == v1.ProtocolSCTP {
+		proto = "sctp"
 	}
 	return proto
 }

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -34,6 +34,7 @@ import (
 
 var tcp = "TCP"
 var udp = "UDP"
+var sctp = "SCTP"
 var port80 = 80
 var port443 = 443
 
@@ -430,6 +431,12 @@ func TestNetworkPolicy(t *testing.T) {
 	rule_14_s.SetAttr("protocol", "tcp")
 	rule_14_s.SetAttr("toPort", "8080")
 	rule_14_s.AddChild(apicapi.NewHostprotRemoteIp(rule_14_s.GetDn(), "9.0.0.42"))
+
+	rule_15_0 := apicapi.NewHostprotRule(np1SDnI, "0_0")
+	rule_15_0.SetAttr("direction", "ingress")
+	rule_15_0.SetAttr("ethertype", "ipv4")
+	rule_15_0.SetAttr("protocol", "sctp")
+	rule_15_0.SetAttr("toPort", "80")
 	var npTests = []npTest{
 		{netpol("testns", "np1", &metav1.LabelSelector{},
 			[]v1net.NetworkPolicyIngressRule{ingressRule(nil, nil)},
@@ -464,6 +471,12 @@ func TestNetworkPolicy(t *testing.T) {
 					port(&udp, &port80)}, nil)}, nil, allPolicyTypes),
 			makeNp(apicapi.ApicSlice{rule_3_0}, nil, name),
 			nil, "allow-80-udp"},
+		{netpol("testns", "np1", &metav1.LabelSelector{},
+			[]v1net.NetworkPolicyIngressRule{
+				ingressRule([]v1net.NetworkPolicyPort{
+					port(&sctp, &port80)}, nil)}, nil, allPolicyTypes),
+			makeNp(apicapi.ApicSlice{rule_15_0}, nil, name),
+			nil, "allow-80-sctp"},
 		{netpol("testns", "np1", &metav1.LabelSelector{},
 			[]v1net.NetworkPolicyIngressRule{
 				ingressRule([]v1net.NetworkPolicyPort{

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -505,12 +505,7 @@ func apicFilter(name string, tenantName string,
 	var port v1.ServicePort
 	for i, port = range portSpec {
 		pstr := strconv.Itoa(int(port.Port))
-		var proto string
-		if port.Protocol == v1.ProtocolUDP {
-			proto = "udp"
-		} else {
-			proto = "tcp"
-		}
+		proto := getProtocolStr(port.Protocol)
 		fe := apicFilterEntry(filterDn, strconv.Itoa(i), pstr,
 			pstr, proto, "no", false, false)
 		filter.AddChild(fe)
@@ -1065,12 +1060,7 @@ func (cont *AciController) writeApicSvc(key string, service *v1.Service) {
 		aobj.SetAttr("type", t)
 	}
 	for _, port := range service.Spec.Ports {
-		var proto string
-		if port.Protocol == v1.ProtocolUDP {
-			proto = "udp"
-		} else {
-			proto = "tcp"
-		}
+		proto := getProtocolStr(port.Protocol)
 		p := apicapi.NewVmmInjectedSvcPort(aobjDn,
 			strconv.Itoa(int(port.Port)), proto, port.TargetPort.String())
 		p.SetAttr("nodePort", strconv.Itoa(int(port.NodePort)))
@@ -1702,4 +1692,18 @@ func (seps *serviceEndpointSlice) SetServiceApicObject(aobj apicapi.ApicObject, 
 		return false
 	}
 	return true
+}
+func getProtocolStr(proto v1.Protocol) string {
+	var protostring string
+	switch proto {
+	case v1.ProtocolUDP:
+		protostring = "udp"
+	case v1.ProtocolTCP:
+		protostring = "tcp"
+	case v1.ProtocolSCTP:
+		protostring = "sctp"
+	default:
+		protostring = "tcp"
+	}
+	return protostring
 }


### PR DESCRIPTION
currently this is alpha feature in kubernetes by default it is not enabled.
In Openshift 4.3 onwords feature gate is enabled.
Note:
Datapath changes are required to support complete functionality

(cherry picked from commit 31180141552b117f651f2248261f271a342a16f3)