### PR TITLE
Cleanup old oplfex devices

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -211,7 +211,7 @@ type ControllerConfig struct {
 	EnableVmmInjectedLabels bool `json:"enable-vmm-injected-labels,omitempty"`
 
 	// Timeout to delete old opflex devices
-	DeviceDeleteTimeout float64 `json:"device-delete-timeout,omitempty"`
+	OpflexDeviceDeleteTimeout float64 `json:"opflex-device-delete-timeout,omitempty"`
 }
 
 type netIps struct {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -209,6 +209,9 @@ type ControllerConfig struct {
 
 	// Enable creation of VmmInjectedLabel, default is false
 	EnableVmmInjectedLabels bool `json:"enable-vmm-injected-labels,omitempty"`
+
+	// Timeout to delete old opflex devices
+	DeviceDeleteTimeout float64 `json:"device-delete-timeout,omitempty"`
 }
 
 type netIps struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -494,9 +494,9 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		panic(err)
 	}
 
-	// If DeviceDeleteTimeout is not defined, default to 1800s
-	if cont.config.DeviceDeleteTimeout == 0 {
-		cont.config.DeviceDeleteTimeout = 1800
+	// If OpflexDeviceDeleteTimeout is not defined, default to 1800s
+	if cont.config.OpflexDeviceDeleteTimeout == 0 {
+		cont.config.OpflexDeviceDeleteTimeout = 1800
 	}
 
 	// If not defined, default to 32

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -306,5 +306,6 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 	if !cont.config.DisablePeriodicSnatGlobalInfoSync {
 		go cont.snatGlobalInfoSync(stopCh, 60)
 	}
+	go cont.syncOpflexDevices(stopCh, 60)
 	return nil
 }

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/noironetworks/aci-containers/pkg/apicapi"
 	"github.com/noironetworks/aci-containers/pkg/metadata"
@@ -274,6 +275,61 @@ func (cont *AciController) updateServicesForNode(nodename string) {
 }
 
 // must have index lock
+func (cont *AciController) getActiveFabricPathDn(node string) string {
+	var fabricPathDn string
+	sz := len(cont.nodeOpflexDevice[node])
+	for i := range cont.nodeOpflexDevice[node] {
+		device := cont.nodeOpflexDevice[node][sz-1-i]
+		if device.GetAttrStr("state") == "connected" {
+			fabricPathDn = device.GetAttrStr("fabricPathDn")
+			break
+		}
+	}
+	return fabricPathDn
+}
+
+func (cont *AciController) deleteOldOpflexDevices() {
+	cont.indexMutex.Lock()
+	defer cont.indexMutex.Unlock()
+	for node, devices := range cont.nodeOpflexDevice {
+		fabricPathDn := cont.getActiveFabricPathDn(node)
+		if fabricPathDn != "" {
+			updated := false
+			for i, device := range devices {
+				if device.GetAttrStr("delete") == "true" && device.GetAttrStr("fabricPathDn") != fabricPathDn {
+					deleteTimeStr := device.GetAttrStr("deleteTime")
+					deleteTime, err := time.Parse(time.RFC3339, deleteTimeStr)
+					if err != nil {
+						cont.log.Error("Failed to parse opflex device delete time: ", err)
+						continue
+					}
+					now := time.Now()
+					diff := now.Sub(deleteTime)
+					if diff.Seconds() >= cont.config.DeviceDeleteTimeout {
+						devices = append(devices[:i], devices[i+1:]...)
+						updated = true
+					}
+				}
+			}
+			if updated {
+				cont.nodeOpflexDevice[node] = devices
+			}
+		}
+	}
+}
+
+// must have index lock
+func (cont *AciController) setDeleteFlagForOldDevices(node, fabricPathDn string) {
+	for _, device := range cont.nodeOpflexDevice[node] {
+		if device.GetAttrStr("fabricPathDn") != fabricPathDn {
+			t := time.Now()
+			device.SetAttr("delete", "true")
+			device.SetAttr("deleteTime", t.Format(time.RFC3339))
+		}
+	}
+}
+
+// must have index lock
 func (cont *AciController) fabricPathForNode(name string) (string, bool) {
 	sz := len(cont.nodeOpflexDevice[name])
 	for i := range cont.nodeOpflexDevice[name] {
@@ -281,7 +337,9 @@ func (cont *AciController) fabricPathForNode(name string) (string, bool) {
 		if device.GetAttrStr("state") == "connected" {
 			cont.fabricPathLogger(device.GetAttrStr("hostName"), device).Info("Processing fabric path for node ",
 				"when connected device state is found")
-			return device.GetAttrStr("fabricPathDn"), true
+			fabricPathDn := device.GetAttrStr("fabricPathDn")
+			cont.setDeleteFlagForOldDevices(name, fabricPathDn)
+			return fabricPathDn, true
 		}
 	}
 	if sz > 0 {

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -317,7 +317,7 @@ func (cont *AciController) deleteOldOpflexDevices() {
 					}
 					now := time.Now()
 					diff := now.Sub(deleteTime)
-					if diff.Seconds() >= cont.config.DeviceDeleteTimeout {
+					if diff.Seconds() >= cont.config.OpflexDeviceDeleteTimeout {
 						delDevices = append(delDevices, device)
 					}
 				}


### PR DESCRIPTION
* Check if there are any other opflex-odevs in the list which have a
different “fabricPathDn” than the last one
* Flag these entries for delete after a configurable period which defaults to 30 minutes
* Just before finally deleting the entry check if the opflex-odev list has changed and if the opflex-odevs we are trying to delete are not the only ones in the list or are currently being used