### PR TITLE
Increase snatWait time

### DIFF
--- a/pkg/controller/snatglobalinfo_test.go
+++ b/pkg/controller/snatglobalinfo_test.go
@@ -129,7 +129,7 @@ var nodeTests = []nodedata{
 
 func snatWait(t *testing.T, desc string, expected map[string]snatglobalinfo.GlobalInfo,
 	actual map[string]*snatglobalinfo.GlobalInfo) {
-	tu.WaitFor(t, desc, 100*time.Millisecond, func(last bool) (bool, error) {
+	tu.WaitFor(t, desc, 1000*time.Millisecond, func(last bool) (bool, error) {
 		for key, v := range expected {
 			val, ok := actual[key]
 			if ok {


### PR DESCRIPTION
- TestPeriodicSnatGlobalCacheCachesync fails periodically due to test timeout.
- Few data races were found in the test code that needs further work. Will take it up as a separate PR.
- This is a temporary fix.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com
