### PR TITLE
Check for port exhausted when nodeName is not present in globalInfoCache

### DIFF
--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -438,6 +438,7 @@ func (cont *AciController) nodeDeleted(obj interface{}) {
 	}
 	cont.apicConn.ClearApicObjects(cont.aciNameForKey("node", node.Name))
 	cont.apicConn.ClearApicObjects(cont.aciNameForKey("node-vmm", node.Name))
+	cont.log.Infof("Node deleted: %s", node.ObjectMeta.Name)
 
 	cont.indexMutex.Lock()
 	defer cont.indexMutex.Unlock()

--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -470,6 +470,12 @@ func (cont *AciController) deleteNodeinfoFromGlInfoCache(nodename string) bool {
 			if len(glinfos) == 0 {
 				delete(cont.snatGlobalInfoCache, snatip)
 			}
+		} else {
+			if cont.checksnatPolicyPortExhausted(v.SnatPolicyName) {
+				if cont.setSnatPolicyStatus(v.SnatPolicyName, snatv1.Ready) == true {
+					return true
+				}
+			}
 		}
 	}
 	return false


### PR DESCRIPTION
Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com