### PR TITLE
Fixed deadlock in hostagent

### DIFF
--- a/pkg/hostagent/snatlocalinfo.go
+++ b/pkg/hostagent/snatlocalinfo.go
@@ -51,7 +51,6 @@ func (agent *HostAgent) UpdateLocalInfoCr() bool {
 		var localInfo SnatLocalInfo
 		localInfo.snatIp = ginfo.SnatIp
 		agent.snatPolicyCacheMutex.RLock()
-		defer agent.snatPolicyCacheMutex.RUnlock()
 		if _, ok := agent.snatPolicyCache[ginfo.SnatPolicyName]; ok {
 			if len(agent.snatPolicyCache[ginfo.SnatPolicyName].Spec.DestIp) == 0 {
 				localInfo.destIps = []string{"0.0.0.0/0"}
@@ -60,6 +59,7 @@ func (agent *HostAgent) UpdateLocalInfoCr() bool {
 					agent.snatPolicyCache[ginfo.SnatPolicyName].Spec.DestIp
 			}
 		}
+		agent.snatPolicyCacheMutex.RUnlock()
 		localInfo.snatpolicyName = ginfo.SnatPolicyName
 		snatLocalInfo[ginfo.SnatIpUid] = localInfo
 	}


### PR DESCRIPTION
Trying to access snatPolicyCacheMutex.RLock again in same goroutine
without releasing already acquired snatPolicyCacheMutex.RLock was causing
deadlock. This goroutine accessed its first snatPolicyCacheMutex.RLock
and then another goroutine stated waiting for snatPolicyCacheMutex.Lock
and hence the first goroutine was not able to access the 2nd
snatPolicyCacheMutex.RLock which caused the deadlock

Avoided the 2nd occurance of snatPolicyCacheMutex.RLock in same
goroutine without releasing the 1st read lock.

(cherry picked from commit 65e7351d01252b1f561af892bccc538cc7c3e586)