### PR TITLE
Add error checking when watchers of core resources fail to list and watch

### DIFF
--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -42,10 +42,18 @@ func (cont *AciController) initSnatNodeInformerFromClient(
 	cont.initSnatNodeInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return snatClient.AciV1().NodeInfos(metav1.NamespaceAll).List(context.TODO(), options)
+				obj, err := snatClient.AciV1().NodeInfos(metav1.NamespaceAll).List(context.TODO(), options)
+				if err != nil {
+					cont.log.Fatal("Failed to list NodeInfos during initialization of SnatNodeInformer")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return snatClient.AciV1().NodeInfos(metav1.NamespaceAll).Watch(context.TODO(), options)
+				obj, err := snatClient.AciV1().NodeInfos(metav1.NamespaceAll).Watch(context.TODO(), options)
+				if err != nil {
+					cont.log.Fatal("Failed to watch NodeInfos during initialization SnatNodeInformer")
+				}
+				return obj, err
 			},
 		})
 }
@@ -77,14 +85,20 @@ func (cont *AciController) initSnatCfgFromClient(
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.FieldSelector =
 					fields.Set{"metadata.name": "snat-operator-config"}.String()
-				return kubeClient.CoreV1().ConfigMaps(
-					"aci-containers-system").List(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().ConfigMaps("aci-containers-system").List(context.TODO(), options)
+				if err != nil {
+					cont.log.Fatal("Failed to list ConfigMap during initialization of SnatCfg")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.FieldSelector =
 					fields.Set{"metadata.name": "snat-operator-config"}.String()
-				return kubeClient.CoreV1().ConfigMaps(
-					"aci-containers-system").Watch(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().ConfigMaps("aci-containers-system").Watch(context.TODO(), options)
+				if err != nil {
+					cont.log.Fatal("Failed to watch NodeInfos during initialization SnatNodeInformer")
+				}
+				return obj, err
 			},
 		})
 }

--- a/pkg/hostagent/nodes.go
+++ b/pkg/hostagent/nodes.go
@@ -52,12 +52,20 @@ func (agent *HostAgent) initNodeInformerFromClient(
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.FieldSelector =
 					fields.Set{"metadata.name": agent.config.NodeName}.String()
-				return kubeClient.CoreV1().Nodes().List(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Nodes().List(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to list Nodes during initialization of NodeInformer")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.FieldSelector =
 					fields.Set{"metadata.name": agent.config.NodeName}.String()
-				return kubeClient.CoreV1().Nodes().Watch(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Nodes().Watch(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to watch Nodes during initialization of NodeInformer")
+				}
+				return obj, err
 			},
 		})
 }

--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -208,12 +208,20 @@ func (agent *HostAgent) initPodInformerFromClient(
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.FieldSelector =
 					fields.Set{"spec.nodeName": agent.config.NodeName}.String()
-				return kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to list Pods during initialization of PodInformer")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.FieldSelector =
 					fields.Set{"spec.nodeName": agent.config.NodeName}.String()
-				return kubeClient.CoreV1().Pods(metav1.NamespaceAll).Watch(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).Watch(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to watch Pods during initialization of PodInformer")
+				}
+				return obj, err
 			},
 		})
 
@@ -222,12 +230,20 @@ func (agent *HostAgent) initPodInformerFromClient(
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = labels.Set{"name": "aci-containers-controller"}.String()
 				//options.LabelSelector = "name=aci-containers-controller"
-				return kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to list Pods during initialization of ControllerInformer")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = labels.Set{"name": "aci-containers-controller"}.String()
 				//options.LabelSelector = "name=aci-containers-controller"
-				return kubeClient.CoreV1().Pods(metav1.NamespaceAll).Watch(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).Watch(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to watch Pods during initialization of ControllerInformer")
+				}
+				return obj, err
 			},
 		})
 }

--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -123,10 +123,18 @@ func (agent *HostAgent) initEndpointsInformerFromClient(
 	agent.initEndpointsInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).List(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).List(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to list Endpoints during initialization of EndpointsInformer")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).Watch(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).Watch(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to watch Endpoints during initialization of EndpointsInformer")
+				}
+				return obj, err
 			},
 		})
 }
@@ -156,10 +164,18 @@ func (agent *HostAgent) initEndpointSliceInformerFromClient(
 	agent.initEndpointSliceInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return kubeClient.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).List(context.TODO(), options)
+				obj, err := kubeClient.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).List(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to list EndpointSlices during initialization of EndpointSliceInformer")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return kubeClient.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).Watch(context.TODO(), options)
+				obj, err := kubeClient.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).Watch(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to watch EndpointSlices during initialization of EndpointSliceInformer")
+				}
+				return obj, err
 			},
 		})
 }
@@ -189,10 +205,18 @@ func (agent *HostAgent) initServiceInformerFromClient(
 	agent.initServiceInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return kubeClient.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to list Services during initialization of ServiceInformer")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return kubeClient.CoreV1().Services(metav1.NamespaceAll).Watch(context.TODO(), options)
+				obj, err := kubeClient.CoreV1().Services(metav1.NamespaceAll).Watch(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to watch Services during initialization of ServiceInformer")
+				}
+				return obj, err
 			},
 		})
 }

--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -105,10 +105,18 @@ func (agent *HostAgent) initSnatGlobalInformerFromClient(
 	agent.initSnatGlobalInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return snatClient.AciV1().SnatGlobalInfos(metav1.NamespaceAll).List(context.TODO(), options)
+				obj, err := snatClient.AciV1().SnatGlobalInfos(metav1.NamespaceAll).List(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to list SnatGlobalInfo during initialization of SnatGlobalInformer")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return snatClient.AciV1().SnatGlobalInfos(metav1.NamespaceAll).Watch(context.TODO(), options)
+				obj, err := snatClient.AciV1().SnatGlobalInfos(metav1.NamespaceAll).Watch(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to watch SnatGlobalInfo during initialization of SnatGlobalInformer")
+				}
+				return obj, err
 			},
 		})
 }
@@ -118,10 +126,18 @@ func (agent *HostAgent) initSnatPolicyInformerFromClient(
 	agent.initSnatPolicyInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return snatClient.AciV1().SnatPolicies().List(context.TODO(), options)
+				obj, err := snatClient.AciV1().SnatPolicies().List(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to list SnatPolicies during initialization of SnatPolicyInformer")
+				}
+				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return snatClient.AciV1().SnatPolicies().Watch(context.TODO(), options)
+				obj, err := snatClient.AciV1().SnatPolicies().Watch(context.TODO(), options)
+				if err != nil {
+					agent.log.Fatal("Failed to watch SnatPolicies during initialization of SnatPolicyInformer")
+				}
+				return obj, err
 			},
 		})
 }


### PR DESCRIPTION
- This patch adds error checking when watchers of core resources fail to list and watch.
- We exit the aci-containers-controller or the host-agent (any place from where we are adding a watcher) and log which watcher has failed to be added.

- Needs to be revisited to check if there is a common place where we can handle this for all resources

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com