### PR TITLE
[kwai]Add EPRegistry check back in place for podif CRD

### DIFF
--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -186,17 +186,19 @@ func NewHostAgent(config *HostAgentConfig, env Environment, log *logrus.Logger) 
 		"rdconfig":      ha.syncRdConfig,
 		"snatLocalInfo": ha.UpdateLocalInfoCr}
 
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		log.Errorf("ERROR getting cluster config: %v", err)
-		return ha
+	if ha.config.EPRegistry == "k8s" {
+		cfg, err := rest.InClusterConfig()
+		if err != nil {
+			log.Errorf("ERROR getting cluster config: %v", err)
+			return ha
+		}
+		aciawClient, err := crdclientset.NewForConfig(cfg)
+		if err != nil {
+			log.Errorf("ERROR getting crd client for registry: %v", err)
+			return ha
+		}
+		ha.crdClient = aciawClient.AciV1()
 	}
-	aciawClient, err := crdclientset.NewForConfig(cfg)
-	if err != nil {
-		log.Errorf("ERROR getting crd client for registry: %v", err)
-		return ha
-	}
-	ha.crdClient = aciawClient.AciV1()
 	return ha
 }
 


### PR DESCRIPTION
(cherry picked from commit 7d197e30069d8387d60db06b1a538a951297c044)

- The check was removed to enable ERSPAN feature in on-prem case. This caused issues with the way podifs are processed at scale. This commit reverts the change and puts the check back in place.

- To enable ERSPAN feature, we need to derive the config from acc-provision input file. An example of the config is below:
```
kube_config:
  …
  ep_registry: k8s
```

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com