### PR TITLE
Set childAction attribute of vnsSvcRedirectPol object to deleteAll

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -712,6 +712,7 @@ func NewVnsSvcRedirectPol(tenantName string, name string) ApicObject {
 	ret["vnsSvcRedirectPol"].Attributes["name"] = name
 	ret["vnsSvcRedirectPol"].Attributes["dn"] =
 		fmt.Sprintf("uni/tn-%s/svcCont/svcRedirectPol-%s", tenantName, name)
+	ret["vnsSvcRedirectPol"].Attributes["childAction"] = "deleteAll"
 	return ret
 }
 


### PR DESCRIPTION
When vnsSvcRedirectPol is deleted from the service graph,
the child object isnt deleted. Hence there might be two nodes in the PBR.
This commit ensures the child vnsRedirectDest is deleted when
the top level object vnsSvcRedirectPol is deleted.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com