### PR TITLE
Include subscription delay in refresh path

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -733,6 +733,7 @@ func (conn *ApicConnection) refresh() {
 			}
 			complete(resp)
 			conn.log.Debugf("Refresh sub: url %v", url)
+			time.Sleep(conn.SubscriptionDelay)
 		}
 		if len(sub.childSubs) > 0 {
 			for id := range sub.childSubs {


### PR DESCRIPTION
To prevent apic failures in the refresh path

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit 95aa28d0cfd6c32c6effc573c51a657107dbaabf)