### PR TITLE
Conditional addition of subscription for vmmInjetedLabel

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -772,6 +772,7 @@ var metadata = map[string]*apicMeta{
 			"hostName":        "",
 			"computeNodeName": "",
 		},
+		children: []string{},
 	},
 	"vmmInjectedDepl": {
 		attributes: map[string]interface{}{
@@ -779,6 +780,7 @@ var metadata = map[string]*apicMeta{
 			"name":     "",
 			"replicas": "",
 		},
+		children: []string{},
 	},
 	"vmmInjectedReplSet": {
 		attributes: map[string]interface{}{
@@ -786,6 +788,7 @@ var metadata = map[string]*apicMeta{
 			"name":           "",
 			"deploymentName": "",
 		},
+		children: []string{},
 	},
 	"vmmInjectedSvc": {
 		attributes: map[string]interface{}{
@@ -995,6 +998,12 @@ var metadata = map[string]*apicMeta{
 			"faultDesc":     "",
 			"faultSeverity": "",
 			"faultCode":     "",
+		},
+	},
+	"vmmInjectedLabel": {
+		attributes: map[string]interface{}{
+			"name":  "",
+			"value": "",
 		},
 	},
 }


### PR DESCRIPTION
- Before subscribing to vmm objects, add vmmInjectedLabel as a child after explicit APIC version check
- Since it is not supported for APIC versions < "5.0"

Refer: https://github.com/noironetworks/support/issues/1607

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com