### PR TITLE
[kwai]Modify node info behavior when SNAT ports exhaust

### DIFF
--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -241,7 +241,7 @@ func (agent *HostAgent) snatPolicyUpdated(oldobj interface{}, newobj interface{}
 	// 2. if it is not present then delete the policy from localInfo as the portinfo is not allocated  for node
 	if newpolicyinfo.Status.State == snatpolicy.IpPortsExhausted {
 		agent.log.Info("Ports exhausted: ", newpolicyinfo.ObjectMeta.Name)
-		ginfo, ok := agent.opflexSnatGlobalInfos[agent.config.NodeName]
+		/*ginfo, ok := agent.opflexSnatGlobalInfos[agent.config.NodeName]
 		present := false
 		if ok {
 			for _, v := range ginfo {
@@ -252,7 +252,7 @@ func (agent *HostAgent) snatPolicyUpdated(oldobj interface{}, newobj interface{}
 		}
 		if !ok || !present {
 			agent.deletePolicy(newpolicyinfo)
-		}
+		}*/
 		return
 	}
 	if newpolicyinfo.Status.State != snatpolicy.Ready {

--- a/pkg/hostagent/snats_test.go
+++ b/pkg/hostagent/snats_test.go
@@ -311,6 +311,6 @@ func TestSnatPortExhausted(t *testing.T) {
 	agent.log.Info("SnatLocal Info #### ", agent.snatPods)
 	// check the policy is deleted from local information as ip/port is not allocated
 	_, ok := agent.snatPods["policy1"]
-	assert.Equal(t, false, ok, "create", "Epfile", "uids")
+	assert.Equal(t, true, ok, "create", "Epfile", "uids")
 	agent.stop()
 }


### PR DESCRIPTION
Instead of deleting policy entry, just log and return during handle snat policy update

(cherry picked from commit d8e6d86f53e7edf2951dae85cbcf80b27cdea64d)