### PR TITLE
backporting to kmr2: add WaitForCacheSync on various k8s resource informers

### DIFF
--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -197,13 +197,45 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 	go env.agent.podInformer.Run(stopCh)
 	cache.WaitForCacheSync(stopCh, env.agent.podInformer.HasSynced)
 	env.agent.log.Info("Pod cache sync successful")
+
+	env.agent.log.Debug("Starting controller informers")
 	go env.agent.controllerInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for controller cache sync")
+	cache.WaitForCacheSync(stopCh, env.agent.controllerInformer.HasSynced)
+	env.agent.log.Info("controller cache sync successful")
+
 	env.agent.serviceEndPoints.Run(stopCh)
+
+	env.agent.log.Debug("Starting namespace informers")
 	go env.agent.nsInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for namespace cache sync")
+	cache.WaitForCacheSync(stopCh, env.agent.nsInformer.HasSynced)
+	env.agent.log.Info("namespace cache sync successful")
+
+	env.agent.log.Debug("Starting networkPolicy informers")
 	go env.agent.netPolInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for networkPolicy cache sync")
+	cache.WaitForCacheSync(stopCh, env.agent.netPolInformer.HasSynced)
+	env.agent.log.Info("networkPolicy cache sync successful")
+
+	env.agent.log.Debug("Starting deployment informers")
 	go env.agent.depInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for deployment cache sync")
+	cache.WaitForCacheSync(stopCh, env.agent.depInformer.HasSynced)
+	env.agent.log.Info("deployment cache sync successful")
+
+	env.agent.log.Debug("Starting ReplicationController informers")
 	go env.agent.rcInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for ReplicationController cache sync")
+	cache.WaitForCacheSync(stopCh, env.agent.rcInformer.HasSynced)
+	env.agent.log.Info("ReplicationController cache sync successful")
+
+	env.agent.log.Debug("Starting qosPolicy informers")
 	go env.agent.qosPolicyInformer.Run(stopCh)
+	env.agent.log.Info("Waiting for qosPolicy cache sync")
+	cache.WaitForCacheSync(stopCh, env.agent.qosPolicyInformer.HasSynced)
+	env.agent.log.Info("qosPolicy cache sync successful")
+
 	env.agent.log.Info("Cache sync successful")
 	return true, nil
 }


### PR DESCRIPTION
(cherry picked from commit 10ca5db5edf384d1a3fd349ae5c171fc425c9c08)

issue: https://github.com/noironetworks/support/issues/1754
addressing: https://github.com/noironetworks/aci-containers/pull/976#issuecomment-1072163966

- Wait until various k8s resource informers (like podInformer, controllerInformer, nsInformer, etc) is synced while initialising host agents.
- Check how much time it's taking to complete all sync.