### PR TITLE
Move coveralls to the after_success lifecycle hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ matrix:
       script:
         - make goinstall
         - make check >& /tmp/check.log
-        - $GOPATH/bin/goveralls -coverprofile=covprof-ipam,covprof-index,covprof-apicapi,covprof-hostagent,covprof-controller,covprof-gbpserver -service=travis-ci
       after_failure:
         - grep -C 200 FAIL /tmp/check.log
         - tail -200 /tmp/check.log
       after_success:
         - tail -200 /tmp/check.log
+        - $GOPATH/bin/goveralls -coverprofile=covprof-ipam,covprof-index,covprof-apicapi,covprof-hostagent,covprof-controller,covprof-gbpserver -service=travis-ci
 


### PR DESCRIPTION
- Since an external service should not break our builds, this makes sure the  builds won’t fail because the exit code of after_success and after_failure  stages do not affect the build result.
- see: https://docs.travis-ci.com/user/job-lifecycle/#breaking-the-build

- We need to also check if  switching to codecov (https://codecov.io/) is worth the effort, since we are seeing a lot of issues with coveralls lately. 

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com