### PR TITLE
Add multiple srcMembers to a single srcGrp

### DIFF
--- a/pkg/controller/erspan.go
+++ b/pkg/controller/erspan.go
@@ -226,6 +226,11 @@ func (cont *AciController) getAccLeafPorts() []string {
 	return accPorts
 }
 
+func transformMac(mac string) string {
+	m := strings.ReplaceAll(mac, ":", "-")
+	return m
+}
+
 func (cont *AciController) buildErspanObjs(span *erspanpolicy.ErspanPolicy) apicapi.ApicSlice {
 
 	spankey, _ := cache.MetaNamespaceKeyFunc(span)
@@ -234,12 +239,8 @@ func (cont *AciController) buildErspanObjs(span *erspanpolicy.ErspanPolicy) apic
 
 	// Source policies
 	srcGrp := apicapi.NewSpanVSrcGrp(labelKey)
-	srcName := labelKey + "_Src"
 	apicSlice := apicapi.ApicSlice{srcGrp}
 	srcGrp.SetAttr("adminSt", span.Spec.Source.AdminState)
-	src := apicapi.NewSpanVSrc(srcGrp.GetDn(), srcName)
-	srcGrp.AddChild(src)
-	src.SetAttr("dir", span.Spec.Source.Direction)
 
 	// Build fvCEp for matching pods
 	cont.indexMutex.Lock()
@@ -253,8 +254,12 @@ func (cont *AciController) buildErspanObjs(span *erspanpolicy.ErspanPolicy) apic
 		mac := strings.ToUpper(macRaw)
 		epg := cont.podIftoEp[podkey].EPG
 		appProfile := cont.podIftoEp[podkey].AppProfile
+		srcName := labelKey + "_Src_" + transformMac(mac)
 		fvCEpDn := fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s/cep-%s",
 			cont.config.AciPolicyTenant, appProfile, epg, mac)
+		src := apicapi.NewSpanVSrc(srcGrp.GetDn(), srcName)
+		srcGrp.AddChild(src)
+		src.SetAttr("dir", span.Spec.Source.Direction)
 		srcCEp := apicapi.NewSpanRsSrcToVPort(src.GetDn(), fvCEpDn)
 		src.AddChild(srcCEp)
 	}
@@ -286,8 +291,8 @@ func (cont *AciController) buildErspanObjs(span *erspanpolicy.ErspanPolicy) apic
 		accBndlGrp.AddChild(infraRsSpanVDstGrp)
 		apicSlice = append(apicSlice, infraRsSpanVDstGrp)
 	}
-	// Erspan policy binding to Leaf Access Ports.
 
+	// Erspan policy binding to Leaf Access Ports.
 	accPorts := cont.getAccLeafPorts()
 	if len(accPorts) == 0 {
 		cont.log.Info("No Leaf Access Ports found for erspan binding.")

--- a/pkg/controller/erspan_test.go
+++ b/pkg/controller/erspan_test.go
@@ -63,13 +63,13 @@ func buildSpanObjs(name string, dstIP string, flowID int, adminSt string,
 	srcGrp := apicapi.NewSpanVSrcGrp(name)
 	srcGrp.SetAttr("adminSt", adminSt)
 	apicSlice := apicapi.ApicSlice{srcGrp}
-	srcName := name + "_Src"
-	src := apicapi.NewSpanVSrc(srcGrp.GetDn(), srcName)
-	src.SetAttr("dir", dir)
-	srcGrp.AddChild(src)
 	for _, mac := range macs {
 		fvCEpDn := fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s/cep-%s",
 			"consul", "test-ap", "default", mac)
+		srcName := name + "_Src"
+		src := apicapi.NewSpanVSrc(srcGrp.GetDn(), srcName)
+		src.SetAttr("dir", dir)
+		srcGrp.AddChild(src)
 		srcCEp := apicapi.NewSpanRsSrcToVPort(src.GetDn(), fvCEpDn)
 		src.AddChild(srcCEp)
 	}


### PR DESCRIPTION
The spanSrcMember has a single cardinality with srcRef (i.e podmac). Since the podSelector can select more than one pod at a time we need to map each pod (srcRef) to srcMember. This results in all the OVS pods getting the Span config.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com

 