### PR TITLE
Sharding of snatglobalinfo

### DIFF
--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -329,6 +329,7 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 
 func (cont *AciController) syncSnatGlobalInfo() bool {
 	env := cont.env.(*K8sEnvironment)
+	requeue := false
 	globalcl := env.snatGlobalClient
 	if globalcl == nil {
 		return false
@@ -344,36 +345,72 @@ func (cont *AciController) syncSnatGlobalInfo() bool {
 		}
 	}
 	cont.indexMutex.Unlock()
-	snatglobalInfo, err := util.GetGlobalInfoCR(*globalcl)
-	if errors.IsNotFound(err) {
-		spec := snatglobalinfo.SnatGlobalInfoSpec{
-			GlobalInfos: glInfoCache,
-		}
-		if globalcl != nil {
-			err := util.CreateSnatGlobalInfoCR(*globalcl, spec)
-			if err != nil {
-				cont.log.Error("SnatGlobalInfoCR Create failed requeue the request", err)
-				return true
+	snatglinfos, err := util.ListGlobalInfoCRs(*globalcl)
+	if err != nil {
+		cont.log.Error("Failed to list SnatGlobalInfoCRs", err)
+		requeue = true
+	} else if snatglinfos != nil && len(snatglinfos) > 0 {
+		//delete CR if it's not present in
+		for _, glinfocr := range snatglinfos {
+			namecr := glinfocr.Spec.NodeName
+			delete := true
+			for namecache := range glInfoCache {
+				if namecr == namecache {
+					delete = false
+					break
+				}
+			}
+			if delete {
+				err := util.DeleteGlobalInfoCR(*globalcl, namecr)
+				if err != nil {
+					requeue = true
+					cont.log.Error(namecr, " SnatGlobalInfoCR deletion failed :", err)
+					continue
+				}
+				cont.log.Info("Deleted SnatGlobalInfoCR :", namecr)
 			}
 		}
-		return false
-	} else if err != nil {
-		cont.log.Error("SnatGlobalInfoCR Create failed requeue the request-1: ", err)
-		return true
+
 	}
-	if reflect.DeepEqual(snatglobalInfo.Spec.GlobalInfos, glInfoCache) {
-		return false
+	for name, glinfo := range glInfoCache {
+		spec := snatglobalinfo.SnatGlobalInfoSpec{
+			NodeName: name,
+			GlobalInfos: map[string]snatglobalinfo.GlobalInfoList{
+				name: glinfo,
+			},
+		}
+		snatglobalInfo, err := util.GetGlobalInfoCR(*globalcl, name)
+		if errors.IsNotFound(err) {
+			if globalcl != nil {
+				err := util.CreateSnatGlobalInfoCR(*globalcl, spec)
+				if err != nil {
+					cont.log.Error(name, " SnatGlobalInfoCR Create failed requeue the request", err)
+					requeue = true
+					continue
+				}
+			}
+			continue
+		} else if err != nil {
+			cont.log.Error(name, " SnatGlobalInfoCR Create failed requeue the request-1: ", err)
+			requeue = true
+			continue
+		}
+		if reflect.DeepEqual(snatglobalInfo.Spec, spec) {
+			continue
+		}
+		snatglobalInfo.Spec = spec
+		cont.log.Debug("Update GlobalInfo cache: ", spec)
+		cont.log.Debug("Updating GlobalInfo CR: ", name)
+		err = util.UpdateGlobalInfoCR(*globalcl, snatglobalInfo)
+		if err != nil {
+			cont.log.Error(name, " GlobalInfo CR Update Failed: ", err)
+			requeue = true
+			continue
+		}
+		cont.log.Debug(name, " GlobalInfo CR successfully updated")
+
 	}
-	snatglobalInfo.Spec.GlobalInfos = glInfoCache
-	cont.log.Debug("Update GlobalInfo cache: ", glInfoCache)
-	cont.log.Debug("Updating GlobalInfo CR")
-	err = util.UpdateGlobalInfoCR(*globalcl, snatglobalInfo)
-	if err != nil {
-		cont.log.Error("GlobalInfo CR Update Failed: ", err)
-		return true
-	}
-	cont.log.Debug("GlobalInfo CR successfully updated")
-	return false
+	return requeue
 }
 
 func (cont *AciController) updateGlobalInfoforPolicy(portrange snatglobalinfo.PortRange,

--- a/pkg/controller/snats.go
+++ b/pkg/controller/snats.go
@@ -291,12 +291,13 @@ func (cont *AciController) createGlobalInfoCache(unittestmode bool) bool {
 		}
 		cont.log.Fatalf("snatglobalinfo client not found")
 	}
-	snatglobalInfo, err := util.GetGlobalInfoCR(*globalcl)
+	//snatglobalInfo, err := util.GetGlobalInfoCR(*globalcl)
+	snatglobalInfos, err := util.ListGlobalInfoCRs(*globalcl)
 
-	if err != nil {
-		cont.log.Info("No existing snatglobalinfo CR found in controller bootstrap")
+	if err != nil || len(snatglobalInfos) < 1 {
+		cont.log.Error("No existing snatglobalinfo CR found in controller bootstrap")
 	} else {
-		cont.log.Info("Syncing snatglobalinfo cache with existing CR")
+		cont.log.Info("Syncing snatglobalinfo cache with existing CRs")
 		macAddressToNodeName := make(map[string]string)
 		for _, value := range nodeInfos {
 			nodeName := value.ObjectMeta.Name
@@ -304,16 +305,18 @@ func (cont *AciController) createGlobalInfoCache(unittestmode bool) bool {
 			macAddressToNodeName[macAddress] = nodeName
 		}
 
-		for _, glinfos := range snatglobalInfo.Spec.GlobalInfos {
-			for _, v := range glinfos {
-				nodeName := macAddressToNodeName[v.MacAddress]
-				snatIP := v.SnatIp
-				if _, ok := cont.snatGlobalInfoCache[snatIP]; !ok {
-					cont.snatGlobalInfoCache[snatIP] = make(map[string]*snatglobalinfo.GlobalInfo)
+		for _, snatglinfos := range snatglobalInfos {
+			for _, ginfos := range snatglinfos.Spec.GlobalInfos {
+				for _, v := range ginfos {
+					nodeName := macAddressToNodeName[v.MacAddress]
+					snatIP := v.SnatIp
+					if _, ok := cont.snatGlobalInfoCache[snatIP]; !ok {
+						cont.snatGlobalInfoCache[snatIP] = make(map[string]*snatglobalinfo.GlobalInfo)
+					}
+					copiedValue := v
+					cont.snatGlobalInfoCache[snatIP][nodeName] = &copiedValue
+					cont.log.Info("Adding globalinfo entry for snatIP ", snatIP, " and node name ", nodeName, ": ", cont.snatGlobalInfoCache[snatIP][nodeName])
 				}
-				copiedValue := v
-				cont.snatGlobalInfoCache[snatIP][nodeName] = &copiedValue
-				cont.log.Info("Adding globalinfo entry for snatIP ", snatIP, " and node name ", nodeName, ": ", cont.snatGlobalInfoCache[snatIP][nodeName])
 			}
 		}
 	}

--- a/pkg/hostagent/integ_test.go
+++ b/pkg/hostagent/integ_test.go
@@ -685,7 +685,7 @@ func mkSnatGlobalObj() *snatglobal.SnatGlobalInfo {
 			}
 		}
 	}
-	return snatglobaldata("123456", "snatglobalinfo", "test-node", "aci", newglobal)
+	return snatglobaldata("123456", "test-node", "aci", newglobal)
 }
 func (it *integ) checkEpSnatUids(id int, uids []string, sg string) {
 	epid := fmt.Sprintf("%d%s_%d%s_", id, testPodID, id, testPodID)

--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -607,15 +607,6 @@ func (agent *HostAgent) snaGlobalInfoChanged(snatobj interface{}, logger *logrus
 	}
 	logger.Debug("Snat Global info Changed...")
 	globalInfo := snat.Spec.GlobalInfos
-	// This case is possible when all the pods will be deleted from that node
-	if len(globalInfo) < len(agent.opflexSnatGlobalInfos) {
-		for nodename := range agent.opflexSnatGlobalInfos {
-			if _, ok := globalInfo[nodename]; !ok {
-				delete(agent.opflexSnatGlobalInfos, nodename)
-				syncSnat = true
-			}
-		}
-	}
 	for nodename, val := range globalInfo {
 		var newglobalinfos []*opflexSnatGlobalInfo
 		for _, v := range val {
@@ -701,12 +692,11 @@ func (agent *HostAgent) snaGlobalInfoChanged(snatobj interface{}, logger *logrus
 func (agent *HostAgent) snatGlobalInfoDelete(obj interface{}) {
 	agent.log.Debug("Snat Global Info Obj Delete")
 	snat := obj.(*snatglobal.SnatGlobalInfo)
-	globalInfo := snat.Spec.GlobalInfos
+	nodename := snat.Spec.NodeName
 	agent.indexMutex.Lock()
-	for nodename := range globalInfo {
-		if _, ok := agent.opflexSnatGlobalInfos[nodename]; ok {
-			delete(agent.opflexSnatGlobalInfos, nodename)
-		}
+
+	if _, ok := agent.opflexSnatGlobalInfos[nodename]; ok {
+		delete(agent.opflexSnatGlobalInfos, nodename)
 	}
 	agent.indexMutex.Unlock()
 }

--- a/pkg/snatglobalinfo/apis/aci.snat/v1/types.go
+++ b/pkg/snatglobalinfo/apis/aci.snat/v1/types.go
@@ -11,6 +11,7 @@ type SnatGlobalInfoSpec struct {
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 	// +kubebuilder:validation:Enum=selector, node
 	GlobalInfos map[string]GlobalInfoList `json:"globalInfos"`
+	NodeName    string                    `json:"nodeName"`
 }
 
 // SnatGlobalInfoStatus defines the observed state of SnatGlobalInfo


### PR DESCRIPTION
* One snatglobalinfo CR per node
* Added Nodename to snatglobalinfo spec

Currently the snatglobalinfo CRD spec has a list of nodes and is used as a single CR. This causes scale issues as the number of nodes increases (most notably the size of the CR grows to more than 1.5 MB and etcd cannot handle it anymore).

(cherry picked from commit 513fe2a21de3af001880f92af43a08a81e3c2af0)