### PR TITLE
Polulate the dnsName for the service class vmmInjectedSvc

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -203,6 +203,9 @@ type ControllerConfig struct {
 	CSRTunnelIDBase int `json:"csr-tunnel-id-base,omitempty"`
 	// enable EndpointSlice
 	EnabledEndpointSlice bool `json:"enable_endpointslice,omitempty"`
+
+	// Cluster Flavour
+	Flavor string `json:"flavor,omitempty"`
 }
 
 type netIps struct {


### PR DESCRIPTION
This PR populates the the dnsName for the service vmmInjectedSvc for different service types. 
In case of aws, for a loadbalancer service,  the dns name is allocated by aws itself. But for NodePort, ClusterIP, ExternalName services, FQDN by default would be <service-name>.<namespace>.svc.cluster.local

Verified the DN posting on APIC 

Verified the dnsName assigned by loadbalancer service on aws 

Corresponding issue: https://github.com/noironetworks/support/issues/1380