### PR TITLE
Code to sync snatglobalinfo and nodeinfos on the controller, logging changes

### DIFF
--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -100,14 +100,14 @@ func (cont *AciController) initSnatCfgInformerBase(listWatch *cache.ListWatch) {
 		},
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
-	cont.log.Debug("Initializing SnatCfg  Informers: ")
+	cont.log.Info("Initializing SnatCfg  Informers: ")
 }
 
 // Handle any changes to snatOperator Config
 func (cont *AciController) snatCfgUpdate(obj interface{}) {
 	snatcfg := obj.(*v1.ConfigMap)
 	var portRange snatglobalinfo.PortRange
-	cont.log.Debug("snatCfgUpdated: ", snatcfg)
+	cont.log.Info("snatCfgUpdated: ", snatcfg)
 	data := snatcfg.Data
 	start, err1 := strconv.Atoi(data["start"])
 	end, err2 := strconv.Atoi(data["end"])
@@ -139,7 +139,7 @@ func (cont *AciController) snatNodeInfoAdded(obj interface{}) {
 	if err != nil {
 		return
 	}
-	cont.log.Debug("Node Info Added: ", nodeinfokey)
+	cont.log.Info("Node Info Added: ", nodeinfokey)
 	cont.indexMutex.Lock()
 	cont.snatNodeInfoCache[nodeinfo.ObjectMeta.Name] = nodeinfo
 	cont.indexMutex.Unlock()
@@ -329,7 +329,7 @@ func (cont *AciController) syncSnatGlobalInfo() bool {
 		return false
 	}
 	snatglobalInfo.Spec.GlobalInfos = glInfoCache
-	cont.log.Info("Update GlobalInfo: ", glInfoCache)
+	cont.log.Debug("Update GlobalInfo: ", glInfoCache)
 	err = util.UpdateGlobalInfoCR(*globalcl, snatglobalInfo)
 	if err != nil {
 		cont.log.Info("Update Failed: ", err)
@@ -358,7 +358,7 @@ func (cont *AciController) updateGlobalInfoforPolicy(portrange snatglobalinfo.Po
 	}
 	cont.snatGlobalInfoCache[snatIp][nodename] = glinfo
 	cont.indexMutex.Unlock()
-	cont.log.Debug("Node name and globalinfo: ", nodename, glinfo)
+	cont.log.Info("Node name and globalinfo: ", nodename, glinfo)
 }
 
 func (cont *AciController) getIpAndPortRange(nodename string, snatpolicy *ContSnatPolicy, serviceIp string) (string,
@@ -423,6 +423,7 @@ func (cont *AciController) deleteNodeinfoFromGlInfoCache(nodename string) bool {
 					return true
 				}
 			}
+			cont.log.Info("Deleting following node from globalinfo: ", nodename)
 			delete(glinfos, nodename)
 			if len(glinfos) == 0 {
 				delete(cont.snatGlobalInfoCache, snatip)
@@ -468,11 +469,13 @@ func (cont *AciController) clearSnatGlobalCache(policyName string, nodename stri
 				if _, exists := v[nodename]; exists {
 					delete(v, nodename)
 					if len(v) == 0 {
+						cont.log.Info("Clearing following snat IP from snatglobalinfo: ", snatip)
 						delete(cont.snatGlobalInfoCache, snatip)
 					}
 					break
 				}
 			} else {
+				cont.log.Info("Clearing following snat IP from snatglobalinfo: ", snatip)
 				delete(cont.snatGlobalInfoCache, snatip)
 			}
 		} else {


### PR DESCRIPTION
1. The controller now watches the snatglobalinfo object for updates, and verifies the value against nodeinfos- if there's a discrepancy, we queue the nodeinfo to update the snatglobalinfo
2. Modify log level for SNAT code and add new logs 