### PR TITLE
Ipam leak master

### DIFF
--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -105,6 +105,8 @@ type HostAgent struct {
 	// reverse map to get ServiceIp's from poduid
 	podtoServiceUids map[string]map[string]string
 	nodePodIfEPs     map[string]*opflexEndpoint
+	// integration test checker
+	integ_test *string `json:",omitempty"`
 }
 
 type ServiceEndPointType interface {

--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -15,6 +15,9 @@
 package hostagent
 
 import (
+	"net"
+	"time"
+
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/noironetworks/aci-containers/pkg/metadata"
 	v1netpol "github.com/noironetworks/aci-containers/pkg/networkpolicy/apis/netpolicy/v1"
@@ -27,8 +30,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	framework "k8s.io/client-go/tools/cache/testing"
 	record "k8s.io/client-go/tools/record"
-	"net"
-	"time"
 )
 
 const nodename = "test-node"
@@ -174,6 +175,9 @@ func testAgentWithConf(hcf *HostAgentConfig) *testHostAgent {
 	agent.initDepPodIndex()
 	agent.initRCPodIndex()
 	agent.initQoSPolPodIndex()
+
+	integ_test := "true"
+	agent.integ_test = &integ_test
 
 	return agent
 }

--- a/pkg/hostagent/integ_test.go
+++ b/pkg/hostagent/integ_test.go
@@ -293,6 +293,7 @@ func (it *integ) cniAdd(podName, cid, ifname string) error {
 				HostVethName: "eth0",
 				Name:         ifname,
 				Sandbox:      testNetNS,
+				Mac:          "00:00:00:00:00:00",
 			},
 		},
 	}

--- a/pkg/hostagent/integ_test.go
+++ b/pkg/hostagent/integ_test.go
@@ -280,12 +280,13 @@ func (it *integ) addPodObj(id int, ns, eg, sg string, labels map[string]string) 
 }
 
 func (it *integ) cniAdd(podName, cid, ifname string) error {
-
+	integ_test := "true"
 	md := metadata.ContainerMetadata{
 		Id: metadata.ContainerId{
 			ContId:    cid,
 			Namespace: it.testNS,
 			Pod:       podName,
+			IntegTest: &integ_test,
 		},
 		Ifaces: []*metadata.ContainerIfaceMd{
 			{
@@ -340,6 +341,74 @@ func mkPod(uuid string, namespace string, name string,
 			Labels: labels,
 		},
 	}
+}
+
+func TestIPAMadd(t *testing.T) {
+	poolSizes := make([]int64, len(updIpams))
+	ncf := cniNetConfig{Subnet: cnitypes.IPNet{IP: net.ParseIP("10.128.2.0"), Mask: net.CIDRMask(24, 32)}}
+	hcf := &HostAgentConfig{
+		NodeName:  "node1",
+		EpRpcSock: "/tmp/aci-containers-ep-rpc.sock",
+		NetConfig: []cniNetConfig{ncf},
+	}
+
+	it := SetupInteg(t, hcf)
+	defer it.tearDown()
+
+	ipCounter := func() int64 {
+		var total int64
+		it.ta.ipamMutex.Lock()
+		defer it.ta.ipamMutex.Unlock()
+
+		ipaList := it.ta.podIps.GetV4IpCache()
+		for _, ipa := range ipaList {
+			total += ipa.GetSize()
+		}
+
+		return total
+	}
+
+	for ix, am := range updIpams {
+		it.setupNode(am, true)
+		poolSizes[ix] = ipCounter()
+		log.Infof("IP pool size is %v", poolSizes[ix])
+	}
+
+	// schedule annotation update in the background
+	stopCh := make(chan bool)
+	go func() {
+		var ix int
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-time.After(2 * time.Millisecond):
+				it.setupNode(updIpams[ix], false)
+			}
+
+			ix++
+			if ix > 1 {
+				ix = 0
+			}
+		}
+	}()
+
+	//	for jx := 0; jx < 2000; jx++ {
+	count := 1
+	it.cniAddParallel(0, count)
+
+	used, err := metadata.CheckMetadata(it.hcf.CniMetadataDir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check for leaks
+	avail := ipCounter()
+	ipCount := used + avail
+	if ipCount != poolSizes[0] && ipCount != poolSizes[1] {
+		t.Fatalf("ADD Iter: IP addr leak -- total: %v used: %v avail: %v", poolSizes, used, avail)
+	}
+	//}
 }
 
 func TestIPAM(t *testing.T) {

--- a/pkg/hostagent/ipam.go
+++ b/pkg/hostagent/ipam.go
@@ -149,7 +149,6 @@ func (agent *HostAgent) allocateIps(iface *metadata.ContainerIfaceMd, podKey str
 			}
 		}
 	}
-
 	if result != nil {
 		agent.deallocateIpsLocked(iface)
 	} else {
@@ -166,6 +165,7 @@ func (agent *HostAgent) deallocateIpsLocked(iface *metadata.ContainerIfaceMd) {
 		if ip.Address.IP == nil {
 			continue
 		}
+		agent.log.Infof("Deallocating IP: %v", ip.Address.IP)
 		if ip.Address.IP.To4() != nil {
 			agent.podIps.DeallocateIp(ip.Address.IP)
 			delete(agent.usedIPs, ip.Address.IP.String())
@@ -192,6 +192,7 @@ func (agent *HostAgent) deallocateMdIps(md *metadata.ContainerMetadata) {
 				continue
 			}
 
+			agent.log.Infof("Deallocating IP: %v", ip.Address.IP)
 			if ip.Address.IP.To4() != nil {
 				agent.podIps.DeallocateIp(ip.Address.IP)
 				delete(agent.usedIPs, ip.Address.IP.String())

--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -259,6 +259,7 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 		"namespace": metadata.Id.Namespace,
 		"container": metadata.Id.ContId,
 	})
+	logger.Infof("262 metadata.ID : %v", metadata.Id)
 
 	podKey := makePodKey(metadata.Id.Namespace, metadata.Id.Pod)
 	logger.Debug("Setting up veth")
@@ -303,7 +304,8 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 		}
 		logger.Infof("305 iface: %v", iface)
 		var hostVethName, mac string
-		if metadata.Id.IntegTest != nil {
+		if metadata.Id.IntegTest != nil && *metadata.Id.IntegTest == "true" {
+			logger.Infof("307 metadata.ID : %v", metadata.Id)
 			hostVethName, mac = iface.HostVethName, iface.Mac
 		}
 		for _, ip := range iface.IPs {
@@ -330,7 +332,8 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 			}
 		}
 		logger.Infof("329 iface: %v", iface)
-		if metadata.Id.IntegTest != nil {
+		if metadata.Id.IntegTest != nil && *metadata.Id.IntegTest == "true" {
+			logger.Infof("307 metadata.ID : %v", metadata.Id)
 			iface.HostVethName, iface.Mac = hostVethName, mac
 		}
 		if len(iface.HostVethName) == 0 || len(iface.Mac) == 0 {

--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -301,6 +301,11 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 				return nil, err
 			}
 		}
+		logger.Infof("305 iface: %v", iface)
+		var hostVethName, mac string
+		if metadata.Id.IntegTest != nil {
+			hostVethName, mac = iface.HostVethName, iface.Mac
+		}
 		for _, ip := range iface.IPs {
 			//There are 4 cases: IPv4-only, IPv6-only, dual stack with either IPv4 or IPv6 as the first address.
 			//We are guaranteed to derive the MAC address from IPv4 if it is assigned
@@ -324,7 +329,10 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 				return nil, err
 			}
 		}
-
+		logger.Infof("329 iface: %v", iface)
+		if metadata.Id.IntegTest != nil {
+			iface.HostVethName, iface.Mac = hostVethName, mac
+		}
 		if len(iface.HostVethName) == 0 || len(iface.Mac) == 0 {
 			l := fmt.Sprintf("Failed to setup Veth.{ContainerName= %v, HostVethName: { Name=%v, Lenght=%v} ,MAC: {Name=%v, Length=%v}}", metadata.Id.ContId, iface.HostVethName, len(iface.HostVethName), iface.Mac, len(iface.Mac))
 			er := fmt.Errorf("Unable to Configure Container Interface, Error: %v", l)

--- a/pkg/metadata/cnimetadata.go
+++ b/pkg/metadata/cnimetadata.go
@@ -37,10 +37,9 @@ type ContainerIfaceMd struct {
 }
 
 type ContainerId struct {
-	Namespace string  `json:"namespace,omitempty"`
-	Pod       string  `json:"pod,omitempty"`
-	ContId    string  `json:"cont-id,omitempty"`
-	IntegTest *string `json:"integ-test,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Pod       string `json:"pod,omitempty"`
+	ContId    string `json:"cont-id,omitempty"`
 }
 
 type ContainerMetadata struct {

--- a/pkg/metadata/cnimetadata.go
+++ b/pkg/metadata/cnimetadata.go
@@ -37,9 +37,10 @@ type ContainerIfaceMd struct {
 }
 
 type ContainerId struct {
-	Namespace string `json:"namespace,omitempty"`
-	Pod       string `json:"pod,omitempty"`
-	ContId    string `json:"cont-id,omitempty"`
+	Namespace string  `json:"namespace,omitempty"`
+	Pod       string  `json:"pod,omitempty"`
+	ContId    string  `json:"cont-id,omitempty"`
+	IntegTest *string `json:"integ-test,omitempty"`
 }
 
 type ContainerMetadata struct {

--- a/pkg/metadata/cnimetadata.go
+++ b/pkg/metadata/cnimetadata.go
@@ -100,7 +100,7 @@ func CheckMetadata(datadir string, network string) (int64, error) {
 				for _, ip := range ifc.IPs {
 					curr, ok := ipMap[ip.Address.String()]
 					if ok {
-						return 0, fmt.Errorf("pod: %s alreay has IP: %s, clashes with pod: %s", curr, ip.Address.String(), podId)
+						return 0, fmt.Errorf("pod: %s already has IP: %s, clashes with pod: %s", curr, ip.Address.String(), podId)
 					}
 
 					ipMap[ip.Address.String()] = podId


### PR DESCRIPTION
Not the best way I could think of to modify the integration test. 
The problem I'm facing here is that setupVeth makes some system level calls and expects to read from a network namespace file. So I think an approach could be to mock a netns file for the integ-test.