### PR TITLE
dep/ns/pod annotattion-clear faults on apic when subsequent annotatio…

### DIFF
--- a/pkg/controller/deployments.go
+++ b/pkg/controller/deployments.go
@@ -176,6 +176,7 @@ func (cont *AciController) deploymentDeleted(obj interface{}) {
 	} else {
 		key := cont.aciNameForKey("deployment", depkey)
 		cont.apicConn.ClearApicObjects(key)
+		cont.apicConn.ClearApicObjects(cont.aciNameForKey("depfs", depkey))
 	}
 	cont.depPods.DeleteSelectorObj(obj)
 }
@@ -189,7 +190,7 @@ func (cont *AciController) checkIfEpgExistDep(dep *appsv1.Deployment) {
 		return
 	}
 
-	key := cont.aciNameForKey("deployment", depkey)
+	key := cont.aciNameForKey("depfs", depkey)
 	epGroup, ok := dep.ObjectMeta.Annotations[metadata.EgAnnotation]
 	if ok {
 		severity := major

--- a/pkg/controller/namespaces.go
+++ b/pkg/controller/namespaces.go
@@ -125,24 +125,25 @@ func (cont *AciController) namespaceDeleted(obj interface{}) {
 		}
 	}
 	cont.apicConn.ClearApicObjects(cont.aciNameForKey("ns", ns.Name))
+	cont.apicConn.ClearApicObjects(cont.aciNameForKey("nsfs", ns.Name))
 	cont.depPods.DeleteNamespace(ns)
 	cont.netPolPods.DeleteNamespace(ns)
 	cont.netPolIngressPods.DeleteNamespace(ns)
 	cont.updatePodsForNamespace(ns.ObjectMeta.Name)
 }
 
-func (cont *AciController) checkIfEpgExistNs(namespaceobj *v1.Namespace) {
+func (cont *AciController) checkIfEpgExistNs(ns *v1.Namespace) {
 
-	nskey := cont.aciNameForKey("ns", namespaceobj.Name)
+	nskey := cont.aciNameForKey("nsfs", ns.Name)
 	if nskey == "" {
 		cont.log.Error("Could not retrieve namespace key")
 		return
 	}
-	epGroup, ok := namespaceobj.ObjectMeta.Annotations[metadata.EgAnnotation]
+	epGroup, ok := ns.ObjectMeta.Annotations[metadata.EgAnnotation]
 	if ok {
 		severity := critical
 		faultCode := 11
-		cont.handleEpgAnnotationUpdate(nskey, faultCode, severity, namespaceobj.Name, epGroup)
+		cont.handleEpgAnnotationUpdate(nskey, faultCode, severity, ns.Name, epGroup)
 	}
 
 	return


### PR DESCRIPTION
Clears fault object on apic when subsequent annotation is correct and when the dep/ns/pod resource is deleted
upon wrong annotation of ns/pod/dep, we post the fault Object on APIC. and upon next correct annotation , faults against the resource ns/pod/dep will be cleared 
also this fix takes care of clearing the fault objects(if it is present on APIC) when the ns/pod/dep is deleted

Tested and verified on the ACI setup 