### PR TITLE
Fix for IPAM leaks in hostagent due to data races

### DIFF
--- a/pkg/hostagent/ipam.go
+++ b/pkg/hostagent/ipam.go
@@ -120,6 +120,8 @@ func makeIFaceIp(nc *cniNetConfig, ip net.IP) metadata.ContainerIfaceIP {
 func (agent *HostAgent) allocateIps(iface *metadata.ContainerIfaceMd, podKey string) error {
 	var result error
 	var err error
+	agent.indexMutex.Lock()
+	defer agent.indexMutex.Unlock()
 	agent.ipamMutex.Lock()
 	defer agent.ipamMutex.Unlock()
 

--- a/pkg/hostagent/ovs.go
+++ b/pkg/hostagent/ovs.go
@@ -290,8 +290,6 @@ func (agent *HostAgent) diffPorts(bridges map[string]ovsBridge) []libovsdb.Opera
 		}
 	}
 
-	agent.indexMutex.Unlock()
-
 	for _, brName := range brNames {
 		br, ok := bridges[brName]
 		if !ok {
@@ -321,7 +319,7 @@ func (agent *HostAgent) diffPorts(bridges map[string]ovsBridge) []libovsdb.Opera
 			ops = append(ops, delBrPortOp(br.uuid, delports))
 		}
 	}
-
+	agent.indexMutex.Unlock()
 	return ops
 }
 

--- a/pkg/hostagent/status.go
+++ b/pkg/hostagent/status.go
@@ -68,6 +68,7 @@ func (agent *HostAgent) RunStatus() {
 	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		agent.indexMutex.Lock()
+		agent.ipamMutex.Lock()
 		status := &agentStatus{
 			Endpoints: len(agent.opflexEps),
 			Services:  len(agent.opflexServices),
@@ -78,11 +79,13 @@ func (agent *HostAgent) RunStatus() {
 			UsedIPs: len(agent.usedIPs),
 		}
 		json.NewEncoder(w).Encode(status)
+		agent.ipamMutex.Unlock()
 		agent.indexMutex.Unlock()
 	})
 	http.HandleFunc("/ipam", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		agent.indexMutex.Lock()
+		agent.ipamMutex.Lock()
 		is := &ipamStatus{
 			PodIps: metadata.NetIps{
 				V4: agent.podIps.CombineV4(),
@@ -91,6 +94,7 @@ func (agent *HostAgent) RunStatus() {
 			UsedIPs: agent.usedIPs,
 		}
 		json.NewEncoder(w).Encode(is)
+		agent.ipamMutex.Unlock()
 		agent.indexMutex.Unlock()
 	})
 	agent.log.Info("Starting status server")


### PR DESCRIPTION
Added locks to fix data races in hostagent.

Accessing shared variables without lock in hostagent was causing data
races leading to IPAM leaks

(cherry picked from commit 4325f4b8cc6711377eb6d61d1a8a530c44be5de1)