### PR TITLE
Clear split subscriptions on connection reset

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -651,6 +651,9 @@ func (conn *ApicConnection) Run(stopCh <-chan struct{}) {
 				"host": conn.Apic[conn.ApicIndex],
 			}).Info("Connecting to APIC")
 
+			for dn := range conn.subscriptions.subs {
+				conn.subscriptions.subs[dn].childSubs = make(map[string]subComponent)
+			}
 			conn.subscriptions.ids = make(map[string]string)
 
 			token, err := conn.login()


### PR DESCRIPTION
If controller loses an apic connection, the next apic in the list will be tried.
At that time, clear the child subscription ids that were cached.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit ca4e0dda9d90284082a13c29842122b06fca33ed)