### PR TITLE
Eliminate APIC GetVersion func call when writing svc obj

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -542,6 +542,8 @@ loop:
 	conn.Log.Debug("Exiting websocket handler")
 }
 
+//This function should only to be called before we make the first connection to APIC.
+//Use the cached Apic version when determining the version elsewhere. This can lead to inconsistent tokens.
 func (conn *ApicConnection) GetVersion() (string, error) {
 	versionMo := "firmwareCtrlrRunning"
 

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1061,13 +1061,8 @@ func (cont *AciController) writeApicSvc(key string, service *v1.Service) {
 		return
 	}
 	var setApicSvcDnsName bool
-	if len(cont.config.ApicHosts) != 0 {
-		version, err := cont.apicConn.GetVersion()
-		if err != nil {
-			cont.log.Error("Could not get APIC version, err: ", err)
-		} else if version >= "5.1" {
-			setApicSvcDnsName = true
-		}
+	if len(cont.config.ApicHosts) != 0 && apicapi.ApicVersion >= "5.1" {
+		setApicSvcDnsName = true
 	}
 	// APIC model only allows one of these
 	for _, ingress := range service.Status.LoadBalancer.Ingress {


### PR DESCRIPTION
"GetVersion()" function should only to be called before we make the first connection to APIC. We need to use the cached Apic version when determining the version elsewhere. This can lead to inconsistent tokens.