### PR TITLE
Set goveralls v0.0.8 explicitly in travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
       sudo: false
       go: "1.16"
       before_install:
-        - go get github.com/mattn/goveralls
+        - go get github.com/mattn/goveralls@v0.0.8
       install:
         - export PATH=$PATH:$GOPATH/bin
       script:


### PR DESCRIPTION
Travis checks no longer failing.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com