### PR TITLE
[kwai]Build SNAT GlobalInfo cache during controller startup

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -119,7 +119,7 @@ func main() {
 		}
 		defer nslb.Stop()
 	}
-	cont := controller.NewController(config, env, log)
+	cont := controller.NewController(config, env, log, false)
 	cont.Init()
 	cont.Run(wait.NeverStop)
 	cont.RunStatus()

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -66,7 +66,7 @@ func testController() *testAciController {
 	}
 
 	cont := &testAciController{
-		AciController: *NewController(NewConfig(), &K8sEnvironment{}, log),
+		AciController: *NewController(NewConfig(), &K8sEnvironment{}, log, true),
 	}
 	cont.env.(*K8sEnvironment).cont = &cont.AciController
 	cont.serviceEndPoints = &serviceEndpoint{}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -58,6 +58,8 @@ type AciController struct {
 	defaultEg string
 	defaultSg string
 
+	unitTestMode bool
+
 	podQueue          workqueue.RateLimitingInterface
 	netPolQueue       workqueue.RateLimitingInterface
 	qosQueue          workqueue.RateLimitingInterface
@@ -281,13 +283,14 @@ func createQueue(name string) workqueue.RateLimitingInterface {
 		"delta")
 }
 
-func NewController(config *ControllerConfig, env Environment, log *logrus.Logger) *AciController {
+func NewController(config *ControllerConfig, env Environment, log *logrus.Logger, unittestmode bool) *AciController {
 	cont := &AciController{
-		log:       log,
-		config:    config,
-		env:       env,
-		defaultEg: "",
-		defaultSg: "",
+		log:          log,
+		config:       config,
+		env:          env,
+		defaultEg:    "",
+		defaultSg:    "",
+		unitTestMode: unittestmode,
 
 		podQueue:          createQueue("pod"),
 		netPolQueue:       createQueue("networkPolicy"),


### PR DESCRIPTION
Fix for SR690980526
Load the node infos during when the controller starts and build snatGlobalInfoCache accordingly. This helps us preserve any existing SNAT port allocations

This reverts commit f6a8b9d9a00d3354e10e3f1ba1bfa47b47ea2ad9.

(cherry picked from commit ccb7a9fa39e672c7a6cdd3a05082ca7f51051a12)