### PR TITLE
[kwai] Make creation of VmmInjectedLabel configurable

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -206,6 +206,9 @@ type ControllerConfig struct {
 
 	// Cluster Flavour
 	Flavor string `json:"flavor,omitempty"`
+
+	// Enable creation of VmmInjectedLabel, default is false
+	EnableVmmInjectedLabels bool `json:"enable-vmm-injected-labels,omitempty"`
 }
 
 type netIps struct {
@@ -243,6 +246,7 @@ func InitFlags(config *ControllerConfig) {
 	flag.StringVar(&config.LBType, "loadbalancer", lbTypeAci, "Loadbalancer")
 	flag.IntVar(&config.MaxCSRTunnels, "max-csr-tunnels", 16, "Number of CSR tunnels")
 	flag.IntVar(&config.CSRTunnelIDBase, "csr-tunnel-id-base", 4001, "CSR starting tunnel ID")
+	flag.BoolVar(&config.EnableVmmInjectedLabels, "enable-vmm-injected-labels", false, "Enable creation of VmmInjectedLabel")
 }
 
 func (cont *AciController) loadIpRanges(v4 *ipam.IpAlloc, v6 *ipam.IpAlloc,

--- a/pkg/controller/deployments.go
+++ b/pkg/controller/deployments.go
@@ -107,7 +107,7 @@ func (cont *AciController) writeApicDepl(dep *appsv1.Deployment) {
 	} else {
 		aobj.SetAttr("replicas", "1")
 	}
-	if dep.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.0" {
+	if cont.config.EnableVmmInjectedLabels && dep.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.0" {
 		for key, val := range dep.ObjectMeta.Labels {
 			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),

--- a/pkg/controller/namespaces.go
+++ b/pkg/controller/namespaces.go
@@ -69,7 +69,7 @@ func (cont *AciController) writeApicNs(ns *v1.Namespace) {
 	aobj := apicapi.NewVmmInjectedNs(cont.vmmDomainProvider(),
 		cont.config.AciVmmDomain, cont.config.AciVmmController,
 		ns.Name)
-	if ns.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.2" {
+	if cont.config.EnableVmmInjectedLabels && ns.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.2" {
 		for key, val := range ns.ObjectMeta.Labels {
 			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -18,9 +18,10 @@ package controller
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"reflect"
 	"strconv"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/noironetworks/aci-containers/pkg/apicapi"
 	"github.com/noironetworks/aci-containers/pkg/metadata"
@@ -199,7 +200,7 @@ func (cont *AciController) writeApicPod(pod *v1.Pod) {
 			break
 		}
 	}
-	if pod.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.0" {
+	if cont.config.EnableVmmInjectedLabels && pod.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.0" {
 		for key, val := range pod.ObjectMeta.Labels {
 			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),

--- a/pkg/controller/replicasets.go
+++ b/pkg/controller/replicasets.go
@@ -83,7 +83,7 @@ func (cont *AciController) writeApicRs(rs *appsv1.ReplicaSet) {
 			break
 		}
 	}
-	if rs.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.0" {
+	if cont.config.EnableVmmInjectedLabels && rs.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.0" {
 		for key, val := range rs.ObjectMeta.Labels {
 			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1118,7 +1118,7 @@ func (cont *AciController) writeApicSvc(key string, service *v1.Service) {
 		p.SetAttr("nodePort", strconv.Itoa(int(port.NodePort)))
 		aobj.AddChild(p)
 	}
-	if service.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.2" {
+	if cont.config.EnableVmmInjectedLabels && service.ObjectMeta.Labels != nil && apicapi.ApicVersion >= "5.2" {
 		for key, val := range service.ObjectMeta.Labels {
 			newLabelKey := cont.aciNameForKey("label", key)
 			label := apicapi.NewVmmInjectedLabel(aobj.GetDn(),


### PR DESCRIPTION
To reduce the number of APIC objects that need to managed (especially
in the case of heavy load and large scale) we should create the
vmmInjectedLabels optionally based on a configuration.
Default is set to false

Signed-off-by: Tanya Tukade tanyatukade.123@gmail.com
(cherry picked from commit dc199ab45d51a88a055b8c89dde6a22b7efd2669)