### PR TITLE
Adding OCP-4.6 flavor for ESX to enable Ingress traffic when endpoint…

### DIFF
--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -110,6 +110,7 @@ type opflexOcService struct {
 var Version = map[string]bool{
 	"openshift-4.4-esx": true,
 	"openshift-4.5-esx": true,
+	"openshift-4.6-esx": true,
 }
 
 func (agent *HostAgent) initEndpointsInformerFromClient(


### PR DESCRIPTION
Adding OCP-4.6 flavor for ESX to enable ingress traffic when endpoint stratergy is exposed as Loadbalancer

(cherry picked from commit 1ab8d3d3179a36ad1f91c2e1ec7c0f8a012500be)