### PR TITLE
Fix SNAT testing inside controller and UT for periodic sync

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -634,8 +634,8 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	go cont.apicConn.Run(stopCh)
 }
 
-func (cont *AciController) enableGlobalSync(stopCh <-chan struct{}) {
-	time.Sleep(time.Minute)
+func (cont *AciController) snatGlobalInfoSync(stopCh <-chan struct{}, seconds time.Duration) {
+	time.Sleep(seconds * time.Second)
 	cont.log.Info("Go routine to periodically sync globalinfo and nodeinfo started")
 	iteration := 0
 	for {
@@ -672,12 +672,12 @@ func (cont *AciController) enableGlobalSync(stopCh <-chan struct{}) {
 			nodeName := value.ObjectMeta.Name
 			_, ok := expectedmap[nodeName]
 			if !ok && len(policyNames) > 0 {
-				cont.log.Info("Missing entry in snatglobalinfo for node: ", nodeName)
+				cont.log.Info("Adding missing entry in snatglobalinfo for node: ", nodeName)
 				cont.log.Info("No snat policies found in snatglobalinfo")
 				cont.log.Info("Snatpolicy list according to nodeinfo: ", policyNames)
 				marked = true
 			} else if len(policyNames) != len(expectedmap[nodeName]) {
-				cont.log.Info("Missing snatpolicy entry in snatglobalinfo for node: ", nodeName)
+				cont.log.Info("Adding missing snatpolicy entry in snatglobalinfo for node: ", nodeName)
 				cont.log.Info("Snatpolicy list according to snatglobalinfo: ", expectedmap[nodeName])
 				cont.log.Info("Snatpolicy list according to nodeinfo: ", policyNames)
 				marked = true
@@ -688,7 +688,7 @@ func (cont *AciController) enableGlobalSync(stopCh <-chan struct{}) {
 				}
 				eq := reflect.DeepEqual(expectedmap[nodeName], policyNames)
 				if !eq {
-					cont.log.Info("Wrong snatpolicy entry in snatglobalinfo for node: ", nodeName)
+					cont.log.Info("Syncing inconsistent snatpolicy entry in snatglobalinfo for node: ", nodeName)
 					cont.log.Info("Snatpolicy list according to snatglobalinfo: ", expectedmap[nodeName])
 					cont.log.Info("Snatpolicy list according to nodeinfo: ", policyNames)
 					marked = true
@@ -701,6 +701,7 @@ func (cont *AciController) enableGlobalSync(stopCh <-chan struct{}) {
 					cont.log.Error("Not able to get key for node: ", nodeName)
 					continue
 				}
+				cont.log.Info("Queuing nodeinfokey for globalinfo sync: ", nodeinfokey)
 				cont.queueNodeInfoUpdateByKey(nodeinfokey)
 			} else {
 				if iteration%5 == 0 {
@@ -708,7 +709,7 @@ func (cont *AciController) enableGlobalSync(stopCh <-chan struct{}) {
 				}
 			}
 		}
-		time.Sleep(time.Minute)
+		time.Sleep(seconds * time.Second)
 		iteration = iteration + 1
 	}
 }

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -289,7 +289,7 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 		cont.snatNodeInformer.HasSynced)
 	cont.log.Info("Cache sync successful")
 	if !cont.config.DisablePeriodicSnatGlobalInfoSync {
-		go cont.enableGlobalSync(stopCh)
+		go cont.snatGlobalInfoSync(stopCh, 60)
 	}
 	return nil
 }


### PR DESCRIPTION
Additional changes:
1. Make the time intervals for global sync method configurable
2. Change method name from enableGlobalSync to snatGlobalInfoSync for better readability
3. Modify logs in snatGlobalInfoSync to be more user-friendly
4. Add check for comparing policy names in SNAT UTs