### PR TITLE
Fix for opflex-dev issue

### DIFF
--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -276,7 +276,8 @@ func (cont *AciController) updateServicesForNode(nodename string) {
 // must have index lock
 func (cont *AciController) fabricPathForNode(name string) (string, bool) {
 	sz := len(cont.nodeOpflexDevice[name])
-	for _, device := range cont.nodeOpflexDevice[name] {
+	for i := range cont.nodeOpflexDevice[name] {
+		device := cont.nodeOpflexDevice[name][sz-1-i]
 		if device.GetAttrStr("state") == "connected" {
 			cont.fabricPathLogger(device.GetAttrStr("hostName"), device).Info("Processing fabric path for node ",
 				"when connected device state is found")


### PR DESCRIPTION
Iterate over the list cont.nodeOpflexDevice[name] in the reverse order such that the last element gets processed first

Fixes the issue where the service graph is not getting reprogrammed correctly in response to a VM migration