### PR TITLE
Fix for snat-uuid missing in ep file

### DIFF
--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -400,6 +400,10 @@ func (agent *HostAgent) EnableSync() (changed bool) {
 }
 
 func (agent *HostAgent) Run(stopCh <-chan struct{}) {
+	err := agent.populateSnatLocalInfos()
+	if err != nil {
+		agent.log.Error("Failed to populate opflexSnatLocalInfos ", err.Error())
+	}
 	syncEnabled, err := agent.env.PrepareRun(stopCh)
 	if err != nil {
 		panic(err.Error())

--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -168,28 +168,46 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 	cache.WaitForCacheSync(stopCh, env.agent.nodeInformer.HasSynced)
 	env.agent.log.Info("Node cache sync successful")
 
+	env.agent.log.Debug("Starting service informer")
+	go env.agent.serviceInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for service cache sync")
+	cache.WaitForCacheSync(stopCh, env.agent.serviceInformer.HasSynced)
+	env.agent.log.Info("Service cache sync successful")
+
+	env.agent.log.Debug("Starting snat global informer")
+	go env.agent.snatGlobalInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for snat global cache sync")
+	cache.WaitForCacheSync(stopCh, env.agent.snatGlobalInformer.HasSynced)
+	env.agent.log.Info("Snat global cache sync successful")
+
+	env.agent.log.Debug("Starting snat policy informer")
+	go env.agent.snatPolicyInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for snat policy sync")
+	cache.WaitForCacheSync(stopCh, env.agent.snatPolicyInformer.HasSynced)
+	env.agent.log.Info("Snat policy sync successful")
+
+	env.agent.log.Debug("Starting rdConfig informer")
+	go env.agent.rdConfigInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for rdConfig cache sync")
+	cache.WaitForCacheSync(stopCh, env.agent.rdConfigInformer.HasSynced)
+	env.agent.log.Info("RdConfig cache sync successful")
+
 	env.agent.log.Debug("Starting remaining informers")
 	env.agent.log.Debug("Exporting node info: ", env.agent.config.NodeName)
 	go env.agent.podInformer.Run(stopCh)
 	cache.WaitForCacheSync(stopCh, env.agent.podInformer.HasSynced)
+	env.agent.log.Info("Pod cache sync successful")
 	go env.agent.controllerInformer.Run(stopCh)
 	env.agent.serviceEndPoints.Run(stopCh)
-	go env.agent.serviceInformer.Run(stopCh)
 	go env.agent.nsInformer.Run(stopCh)
 	go env.agent.netPolInformer.Run(stopCh)
 	go env.agent.depInformer.Run(stopCh)
 	go env.agent.rcInformer.Run(stopCh)
-	go env.agent.snatGlobalInformer.Run(stopCh)
-	go env.agent.snatPolicyInformer.Run(stopCh)
 	go env.agent.qosPolicyInformer.Run(stopCh)
-	go env.agent.rdConfigInformer.Run(stopCh)
-	env.agent.log.Info("Waiting for cache sync for remaining objects")
-	cache.WaitForCacheSync(stopCh, env.agent.serviceInformer.HasSynced,
-		env.agent.snatGlobalInformer.HasSynced, env.agent.snatPolicyInformer.HasSynced,
-		env.agent.rdConfigInformer.HasSynced)
 	env.agent.log.Info("Cache sync successful")
 	return true, nil
 }
+
 func (env *K8sEnvironment) CniDeviceChanged(metadataKey *string, id *md.ContainerId) {
 	env.agent.podChanged(metadataKey)
 }

--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -432,7 +432,7 @@ func (agent *HostAgent) syncEps() bool {
 				if ep.Uuid != epidstr {
 					continue
 				}
-				ep.SnatUuid, err = agent.getSnatUuids(poduuid)
+				ep.SnatUuid, err = agent.getSnatUuids(poduuid, epfile)
 				if err != nil {
 					agent.log.Error("Error while getting snat uuids")
 					needRetry = true
@@ -472,8 +472,9 @@ func (agent *HostAgent) syncEps() bool {
 			if seen[ep.Uuid] {
 				continue
 			}
+			epfile := agent.FormEPFilePath(ep.Uuid)
 			poduuid := strings.Split(ep.Uuid, "_")[0]
-			ep.SnatUuid, err = agent.getSnatUuids(poduuid)
+			ep.SnatUuid, err = agent.getSnatUuids(poduuid, epfile)
 			if err != nil {
 				agent.log.Error("Error while getting snat uuids")
 				needRetry = true
@@ -481,7 +482,6 @@ func (agent *HostAgent) syncEps() bool {
 			}
 			ep.ServiceClusterIps = agent.getServiceIPs(poduuid)
 			opflexEpLogger(agent.log, ep).Info("Adding endpoint")
-			epfile := agent.FormEPFilePath(ep.Uuid)
 			_, err = writeEp(epfile, ep)
 			if err != nil {
 				opflexEpLogger(agent.log, ep).


### PR DESCRIPTION
* RCA: Sometimes syncEps() was called at the time of initialization even before
opflexSnatLocalinfo was not updated with snat-uuids and empty snat-uuid list was written to ep file.

* Fix: If opflexSnatLocalinfo update is not happened before syncEps() at the
time of initialization, snat-uuids in the ep file will be maintained

(cherry picked from commit c15e2e5dba474e20c430575fdd651f91b9c02652)