### PR TITLE
Cleanup old oplfex devices

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -209,6 +209,9 @@ type ControllerConfig struct {
 
 	// Enable creation of VmmInjectedLabel, default is false
 	EnableVmmInjectedLabels bool `json:"enable-vmm-injected-labels,omitempty"`
+
+	// Timeout to delete old opflex devices
+	OpflexDeviceDeleteTimeout float64 `json:"opflex-device-delete-timeout,omitempty"`
 }
 
 type netIps struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -494,6 +494,11 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		panic(err)
 	}
 
+	// If OpflexDeviceDeleteTimeout is not defined, default to 1800s
+	if cont.config.OpflexDeviceDeleteTimeout == 0 {
+		cont.config.OpflexDeviceDeleteTimeout = 1800
+	}
+
 	// If not defined, default to 32
 	if cont.config.PodIpPoolChunkSize == 0 {
 		cont.config.PodIpPoolChunkSize = 32
@@ -683,6 +688,21 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 			cont.opflexDeviceDeleted(dn)
 		})
 	go cont.apicConn.Run(stopCh)
+}
+
+func (cont *AciController) syncOpflexDevices(stopCh <-chan struct{}, seconds time.Duration) {
+	cont.log.Debug("Go routine to periodically delete old opflexdevices started")
+	ticker := time.NewTicker(seconds * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			cont.deleteOldOpflexDevices()
+		case <-stopCh:
+			return
+		}
+	}
 }
 
 func (cont *AciController) snatGlobalInfoSync(stopCh <-chan struct{}, seconds time.Duration) {

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -306,5 +306,6 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 	if !cont.config.DisablePeriodicSnatGlobalInfoSync {
 		go cont.snatGlobalInfoSync(stopCh, 60)
 	}
+	go cont.syncOpflexDevices(stopCh, 60)
 	return nil
 }


### PR DESCRIPTION
* Check if there are any other opflex-odevs in the list which have a different “fabricPathDn” than the last one
* Flag these entries for delete after a configurable period which defaults to 30 minutes
* Just before finally deleting the entry check if the opflex-odev list has changed and if the opflex-odevs we are trying to delete are not the only ones in the list or are currently being used

(cherry picked from commit 8a67a42670b6cd1ff2a200c2c0a50e4433ac56c3)
(cherry picked from commit 0147ded335f98a2674acb1c411fb2af033bae4bb)
(cherry picked from commit 8a67a42670b6cd1ff2a200c2c0a50e4433ac56c3)