### PR TITLE
Introduce 100ms delay after each subscription query

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -100,6 +100,7 @@ type ApicConnection struct {
 	ReconnectInterval   time.Duration
 	RefreshInterval     time.Duration
 	RefreshTickerAdjust time.Duration
+	SubscriptionDelay   time.Duration
 	RetryInterval       time.Duration
 	SnatPbrFltrChain    bool // Configure SNAT PBR to use filter-chain
 	FullSyncHook        func()

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -183,7 +183,8 @@ func configureTls(cert []byte) (*tls.Config, error) {
 
 func New(log *logrus.Logger, apic []string, user string,
 	password string, privKey []byte, cert []byte,
-	prefix string, refresh int, refreshTickerAdjust int) (*ApicConnection, error) {
+	prefix string, refresh int, refreshTickerAdjust int,
+	subscriptionDelay int) (*ApicConnection, error) {
 	tls, err := configureTls(cert)
 	if err != nil {
 		return nil, err
@@ -218,6 +219,7 @@ func New(log *logrus.Logger, apic []string, user string,
 		ReconnectInterval:   time.Duration(5) * time.Second,
 		RefreshInterval:     time.Duration(refresh) * time.Second,
 		RefreshTickerAdjust: time.Duration(refreshTickerAdjust) * time.Second,
+		SubscriptionDelay:   time.Duration(subscriptionDelay) * time.Millisecond,
 		Signer:              signer,
 		Dialer:              dialer,
 		Logger:              log,
@@ -1233,6 +1235,7 @@ func (conn *ApicConnection) doSubscribe(args []string,
 		conn.Log.Error("Could not decode APIC response", err)
 		return false
 	}
+	time.Sleep(conn.SubscriptionDelay)
 	return true
 }
 

--- a/pkg/apicapi/apicapi_test.go
+++ b/pkg/apicapi/apicapi_test.go
@@ -181,7 +181,7 @@ func (server *testServer) testConn(key []byte) (*ApicConnection, error) {
 	})
 
 	n, err := New(log, []string{apic}, "admin", "noir0123", key, cert, "kube",
-		60, 5)
+		60, 5, 5)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/annotation_test.go
+++ b/pkg/controller/annotation_test.go
@@ -172,7 +172,7 @@ func (server *testServer) testConn(key []byte) (*apicapi.ApicConnection, error) 
 	})
 
 	n, err := apicapi.New(log, []string{apic}, "admin", "noir0123", key, cert, "kube",
-		60, 5)
+		60, 5, 5)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -78,6 +78,10 @@ type ControllerConfig struct {
 	// Also, note that this is a string.
 	ApicRefreshTimer string `json:"apic-refreshtime,omitempty"`
 
+	// Delay in milliseconds after each subscription query
+	// Will be defaulted to 100ms.
+	ApicSubscriptionDelay int `json:"apic-subscription-delay,omitempty"`
+
 	// How early (seconds) the subscriptions to be refreshed than
 	// actual subscription refresh-timeout. Will be defaulted to 150Seconds.
 	ApicRefreshTickerAdjust string `json:"apic-refreshticker-adjust,omitempty"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -494,6 +494,12 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		panic(err)
 	}
 
+	//If ApicSubscriptionDelay is not defined, default to 100ms
+	if cont.config.ApicSubscriptionDelay == 0 {
+		cont.config.ApicSubscriptionDelay = 100
+	}
+	cont.log.Info("ApicSubscriptionDelay conf is set to: ", cont.config.ApicSubscriptionDelay)
+
 	// If OpflexDeviceDeleteTimeout is not defined, default to 1800s
 	if cont.config.OpflexDeviceDeleteTimeout == 0 {
 		cont.config.OpflexDeviceDeleteTimeout = 1800
@@ -534,7 +540,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	cont.apicConn, err = apicapi.New(cont.log, cont.config.ApicHosts,
 		cont.config.ApicUsername, cont.config.ApicPassword,
 		privKey, apicCert, cont.config.AciPrefix,
-		refreshTimeout, refreshTickerAdjust)
+		refreshTimeout, refreshTickerAdjust, cont.config.ApicSubscriptionDelay)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/gbpserver/integ_test.go
+++ b/pkg/gbpserver/integ_test.go
@@ -177,7 +177,7 @@ func TestBasic(t *testing.T) {
 	logger.Level = log.DebugLevel
 
 	conn, err := apicapi.New(logger, []string{"127.0.0.1:8899"},
-		"admin", "test0123", apicKey, apicCert, testTenant, 60, 5)
+		"admin", "test0123", apicKey, apicCert, testTenant, 60, 5, 5)
 	if err != nil {
 		t.Errorf("Starting apicapi : %v", err)
 		t.FailNow()
@@ -566,7 +566,7 @@ func TestAPIC(t *testing.T) {
 		DisableColors: true,
 	}
 
-	conn, err := apicapi.New(log1, []string{"18.217.5.107:443"}, "admin", "test!234", nil, nil, "test", 60, 5)
+	conn, err := apicapi.New(log1, []string{"18.217.5.107:443"}, "admin", "test!234", nil, nil, "test", 60, 5, 5)
 	if err != nil {
 		log.Errorf("New connection -- %v", err)
 		t.FailNow()
@@ -626,7 +626,7 @@ func AddEP(t *testing.T, tenant, region, vrf, epgDn string, add bool) {
 		DisableColors: true,
 	}
 
-	conn, err := apicapi.New(log1, []string{"18.217.5.107:443"}, "admin", "noir0!234", nil, nil, "test", 60, 5)
+	conn, err := apicapi.New(log1, []string{"18.217.5.107:443"}, "admin", "noir0!234", nil, nil, "test", 60, 5, 5)
 	if err != nil {
 		log.Errorf("New connection -- %v", err)
 		t.FailNow()

--- a/pkg/gbpserver/stateinit/apic_init.go
+++ b/pkg/gbpserver/stateinit/apic_init.go
@@ -122,7 +122,7 @@ func setupApicConn(cfg *gbpserver.GBPServerConfig) *apicapi.ApicConnection {
 	}
 
 	conn, err := apicapi.New(logger, cfg.Apic.Hosts, cfg.Apic.Username, cfg.Apic.Username,
-		privKey, apicCert, "k8s", refreshTime, 5)
+		privKey, apicCert, "k8s", refreshTime, 5, 5)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/gbpserver/watchers/apic_watch.go
+++ b/pkg/gbpserver/watchers/apic_watch.go
@@ -105,7 +105,7 @@ func (aw *ApicWatcher) Init(apicUrl []string, stopCh <-chan struct{}) error {
 	// eventually, the url and credentials will come from the crd
 	ai := aw.apicInfo
 	conn, err := apicapi.New(aw.logger, apicUrl, ai.user, ai.password,
-		ai.privKey, ai.cert, ai.prefix, refreshTime, 5)
+		ai.privKey, ai.cert, ai.prefix, refreshTime, 5, 5)
 
 	if err != nil {
 		return err

--- a/pkg/gbpserver/watchers/ep_sync_test.go
+++ b/pkg/gbpserver/watchers/ep_sync_test.go
@@ -78,7 +78,7 @@ func (server *testServer) testConn(key []byte) (*apicapi.ApicConnection, error) 
 	})
 
 	n, err := apicapi.New(log, []string{apic}, "admin", "noir0123", key, cert, "kube",
-		60, 5)
+		60, 5, 5)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The server side (nginx) is not able to handle when multiple requests are
sent in quick succession. Added a 100s delay between each subscription
query to fix the issue

Signed-off-by: Akhila <akhila.mohanan@oneconvergence.com>