### PR TITLE
Build snat globalinfo cache during controller startup

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -119,7 +119,7 @@ func main() {
 		}
 		defer nslb.Stop()
 	}
-	cont := controller.NewController(config, env, log)
+	cont := controller.NewController(config, env, log, false)
 	cont.Init()
 	cont.Run(wait.NeverStop)
 	cont.RunStatus()

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -67,7 +67,7 @@ func testController() *testAciController {
 	}
 
 	cont := &testAciController{
-		AciController: *NewController(NewConfig(), &K8sEnvironment{}, log),
+		AciController: *NewController(NewConfig(), &K8sEnvironment{}, log, true),
 	}
 	cont.env.(*K8sEnvironment).cont = &cont.AciController
 	cont.serviceEndPoints = &serviceEndpoint{}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -58,6 +58,8 @@ type AciController struct {
 	defaultEg string
 	defaultSg string
 
+	unitTestMode bool
+
 	podQueue          workqueue.RateLimitingInterface
 	netPolQueue       workqueue.RateLimitingInterface
 	qosQueue          workqueue.RateLimitingInterface
@@ -285,13 +287,14 @@ func createQueue(name string) workqueue.RateLimitingInterface {
 		"delta")
 }
 
-func NewController(config *ControllerConfig, env Environment, log *logrus.Logger) *AciController {
+func NewController(config *ControllerConfig, env Environment, log *logrus.Logger, unittestmode bool) *AciController {
 	cont := &AciController{
-		log:       log,
-		config:    config,
-		env:       env,
-		defaultEg: "",
-		defaultSg: "",
+		log:          log,
+		config:       config,
+		env:          env,
+		defaultEg:    "",
+		defaultSg:    "",
+		unitTestMode: unittestmode,
 
 		podQueue:          createQueue("pod"),
 		netPolQueue:       createQueue("networkPolicy"),


### PR DESCRIPTION
Fix for SR690980526
Load the node infos during when the controller starts and build snatGlobalInfoCache accordingly. This helps us preserve any existing SNAT port allocations