### PR TITLE
Code to sync snatglobalinfo and nodeinfos on the controller, logging changes 

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -29,6 +30,7 @@ import (
 	"golang.org/x/time/rate"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
@@ -631,6 +633,67 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 			cont.opflexDeviceDeleted(dn)
 		})
 	go cont.apicConn.Run(stopCh)
+	go cont.enableGlobalSync(stopCh)
+}
+
+func (cont *AciController) enableGlobalSync(stopCh <-chan struct{}) {
+	time.Sleep(time.Minute)
+	for {
+		cont.log.Debug("Running code to sync GlobalInfo with Node infos")
+		var nodeInfos []*nodeinfo.NodeInfo
+		cont.indexMutex.Lock()
+		cache.ListAll(cont.snatNodeInfoIndexer, labels.Everything(),
+			func(nodeInfoObj interface{}) {
+				nodeInfo := nodeInfoObj.(*nodeinfo.NodeInfo)
+				nodeInfos = append(nodeInfos, nodeInfo)
+			})
+		expected := make(map[string][]string)
+		for _, glinfo := range cont.snatGlobalInfoCache {
+			for nodename, entry := range glinfo {
+				expected[nodename] = append(expected[nodename], entry.SnatPolicyName)
+			}
+		}
+		cont.indexMutex.Unlock()
+
+		for _, value := range nodeInfos {
+			marked := false
+			policyNames := value.Spec.SnatPolicyNames
+			nodeName := value.ObjectMeta.Name
+			_, ok := expected[nodeName]
+			if !ok && len(policyNames) > 0 {
+				cont.log.Debug("Missing entry in snatglobalinfo for node: ", nodeName)
+				marked = true
+				break
+			}
+			if len(policyNames) != len(expected[nodeName]) {
+				cont.log.Debug("Missing snatpolicy entry in snatglobalinfo for node: ", nodeName)
+				marked = true
+			} else {
+				expectedList := expected[nodeName]
+				expectedMap := make(map[string]bool)
+				for _, v := range expectedList {
+					expectedMap[v] = true
+				}
+				eq := reflect.DeepEqual(expectedMap, policyNames)
+				if !eq {
+					cont.log.Debug("Wrong snatpolicy entry in snatglobalinfo for node: ", nodeName)
+					marked = true
+				}
+			}
+			if marked {
+				cont.log.Info("Nodeinfo and globalinfo out of sync for node: ", nodeName)
+				nodeinfokey, err := cache.MetaNamespaceKeyFunc(value)
+				if err != nil {
+					cont.log.Error("Not able to get key for node: ", nodeName)
+					continue
+				}
+				cont.queueNodeInfoUpdateByKey(nodeinfokey)
+			} else {
+				cont.log.Debug("Nodeinfo and globalinfo in sync for node: ", nodeName)
+			}
+		}
+		time.Sleep(time.Minute)
+	}
 }
 
 func (cont *AciController) processSyncQueue(queue workqueue.RateLimitingInterface,

--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -102,14 +102,14 @@ func (cont *AciController) initSnatCfgInformerBase(listWatch *cache.ListWatch) {
 		},
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
-	cont.log.Debug("Initializing SnatCfg  Informers: ")
+	cont.log.Info("Initializing SnatCfg  Informers: ")
 }
 
 // Handle any changes to snatOperator Config
 func (cont *AciController) snatCfgUpdate(obj interface{}) {
 	snatcfg := obj.(*v1.ConfigMap)
 	var portRange snatglobalinfo.PortRange
-	cont.log.Debug("snatCfgUpdated: ", snatcfg)
+	cont.log.Info("snatCfgUpdated: ", snatcfg)
 	data := snatcfg.Data
 	start, err1 := strconv.Atoi(data["start"])
 	end, err2 := strconv.Atoi(data["end"])
@@ -141,7 +141,7 @@ func (cont *AciController) snatNodeInfoAdded(obj interface{}) {
 	if err != nil {
 		return
 	}
-	cont.log.Debug("Node Info Added: ", nodeinfokey)
+	cont.log.Info("Node Info Added: ", nodeinfokey)
 	cont.indexMutex.Lock()
 	cont.snatNodeInfoCache[nodeinfo.ObjectMeta.Name] = nodeinfo
 	cont.indexMutex.Unlock()
@@ -331,7 +331,7 @@ func (cont *AciController) syncSnatGlobalInfo() bool {
 		return false
 	}
 	snatglobalInfo.Spec.GlobalInfos = glInfoCache
-	cont.log.Info("Update GlobalInfo: ", glInfoCache)
+	cont.log.Debug("Update GlobalInfo: ", glInfoCache)
 	err = util.UpdateGlobalInfoCR(*globalcl, snatglobalInfo)
 	if err != nil {
 		cont.log.Info("Update Failed: ", err)
@@ -360,7 +360,7 @@ func (cont *AciController) updateGlobalInfoforPolicy(portrange snatglobalinfo.Po
 	}
 	cont.snatGlobalInfoCache[snatIp][nodename] = glinfo
 	cont.indexMutex.Unlock()
-	cont.log.Debug("Node name and globalinfo: ", nodename, glinfo)
+	cont.log.Info("Node name and globalinfo: ", nodename, glinfo)
 }
 
 func (cont *AciController) getIpAndPortRange(nodename string, snatpolicy *ContSnatPolicy, serviceIp string) (string,
@@ -426,6 +426,7 @@ func (cont *AciController) deleteNodeinfoFromGlInfoCache(nodename string) bool {
 					return true
 				}
 			}
+			cont.log.Info("Deleting following node from globalinfo: ", nodename)
 			delete(glinfos, nodename)
 			if len(glinfos) == 0 {
 				delete(cont.snatGlobalInfoCache, snatip)
@@ -471,11 +472,13 @@ func (cont *AciController) clearSnatGlobalCache(policyName string, nodename stri
 				if _, exists := v[nodename]; exists {
 					delete(v, nodename)
 					if len(v) == 0 {
+						cont.log.Info("Clearing following snat IP from snatglobalinfo: ", snatip)
 						delete(cont.snatGlobalInfoCache, snatip)
 					}
 					break
 				}
 			} else {
+				cont.log.Info("Clearing following snat IP from snatglobalinfo: ", snatip)
 				delete(cont.snatGlobalInfoCache, snatip)
 			}
 		} else {


### PR DESCRIPTION
1. The controller now watches the snatglobalinfo object for updates, and verifies the value against nodeinfos- if there's a discrepancy, we queue the nodeinfo to update the snatglobalinfo
2. Modify log level for SNAT code and add new logs

cherry-picked from https://github.com/noironetworks/aci-containers/pull/797/commits/0870d88b6f49ce7bdb47ecff3ed4ccf368129fe0 and https://github.com/noironetworks/aci-containers/pull/797/commits/2973268c6b2909173d113473b1521c7901d1bc66