### PR TITLE
Sanitize the key for the labels for Injected Objs

### DIFF
--- a/pkg/controller/deployments.go
+++ b/pkg/controller/deployments.go
@@ -109,8 +109,9 @@ func (cont *AciController) writeApicDepl(dep *appsv1.Deployment) {
 	}
 	if dep.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.0" {
 		for key, val := range dep.ObjectMeta.Labels {
+			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),
-				key, val)
+				newLabelKey, val)
 			aobj.AddChild(label)
 		}
 	}

--- a/pkg/controller/namespaces.go
+++ b/pkg/controller/namespaces.go
@@ -71,8 +71,9 @@ func (cont *AciController) writeApicNs(ns *v1.Namespace) {
 		ns.Name)
 	if ns.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.2" {
 		for key, val := range ns.ObjectMeta.Labels {
+			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),
-				key, val)
+				newLabelKey, val)
 			aobj.AddChild(label)
 		}
 	}

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -201,8 +201,9 @@ func (cont *AciController) writeApicPod(pod *v1.Pod) {
 	}
 	if pod.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.0" {
 		for key, val := range pod.ObjectMeta.Labels {
+			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),
-				key, val)
+				newLabelKey, val)
 			aobj.AddChild(label)
 		}
 	}

--- a/pkg/controller/replicasets.go
+++ b/pkg/controller/replicasets.go
@@ -85,8 +85,9 @@ func (cont *AciController) writeApicRs(rs *appsv1.ReplicaSet) {
 	}
 	if rs.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.0" {
 		for key, val := range rs.ObjectMeta.Labels {
+			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),
-				key, val)
+				newLabelKey, val)
 			aobj.AddChild(label)
 		}
 	}

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1116,8 +1116,9 @@ func (cont *AciController) writeApicSvc(key string, service *v1.Service) {
 	}
 	if service.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.2" {
 		for key, val := range service.ObjectMeta.Labels {
+			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),
-				key, val)
+				newLabelKey, val)
 			aobj.AddChild(label)
 		}
 	}


### PR DESCRIPTION
When injecting labels for k8s namespaces, services, replicasets,
deployments, namespaces and pods, we should sanitize the key to
remove any blackslashes in the "name" field. This is done to
comply with APIC naming conventions.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com