### PR TITLE
Workaround for too large RV error

### DIFF
--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -208,7 +208,16 @@ func (agent *HostAgent) initPodInformerFromClient(
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.FieldSelector =
 					fields.Set{"spec.nodeName": agent.config.NodeName}.String()
-				obj, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
+				var obj runtime.Object
+				var err error
+				for {
+					obj, err = kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to list Pods during initialization of PodInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatal("Failed to list Pods during initialization of PodInformer")
 				}
@@ -217,7 +226,16 @@ func (agent *HostAgent) initPodInformerFromClient(
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.FieldSelector =
 					fields.Set{"spec.nodeName": agent.config.NodeName}.String()
-				obj, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).Watch(context.TODO(), options)
+				var obj watch.Interface
+				var err error
+				for {
+					obj, err = kubeClient.CoreV1().Pods(metav1.NamespaceAll).Watch(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to watch Pods during initialization of PodInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatal("Failed to watch Pods during initialization of PodInformer")
 				}
@@ -230,7 +248,16 @@ func (agent *HostAgent) initPodInformerFromClient(
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				options.LabelSelector = labels.Set{"name": "aci-containers-controller"}.String()
 				//options.LabelSelector = "name=aci-containers-controller"
-				obj, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
+				var obj runtime.Object
+				var err error
+				for {
+					obj, err = kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to list Pods during initialization of ControllerInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatal("Failed to list Pods during initialization of ControllerInformer")
 				}
@@ -239,7 +266,16 @@ func (agent *HostAgent) initPodInformerFromClient(
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				options.LabelSelector = labels.Set{"name": "aci-containers-controller"}.String()
 				//options.LabelSelector = "name=aci-containers-controller"
-				obj, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).Watch(context.TODO(), options)
+				var obj watch.Interface
+				var err error
+				for {
+					obj, err = kubeClient.CoreV1().Pods(metav1.NamespaceAll).Watch(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to watch Pods during initialization of ControllerInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatal("Failed to watch Pods during initialization of ControllerInformer")
 				}

--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -123,14 +123,32 @@ func (agent *HostAgent) initEndpointsInformerFromClient(
 	agent.initEndpointsInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).List(context.TODO(), options)
+				var obj runtime.Object
+				var err error
+				for {
+					obj, err = kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).List(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to list Endpoints during initialization of EndpointsInformer :", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to list Endpoints during initialization of EndpointsInformer: %s", err)
 				}
 				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				obj, err := kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).Watch(context.TODO(), options)
+				var obj watch.Interface
+				var err error
+				for {
+					obj, err = kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).Watch(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to watch Endpoints during initialization of EndpointsInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to watch Endpoints during initialization of EndpointsInformer: %s", err)
 				}
@@ -164,14 +182,32 @@ func (agent *HostAgent) initEndpointSliceInformerFromClient(
 	agent.initEndpointSliceInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := kubeClient.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).List(context.TODO(), options)
+				var obj runtime.Object
+				var err error
+				for {
+					obj, err = kubeClient.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).List(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to list EndpointSlices during initialization of EndpointSliceInformer :", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to list EndpointSlices during initialization of EndpointSliceInformer: %s", err)
 				}
 				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				obj, err := kubeClient.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).Watch(context.TODO(), options)
+				var obj watch.Interface
+				var err error
+				for {
+					obj, err = kubeClient.DiscoveryV1beta1().EndpointSlices(metav1.NamespaceAll).Watch(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to watch EndpointSlices during initialization of EndpointSliceInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to watch EndpointSlices during initialization of EndpointSliceInformer: %s", err)
 				}
@@ -205,14 +241,32 @@ func (agent *HostAgent) initServiceInformerFromClient(
 	agent.initServiceInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := kubeClient.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), options)
+				var obj runtime.Object
+				var err error
+				for {
+					obj, err = kubeClient.CoreV1().Services(metav1.NamespaceAll).List(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to list Services during initialization of ServiceInformer :", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to list Services during initialization of ServiceInformer: %s", err)
 				}
 				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				obj, err := kubeClient.CoreV1().Services(metav1.NamespaceAll).Watch(context.TODO(), options)
+				var obj watch.Interface
+				var err error
+				for {
+					obj, err = kubeClient.CoreV1().Services(metav1.NamespaceAll).Watch(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to watch Services during initialization of ServiceInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to watch Services during initialization of ServiceInformer: %s", err)
 				}

--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -106,14 +106,32 @@ func (agent *HostAgent) initSnatGlobalInformerFromClient(
 	agent.initSnatGlobalInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := snatClient.AciV1().SnatGlobalInfos(metav1.NamespaceAll).List(context.TODO(), options)
+				var obj runtime.Object
+				var err error
+				for {
+					obj, err = snatClient.AciV1().SnatGlobalInfos(metav1.NamespaceAll).List(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to list SnatGlobalInfo during initialization of SnatGlobalInformer :", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to list SnatGlobalInfo during initialization of SnatGlobalInformer: %s", err)
 				}
 				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				obj, err := snatClient.AciV1().SnatGlobalInfos(metav1.NamespaceAll).Watch(context.TODO(), options)
+				var obj watch.Interface
+				var err error
+				for {
+					obj, err = snatClient.AciV1().SnatGlobalInfos(metav1.NamespaceAll).Watch(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to watch SnatGlobalInfo during initialization of SnatGlobalInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to watch SnatGlobalInfo during initialization of SnatGlobalInformer: %s", err)
 				}
@@ -127,14 +145,32 @@ func (agent *HostAgent) initSnatPolicyInformerFromClient(
 	agent.initSnatPolicyInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := snatClient.AciV1().SnatPolicies().List(context.TODO(), options)
+				var obj runtime.Object
+				var err error
+				for {
+					obj, err = snatClient.AciV1().SnatPolicies().List(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to list SnatPolicies during initialization of SnatPolicyInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to list SnatPolicies during initialization of SnatPolicyInformer: %s", err)
 				}
 				return obj, err
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				obj, err := snatClient.AciV1().SnatPolicies().Watch(context.TODO(), options)
+				var obj watch.Interface
+				var err error
+				for {
+					obj, err = snatClient.AciV1().SnatPolicies().Watch(context.TODO(), options)
+					if err != nil && strings.Contains(err.Error(), "Too large resource version") {
+						agent.log.Error("Failed to watch SnatPolicies during initialization of SnatPolicyInformer: ", err.Error(), " Retrying")
+						continue
+					}
+					break
+				}
 				if err != nil {
 					agent.log.Fatalf("Failed to watch SnatPolicies during initialization of SnatPolicyInformer: %s", err)
 				}


### PR DESCRIPTION
When apiserver comes up, watch cache (from where watch requests are served)
of each resource is initialized with the latest global resource version(which
might not be the RV of the specific resource we are looking for) and after
that it updates watch cache with all the resources in the cluster and proper
RV of resource is updated in watch cache. If client starts/resume watch
immediately will get "Too large resource version" which will be recovered
when watch cache of api-server is synced

Added retry when "Too large resource version" is seen

(cherry picked from commit bb131e77ac6bf60e798dc9d722cb59f0c0767954)