### PR TITLE
Enabling wait-for-network for pods

### DIFF
--- a/docker/launch-hostagent.sh
+++ b/docker/launch-hostagent.sh
@@ -19,7 +19,8 @@ fi
 if [ -w /mnt/cni-conf ]; then
     # Install CNI configuration
     mkdir -p /mnt/cni-conf/cni/net.d
-    cat <<EOF > /mnt/cni-conf/cni/net.d/01-opflex-cni.conf
+    if [  -z !=  $DISABLE_WAIT_FOR_NETWORK ] && [ $DISABLE_WAIT_FOR_NETWORK = "True" ]; then
+        cat <<EOF > /mnt/cni-conf/cni/net.d/01-opflex-cni.conf
 {
    "cniVersion": "0.3.1",
    "supportedVersions": [ "0.3.0", "0.3.1", "0.4.0" ],
@@ -28,6 +29,18 @@ if [ -w /mnt/cni-conf ]; then
    "ipam": {"type": "opflex-agent-cni-ipam"}
 }
 EOF
+    else
+        cat <<EOF > /mnt/cni-conf/cni/net.d/01-opflex-cni.conf
+{
+   "cniVersion": "0.3.1",
+   "supportedVersions": [ "0.3.0", "0.3.1", "0.4.0" ],
+   "name": "k8s-pod-network",
+   "type": "opflex-agent-cni",
+   "wait-for-network": true,
+   "ipam": {"type": "opflex-agent-cni-ipam"}
+}
+EOF
+    fi
 fi
 
 if [  -z !=  $MULTUS ] && [ $MULTUS = "True" ]; then


### PR DESCRIPTION
This check allows the CNI binary to check if the
pod's datapath is working before it successfully
returns from the call made by the kubelet to add
an interface for the pod.

The check was already present, this change enables
it by default. It can be disabled by setting the
net_config/disable_wait_for_network configuration
to True.