### PR TITLE
Unconfigure container interface configuration and

### DIFF
--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -420,7 +420,7 @@ func (agent *HostAgent) unconfigureContainerIfaces(id *md.ContainerId) error {
 	agent.indexMutex.Lock()
 	mdmap, ok := agent.epMetadata[podid]
 	if !ok {
-		logger.Error("Unconfigure called for pod with no metadata")
+		logger.Info("Unconfigure called for pod with no metadata")
 		// Assume container is already unconfigured
 		agent.indexMutex.Unlock()
 		return nil


### PR DESCRIPTION
clear metdata of container of pod for which
kubelet call to CNI to add interface is failed.

(cherry picked from commit 16cdbf3af026d9f9f6da9389184f08c1fefd554e)