### PR TITLE
Fix for snat policy enforcing wrong snat ip

### DIFF
--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -1018,11 +1018,7 @@ func (agent *HostAgent) getMatchingSnatPolicy(obj interface{}) (snatPolicyNames 
 				}
 				if res == POD {
 					if len(item.Spec.SnatIp) == 0 {
-						var services []*v1.Service
-						cache.ListAllByNamespace(agent.serviceInformer.GetIndexer(), namespace, labels.Everything(),
-							func(servobj interface{}) {
-								services = append(services, servobj.(*v1.Service))
-							})
+						services := util.GetServicesByOneOfLabels(agent.serviceInformer.GetIndexer(), namespace, label)
 						// list the pods and apply the policy at service target
 						for _, service := range services {
 							if util.MatchLabels(item.Spec.Selector.Labels,


### PR DESCRIPTION
List only the services which match the resource label instead of listing all the services in that namespace

Listing all services in the namespace and comparing its label with the labels of snatpolicies in cache was leading to updation of all snatpolicies in that namespace in the nodeinfo. Ideally it should update the nodeinfo only with snatpolicies corresponding to the resources in that node