### PR TITLE
Fix for refresh subscription timeout error

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -464,6 +464,16 @@ func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {
 	go conn.processQueue(conn.deltaQueue, queueStop)
 	conn.indexMutex.Unlock()
 
+	refreshInterval := conn.RefreshInterval
+	if refreshInterval == 0 {
+		refreshInterval = defaultConnectionRefresh
+	}
+	// Adjust refreshTickerInterval.
+	// To refresh the subscriptions early than actual refresh timeout value
+	refreshTickerInterval := refreshInterval - conn.RefreshTickerAdjust
+	refreshTicker := time.NewTicker(refreshTickerInterval)
+	defer refreshTicker.Stop()
+
 	var hasErr bool
 	for value, subscription := range conn.subscriptions.subs {
 		if !(conn.subscribe(value, subscription)) {
@@ -494,16 +504,6 @@ func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {
 			}
 		}()
 	}
-
-	refreshInterval := conn.RefreshInterval
-	if refreshInterval == 0 {
-		refreshInterval = defaultConnectionRefresh
-	}
-	// Adjust refreshTickerInterval.
-	// To refresh the subscriptions early than actual refresh timeout value
-	refreshTickerInterval := refreshInterval - conn.RefreshTickerAdjust
-	refreshTicker := time.NewTicker(refreshTickerInterval)
-	defer refreshTicker.Stop()
 
 	closeConn := func(stop bool) {
 		close(queueStop)


### PR DESCRIPTION
Subscription refresh ticker was started only after all the initial
subscriptions are processed one after other. Since it was taking lot of lime to process
subnet query, there was a delay to send next subscription request. Since the refresh subscription request (all 15) is sent after 30min from the last sent subscrption, the 1st subscription refresh request got timedout.

Started subscription refresh ticker before sending the subscription
requests to fix the issue

(cherry picked from commit 114e4e471fda6df1421ead0c741f17fd229b9a7b)