### PR TITLE
Fix bug in SNAT policy computation logic

### DIFF
--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -250,8 +250,14 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 			}
 			cont.log.Debug("SnatPolicy Name: ", name)
 			if len(snatpolicy.SnatIp) != 0 {
+				nodeSNATEntryFound := cont.checkIfPolicyApplied(nodename, name, snatpolicy.ExpandedSnatIps)
+				if nodeSNATEntryFound {
+					cont.log.Debug("Allocation already done for nodename and snatpolicy", nodename, name)
+					continue
+				}
 				snatIp, portrange, alloc := cont.getIpAndPortRange(nodename, snatpolicy, "")
-				cont.log.Debug("SnatIP and Port range: ", snatIp, portrange)
+				cont.log.Info("Handling nodeinfo for node and snatpolicy: ", nodename, name)
+				cont.log.Info("Allocated SNAT IP and Port Range: ", snatIp, portrange)
 				if alloc == false {
 					cont.log.Error("Port Range Exhausted: ", name)
 					allocfailed[name] = true
@@ -266,10 +272,16 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 				updated = true
 			} else {
 				snatIps := cont.getServiceIps(snatpolicy)
+				nodeSNATEntryFound := cont.checkIfPolicyApplied(nodename, name, snatIps)
+				if nodeSNATEntryFound {
+					cont.log.Debug("Allocation already done for nodename and snatpolicy", nodename, name)
+					continue
+				}
 				cont.log.Debug("Service Ips: ", snatIps)
 				for _, snatip := range snatIps {
 					snatIp, portrange, alloc := cont.getIpAndPortRange(nodename, snatpolicy, snatip)
-					cont.log.Debug("SnatIP and Port range: ", snatIp, portrange)
+					cont.log.Info("Handling nodeinfo for node and snatpolicy: ", nodename, name)
+					cont.log.Info("Allocated SNAT IP and Port Range: ", snatIp, portrange)
 					if alloc == false {
 						cont.log.Error("Port Range Exhausted: ", name)
 						allocfailed[name] = true
@@ -348,7 +360,7 @@ func (cont *AciController) updateGlobalInfoforPolicy(portrange snatglobalinfo.Po
 	portlist = append(portlist, portrange)
 	ip := net.ParseIP(snatIp)
 	snatIpUuid, _ := uuid.FromBytes(ip)
-	cont.log.Debug("SnatIP and Port range: ", snatIp, portrange)
+	cont.log.Debug("Updating globalinfo for SNAT IP and Port range: ", snatIp, portrange)
 	cont.indexMutex.Lock()
 	glinfo := &snatglobalinfo.GlobalInfo{
 		MacAddress:     macaddr,
@@ -363,6 +375,20 @@ func (cont *AciController) updateGlobalInfoforPolicy(portrange snatglobalinfo.Po
 	cont.snatGlobalInfoCache[snatIp][nodename] = glinfo
 	cont.log.Info("Node name and globalinfo: ", nodename, glinfo)
 	cont.indexMutex.Unlock()
+}
+
+func (cont *AciController) checkIfPolicyApplied(nodename string, snatpolicyname string, snatIps []string) bool {
+	var nodeSNATEntryFound bool
+	for _, snatip := range snatIps {
+		if policyEntries, ok := cont.snatGlobalInfoCache[snatip]; ok {
+			if glinfo, nodepresent := policyEntries[nodename]; nodepresent {
+				if glinfo.SnatPolicyName == snatpolicyname {
+					nodeSNATEntryFound = true
+				}
+			}
+		}
+	}
+	return nodeSNATEntryFound
 }
 
 func (cont *AciController) getIpAndPortRange(nodename string, snatpolicy *ContSnatPolicy, serviceIp string) (string,


### PR DESCRIPTION
Currently we compute IP and port allocations for every policy when there's a change in any snat policy. This causes us to allocate additional port ranges to a node and policy pair. To avoid this, we want to skip computing if the policy is already applied on that node.

Also added more logging on INFO and DEBUG levels for SNAT

(cherry picked from commit 8b50ea2e9893704a9481ad09cfb71d89d241de64)