### PR TITLE
Fix for missing snat-uuid in ep file

### DIFF
--- a/pkg/util/snat.go
+++ b/pkg/util/snat.go
@@ -22,8 +22,11 @@ import (
 	snatglobalclset "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/clientset/versioned"
 	snatpolicy "github.com/noironetworks/aci-containers/pkg/snatpolicy/apis/aci.snat/v1"
 	snatpolicyclset "github.com/noironetworks/aci-containers/pkg/snatpolicy/clientset/versioned"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"os"
 	"sort"
 	"strconv"
@@ -170,6 +173,19 @@ func MatchLabels(policylabels map[string]string, reslabels map[string]string) bo
 		}
 	}
 	return true
+}
+
+func GetServicesByOneOfLabels(indexer cache.Indexer, ns string, reslabels map[string]string) []*v1.Service {
+	var services []*v1.Service
+	for key, value := range reslabels {
+		label := make(map[string]string)
+		label[key] = value
+		cache.ListAllByNamespace(indexer, ns, labels.SelectorFromSet(label),
+			func(servobj interface{}) {
+				services = append(services, servobj.(*v1.Service))
+			})
+	}
+	return services
 }
 
 // UpdateSnatPolicy Updates a UpdateSnatPolicy CR


### PR DESCRIPTION
Fix for missing snat-uuid in ep-file when a pod of deployment and
hostagent restarts at same time

A case where deloyment doesnt have snat association but a service
corresponding to the deployment have snat association was not handled
and hence the issue.

(cherry picked from commit a54b39769c85c2ed31556b3ed6c85cfda2282421)