### PR TITLE
[kwai] Increase ApicRefreshTickerAdjust parameter value to 150Secs

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -65,7 +65,7 @@ type ControllerConfig struct {
 
 	// The number of seconds that APIC should wait before timing
 	// out a subscription on a websocket connection. If not
-	// explicitly set, then a default of 900 seconds will
+	// explicitly set, then a default of 1800 seconds will
 	// be sent in websocket subscriptions. If it is set to 0,
 	// then a timeout will not be sent in websocket
 	// subscriptions, and APIC will use it's default timeout
@@ -79,7 +79,7 @@ type ControllerConfig struct {
 	ApicRefreshTimer string `json:"apic-refreshtime,omitempty"`
 
 	// How early (seconds) the subscriptions to be refreshed than
-	// actual subscription refresh-timeout. Will be defaulted to 5Seconds.
+	// actual subscription refresh-timeout. Will be defaulted to 150Seconds.
 	ApicRefreshTickerAdjust string `json:"apic-refreshticker-adjust,omitempty"`
 
 	// A path for a PEM-encoded private key for client certificate

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -469,9 +469,9 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 			panic(err)
 		}
 	}
-	// If not defined, default is 900
+	// If not defined, default is 1800
 	if cont.config.ApicRefreshTimer == "" {
-		cont.config.ApicRefreshTimer = "900"
+		cont.config.ApicRefreshTimer = "1800"
 	}
 	refreshTimeout, err := strconv.Atoi(cont.config.ApicRefreshTimer)
 	if err != nil {
@@ -479,15 +479,15 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	}
 	cont.log.Info("ApicRefreshTimer conf is set to: ", refreshTimeout)
 
-	// Bailout if the refreshTimeout is more than 12Hours
-	if refreshTimeout > (12 * 60 * 60) {
-		cont.log.Info("ApicRefreshTimer can't be more than 12Hrs")
+	// Bailout if the refreshTimeout is more than 12Hours or less than 5Mins
+	if refreshTimeout > (12*60*60) || refreshTimeout < (5*60) {
+		cont.log.Info("ApicRefreshTimer can't be more than 12Hrs or less than 5Mins")
 		panic(err)
 	}
 
-	// If RefreshTickerAdjustInterval is not defined, default to 5Sec.
+	// If RefreshTickerAdjustInterval is not defined, default to 150Sec.
 	if cont.config.ApicRefreshTickerAdjust == "" {
-		cont.config.ApicRefreshTickerAdjust = "5"
+		cont.config.ApicRefreshTickerAdjust = "150"
 	}
 	refreshTickerAdjust, err := strconv.Atoi(cont.config.ApicRefreshTickerAdjust)
 	if err != nil {


### PR DESCRIPTION
and ApicRefreshTimer to 1800Secs to avoid subscription timeouts.

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com
(cherry picked from commit e4969278286a68c8af2381d922dad828daf7c0f5)