### PR TITLE
To make wait_for_network_duration to be configurable.

### DIFF
--- a/cmd/opflexagentcni/main.go
+++ b/cmd/opflexagentcni/main.go
@@ -57,11 +57,12 @@ type K8SArgs struct {
 
 type NetConf struct {
 	types.NetConf
-	LogLevel       string `json:"log-level,omitempty"`
-	LogFile        string `json:"log-file,omitempty"`
-	WaitForNetwork bool   `json:"wait-for-network"`
-	EpRpcSock      string `json:"ep-rpc-sock,omitempty"`
-	DomainType     string `json:"domain-type,omitempty"`
+	LogLevel               string `json:"log-level,omitempty"`
+	LogFile                string `json:"log-file,omitempty"`
+	WaitForNetwork         bool   `json:"wait-for-network"`
+	WaitForNetworkDuration uint16 `json:"wait-for-network-duration"`
+	EpRpcSock              string `json:"ep-rpc-sock,omitempty"`
+	DomainType             string `json:"domain-type,omitempty"`
 }
 
 func loadConf(args *skel.CmdArgs) (*NetConf, *K8SArgs, string, error) {
@@ -88,7 +89,12 @@ func loadConf(args *skel.CmdArgs) (*NetConf, *K8SArgs, string, error) {
 	if err == nil {
 		log.Level = logLevel
 	}
-	log.Debug("NetConf: ", n)
+
+	if n.WaitForNetwork && n.WaitForNetworkDuration == 0 {
+		n.WaitForNetworkDuration = 210
+	}
+
+	log.Debug("NetConf: %v", n)
 
 	k8sArgs := &K8SArgs{}
 	if n.DomainType != "CloudFoundry" {
@@ -239,7 +245,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	if n.WaitForNetwork {
 		logger.Debug("Waiting for network connectivity")
-		waitForAllNetwork(result, id, 10*time.Second)
+		waitForAllNetwork(result, id, time.Duration(n.WaitForNetworkDuration))
 	}
 
 	logger.Debug("ADD result: ", result)
@@ -315,7 +321,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 	}
 	if n.WaitForNetwork {
 		logger.Debug("Waiting for network connectivity")
-		waitForAllNetwork(result, id, 10*time.Second)
+		waitForAllNetwork(result, id, time.Duration(n.WaitForNetworkDuration))
 	}
 	logger.Debug("Check result: ", result)
 	return nil

--- a/docker/launch-hostagent.sh
+++ b/docker/launch-hostagent.sh
@@ -17,6 +17,10 @@ if [ -w /mnt/cni-bin ]; then
     cp ${ACIBIN}/opflex-agent-cni $CNIBIN
 fi
 if [ -w /mnt/cni-conf ]; then
+    INT_DURATION_WAIT_FOR_NETWORK=210
+    if [ -z != $DURATION_WAIT_FOR_NETWORK ]; then
+        INT_DURATION_WAIT_FOR_NETWORK=$((DURATION_WAIT_FOR_NETWORK))
+    fi
     # Install CNI configuration
     mkdir -p /mnt/cni-conf/cni/net.d
     if [  -z !=  $DISABLE_WAIT_FOR_NETWORK ] && [ $DISABLE_WAIT_FOR_NETWORK = "True" ]; then
@@ -37,6 +41,7 @@ EOF
    "name": "k8s-pod-network",
    "type": "opflex-agent-cni",
    "wait-for-network": true,
+   "wait-for-network-duration": $((INT_DURATION_WAIT_FOR_NETWORK)),
    "ipam": {"type": "opflex-agent-cni-ipam"}
 }
 EOF


### PR DESCRIPTION
If wait_for_network is enabled, ACI waits for a set duration to allow datapath to be ready.
This commit allows the wait duration to be configurable.

(cherry picked from commit 2d3a40c8b7e091af3ad4bdf788ecaa63b9e10f9b)