### PR TITLE
Adding OCP-4.6 flavor for ESX to enable Ingress 

### DIFF
--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -110,6 +110,7 @@ type opflexOcService struct {
 var Version = map[string]bool{
 	"openshift-4.4-esx": true,
 	"openshift-4.5-esx": true,
+	"openshift-4.6-esx": true,
 }
 
 func (agent *HostAgent) initEndpointsInformerFromClient(


### PR DESCRIPTION
Adding OCP-4.6 flavor for ESX to enable ingress traffic when endpoint strategy is exposed as Loadbalancer