### PR TITLE
CSCvy67206 APIC Container Domains Should accept empty Labels and Annotations

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -1219,6 +1219,12 @@ func NewVmmClusterFaultInfo(parentDn string, faultCode string) ApicObject {
 	return ret
 }
 func NewVmmInjectedLabel(parentDn string, name string, value string) ApicObject {
+	if name == "" {
+		name = " "
+	}
+	if value == "" {
+		value = " "
+	}
 	ret := newApicObject("vmmInjectedLabel")
 	ret["vmmInjectedLabel"].Attributes["name"] = name
 	ret["vmmInjectedLabel"].Attributes["value"] = value


### PR DESCRIPTION
Empty string is not allowed for naming props in ACI, hence replacing it with a space as compLabel and vmmInjectedLabel are used only by UI for displaying labels