### PR TITLE
Include subscription delay in refresh path

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -733,6 +733,7 @@ func (conn *ApicConnection) refresh() {
 			}
 			complete(resp)
 			conn.Log.Debugf("Refresh sub: url %v", url)
+			time.Sleep(conn.SubscriptionDelay)
 		}
 		if len(sub.ChildSubs) > 0 {
 			for id := range sub.ChildSubs {


### PR DESCRIPTION
To prevent apic failures in the refresh path

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>