### PR TITLE
Fix dns network policy log typo

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -55,11 +55,11 @@ const (
 )
 
 func dnsnetpolInit(cont *AciController, stopCh <-chan struct{}) {
-	cont.log.Debug("Initializing Dns client")
+	cont.log.Debug("Initializing Dns network policy client")
 	restconfig := cont.env.RESTConfig()
 	dnsNetpolClient, err := dnsnetpolclientset.NewForConfig(restconfig)
 	if err != nil {
-		cont.log.Errorf("Failed to intialize erspan client")
+		cont.log.Errorf("Failed to intialize Dns network policy client")
 		return
 	}
 	cont.initDnsNetworkPolicyInformerFromClient(dnsNetpolClient)


### PR DESCRIPTION
Dns network policy log erroneously contained erspan

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com