### PR TITLE
Fix SNAT testing inside controller and UT for periodic SNAT sync

### DIFF
--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -289,7 +289,7 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 		cont.snatNodeInformer.HasSynced)
 	cont.log.Info("Cache sync successful")
 	if !cont.config.DisablePeriodicSnatGlobalInfoSync {
-		go cont.enableGlobalSync(stopCh)
+		go cont.snatGlobalInfoSync(stopCh, 60)
 	}
 	return nil
 }


### PR DESCRIPTION

Additional changes:
1. Make the time intervals for global sync method configurable
2. Change method name from enableGlobalSync to snatGlobalInfoSync for better readability
3. Modify logs in snatGlobalInfoSync to be more user-friendly
4. Add check for comparing policy names in SNAT UTs

(cherry picked from commit 67d08c673e66ca0c66b9d2746d5b55e065207843)