### PR TITLE
Fix for snat policy enforcing wrong snat ip 

### DIFF
--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -1011,11 +1011,7 @@ func (agent *HostAgent) getMatchingSnatPolicy(obj interface{}) (snatPolicyNames 
 				}
 				if res == POD {
 					if len(item.Spec.SnatIp) == 0 {
-						var services []*v1.Service
-						cache.ListAllByNamespace(agent.serviceInformer.GetIndexer(), namespace, labels.Everything(),
-							func(servobj interface{}) {
-								services = append(services, servobj.(*v1.Service))
-							})
+						services := util.GetServicesByOneOfLables(agent.serviceInformer.GetIndexer(), namespace, label)
 						// list the pods and apply the policy at service target
 						for _, service := range services {
 							if util.MatchLabels(item.Spec.Selector.Labels,

--- a/pkg/util/snat.go
+++ b/pkg/util/snat.go
@@ -22,8 +22,11 @@ import (
 	snatglobalclset "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/clientset/versioned"
 	snatpolicy "github.com/noironetworks/aci-containers/pkg/snatpolicy/apis/aci.snat/v1"
 	snatpolicyclset "github.com/noironetworks/aci-containers/pkg/snatpolicy/clientset/versioned"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"os"
 	"sort"
 	"strconv"
@@ -170,6 +173,19 @@ func MatchLabels(policylabels map[string]string, reslabels map[string]string) bo
 		}
 	}
 	return true
+}
+
+func GetServicesByOneOfLables(indexer cache.Indexer, ns string, reslabels map[string]string) []*v1.Service {
+	var services []*v1.Service
+	for key, value := range reslabels {
+		label := make(map[string]string)
+		label[key] = value
+		cache.ListAllByNamespace(indexer, ns, labels.SelectorFromSet(label),
+			func(servobj interface{}) {
+				services = append(services, servobj.(*v1.Service))
+			})
+	}
+	return services
 }
 
 // UpdateSnatPolicy Updates a UpdateSnatPolicy CR


### PR DESCRIPTION
List only the services which match the resource label instead of listing all the services in that namespace

Listing all services in the namespace and comparing its label with the labels of snatpolicies in cache was leading to updation of all snatpolicies in that namespace in the nodeinfo. Ideally it should update the nodeinfo only with snatpolicies corresponding to the resources in that node