### PR TITLE
 Include accprovision operator image in CRD

### DIFF
--- a/pkg/accprovisioninput/apis/aci.ctrl/v1alpha1/types.go
+++ b/pkg/accprovisioninput/apis/aci.ctrl/v1alpha1/types.go
@@ -62,6 +62,7 @@ type NetConfigSpec struct {
 type RegistrySpec struct {
 	ImagePrefix                    string `json:"image_prefix,omitempty"`
 	ImagePullSecret                string `json:"image_pull_secret,omitempty"`
+	AccProvisionOperatorVersion    string `json:"acc_provision_operator_version,omitempty"`
 	AciContainersOperatorVersion   string `json:"aci_containers_operator_version,omitempty"`
 	AciContainersControllerVersion string `json:"aci_containers_controller_version,omitempty"`
 	AciContainersHostVersion       string `json:"aci_containers_host_version,omitempty"`


### PR DESCRIPTION
This enables user to upgrade the cluster by changing the acc-provision-operator image