### PR TITLE
[kwai]Add multiple srcMembers to a single srcGrp

### DIFF
--- a/pkg/controller/erspan_test.go
+++ b/pkg/controller/erspan_test.go
@@ -68,13 +68,13 @@ func buildSpanObjs(name string, dstIP string, flowID int, adminSt string,
 	srcGrp := apicapi.NewSpanVSrcGrp(name)
 	srcGrp.SetAttr("adminSt", adminSt)
 	apicSlice := apicapi.ApicSlice{srcGrp}
-	srcName := name + "_Src"
-	src := apicapi.NewSpanVSrc(srcGrp.GetDn(), srcName)
-	src.SetAttr("dir", dir)
-	srcGrp.AddChild(src)
 	for _, mac := range macs {
 		fvCEpDn := fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s/cep-%s",
 			"consul", "test-ap", "default", mac)
+		srcName := name + "_Src"
+		src := apicapi.NewSpanVSrc(srcGrp.GetDn(), srcName)
+		src.SetAttr("dir", dir)
+		srcGrp.AddChild(src)
 		srcCEp := apicapi.NewSpanRsSrcToVPort(src.GetDn(), fvCEpDn)
 		src.AddChild(srcCEp)
 	}


### PR DESCRIPTION
(cherry picked from commit 3659670b7440efc68ef229dadd009f680385de1b)

The spanSrcMember has a single cardinality with srcRef (i.e podmac). Since the podSelector can select more than one pod at a time we need to map each pod (srcRef) to srcMember. This results in all the OVS pods getting the Span config.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com