### PR TITLE
Batching of HPP programming

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -154,8 +154,7 @@ func injectedSvcPortNormalizer(b *ApicObjectBody) {
 var metadata = map[string]*apicMeta{
 	"fvTenant": {
 		attributes: map[string]interface{}{
-			"name":      "",
-			"nameAlias": "",
+			"name": "",
 		},
 		children: []string{
 			"fvBD",

--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -122,6 +122,7 @@ type ApicConnection struct {
 
 	desiredState       map[string]ApicSlice
 	desiredStateDn     map[string]ApicObject
+	multipleDn         map[string]map[string]ApicObject
 	keyHashes          map[string]string
 	containerDns       map[string]bool
 	cachedState        map[string]ApicSlice
@@ -139,10 +140,22 @@ func (s ApicSlice) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 
+func (conn *ApicConnection) GetMultipleDn() map[string]map[string]ApicObject {
+	conn.indexMutex.Lock()
+	defer conn.indexMutex.Unlock()
+	return conn.multipleDn
+}
+
 func (conn *ApicConnection) GetDesiredState(key string) ApicSlice {
 	conn.indexMutex.Lock()
 	defer conn.indexMutex.Unlock()
 	return conn.desiredState[key]
+}
+
+func (conn *ApicConnection) SetSyncEnabled() {
+	conn.indexMutex.Lock()
+	defer conn.indexMutex.Unlock()
+	conn.syncEnabled = true
 }
 
 func truncatedName(name string) string {

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -235,6 +235,7 @@ func New(log *logrus.Logger, apic []string, user string,
 		},
 		desiredState:       make(map[string]ApicSlice),
 		desiredStateDn:     make(map[string]ApicObject),
+		multipleDn:         make(map[string]map[string]ApicObject),
 		keyHashes:          make(map[string]string),
 		containerDns:       make(map[string]bool),
 		cachedState:        make(map[string]ApicSlice),
@@ -334,12 +335,12 @@ func (conn *ApicConnection) handleQueuedDn(dn string) bool {
 		}
 		conn.indexMutex.Unlock()
 	}
-
 	var requeue bool
 	conn.indexMutex.Lock()
 	pending, hasPendingChange := conn.pendingSubDnUpdate[dn]
 	conn.pendingSubDnUpdate[dn] = pendingChange{isDirty: true}
 	obj, hasDesiredState := conn.desiredStateDn[dn]
+	mulobj, hasMulDn := conn.multipleDn[dn]
 	conn.indexMutex.Unlock()
 
 	if hasPendingChange {
@@ -365,6 +366,14 @@ func (conn *ApicConnection) handleQueuedDn(dn string) bool {
 			}
 		} else {
 			requeue = conn.postDn(dn, obj)
+		}
+	} else if hasMulDn {
+		for key, val := range mulobj {
+			requeue = conn.postDn(key, val)
+			if !requeue {
+				conn.removeFromMultipleDn(key)
+			}
+			break
 		}
 	} else {
 		if hasPendingChange {

--- a/pkg/apicapi/apicapi_test.go
+++ b/pkg/apicapi/apicapi_test.go
@@ -490,6 +490,38 @@ func TestSubscription(t *testing.T) {
 	close(stopCh)
 }
 
+func newTenant(name string, children ApicSlice) ApicObject {
+	tenantObj := NewFvTenant(name)
+	tenantObj["fvTenant"].Attributes["status"] = "modified"
+	tenantObj["fvTenant"].Children = children
+	return tenantObj
+}
+
+func newhpp(name string, remIp1 string, remIp2 string) ApicObject {
+	hpp := NewHostprotPol("common", name)
+	subjIngress := NewHostprotSubj(hpp.GetDn(), "networkpolicy-ingress")
+	rule_0_0 := NewHostprotRule(subjIngress.GetDn(), "0")
+	if remIp1 != "" {
+		rule_0_0.AddChild(
+			NewHostprotRemoteIp(rule_0_0.GetDn(), remIp1))
+	}
+	if remIp2 != "" {
+		rule_0_0.AddChild(
+			NewHostprotRemoteIp(rule_0_0.GetDn(), remIp2))
+	}
+	subjIngress.AddChild(rule_0_0)
+	hpp.AddChild(subjIngress)
+	return hpp
+}
+
+func existingMulState() ApicSlice {
+	hpp0 := newhpp("testhpp0", "1.1.1.1", "2.2.2.2")
+	hpp1 := newhpp("testhpp1", "1.1.1.1", "2.2.2.2")
+	hpp2 := newhpp("testhpp2", "1.1.1.1", "2.2.2.2")
+	s := ApicSlice{hpp0, hpp1, hpp2}
+	return s
+}
+
 func existingState() ApicSlice {
 	bd := NewFvBD("common", "testbd1")
 	subnet := NewFvSubnet(bd.GetDn(), "10.42.10.1/16")
@@ -683,6 +715,80 @@ type reconcileTest struct {
 	deletes      []string
 	expected     map[string][]request
 	desc         string
+}
+
+type multiHppTest struct {
+	existing ApicSlice
+	expected map[string]ApicObject
+	desc     string
+}
+
+func TestMultipleHpp(t *testing.T) {
+	updatehpp0 := newhpp("testhpp0", "1.1.1.1", "3.3.3.3")
+	updatehpp1 := newhpp("testhpp1", "1.1.1.1", "3.3.3.3")
+	mulkeyobj := make(map[string]ApicSlice)
+	mulkeyobj["kube-key0"] = ApicSlice{updatehpp0}
+	mulkeyobj["kube-key1"] = ApicSlice{updatehpp1}
+
+	tenant := newTenant("common", ApicSlice{updatehpp0, updatehpp1})
+	expected := make(map[string]ApicObject)
+	expected[tenant.GetDn()] = tenant
+	hppTests := []multiHppTest{
+		{
+			desc:     "update child",
+			existing: existingMulState(),
+			expected: expected,
+		},
+	}
+
+	for _, test := range hppTests {
+		server := newTestServer()
+		defer server.server.Close()
+		server.mux.Handle("/api/aaaLogin.json", &loginSucc{})
+		server.mux.Handle("/sockettesttoken", server.sh)
+		server.mux.Handle("/api/mo/uni/tn-common.json",
+			&subHandler{
+				id:       "42",
+				response: test.existing,
+			})
+
+		conn, err := server.testConn(nil)
+		assert.Nil(t, err)
+
+		dn := "uni/tn-common"
+		conn.AddSubscriptionDn(dn, []string{"fvTenant"})
+
+		stopCh := make(chan struct{})
+		go conn.Run(stopCh)
+
+		tu.WaitFor(t, "login", 500*time.Millisecond,
+			func(last bool) (bool, error) {
+				return tu.WaitNotNil(t, last, server.sh.socketConn,
+					"socket connection"), nil
+			})
+		time.Sleep(time.Millisecond * 500)
+		conn.syncEnabled = true
+		conn.WriteMulApicObjects(mulkeyobj, "common")
+
+		tu.WaitFor(t, "sync", 500*time.Millisecond,
+			func(last bool) (bool, error) {
+				for dn := range test.expected {
+					for _, val := range conn.multipleDn {
+						if _, ok := val[dn]; !ok {
+							return false, nil
+						}
+						expraw, _ := json.Marshal(test.expected[dn])
+						actualraw, _ := json.Marshal(val[dn])
+						if !tu.WaitEqual(t, last, string(expraw), string(actualraw),
+							test.desc, dn) {
+							return false, nil
+						}
+					}
+				}
+				return true, nil
+			})
+		close(stopCh)
+	}
 }
 
 func TestReconcile(t *testing.T) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -63,6 +63,7 @@ type AciController struct {
 
 	podQueue          workqueue.RateLimitingInterface
 	netPolQueue       workqueue.RateLimitingInterface
+	mulNetPolQueue    workqueue.RateLimitingInterface
 	qosQueue          workqueue.RateLimitingInterface
 	serviceQueue      workqueue.RateLimitingInterface
 	snatQueue         workqueue.RateLimitingInterface
@@ -300,6 +301,7 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 
 		podQueue:          createQueue("pod"),
 		netPolQueue:       createQueue("networkPolicy"),
+		mulNetPolQueue:    createQueue("multipleNetworkPolicy"),
 		qosQueue:          createQueue("qos"),
 		netflowQueue:      createQueue("netflow"),
 		erspanQueue:       createQueue("erspan"),
@@ -385,6 +387,54 @@ func (cont *AciController) Init() {
 	if err != nil {
 		panic(err.Error())
 	}
+}
+
+func (cont *AciController) processMulQueue(queue workqueue.RateLimitingInterface,
+	store cache.Store, handler func([]interface{}) bool,
+	postDelHandler func() bool, stopCh <-chan struct{}) {
+	go wait.Until(func() {
+		for {
+			key, quit := queue.Get()
+			if quit {
+				break
+			}
+
+			var requeue bool
+			switch key := key.(type) {
+			case chan struct{}:
+				close(key)
+			case string:
+				if strings.Contains(key, "_") {
+					var objs []interface{}
+					keys := strings.Split(key, "_")
+					for _, singleKey := range keys {
+						obj, exists, err := store.GetByKey(singleKey)
+						if err != nil {
+							cont.log.Debugf("Error fetching object with key %s from store: %v", singleKey, err)
+						}
+						if exists {
+							objs = append(objs, obj)
+						}
+					}
+					if handler != nil && len(objs) > 0 {
+						requeue = handler(objs)
+					}
+					if postDelHandler != nil && len(objs) > 0 {
+						requeue = postDelHandler()
+					}
+				}
+			}
+			if requeue {
+				queue.AddRateLimited(key)
+			} else {
+				queue.Forget(key)
+			}
+			queue.Done(key)
+
+		}
+	}, time.Second, stopCh)
+	<-stopCh
+	queue.ShutDown()
 }
 
 func (cont *AciController) processQueue(queue workqueue.RateLimitingInterface,
@@ -620,7 +670,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		_, ok := cont.env.(*K8sEnvironment)
 		if ok {
 			qs = []workqueue.RateLimitingInterface{
-				cont.podQueue, cont.netPolQueue, cont.qosQueue,
+				cont.podQueue, cont.netPolQueue, cont.mulNetPolQueue, cont.qosQueue,
 				cont.serviceQueue, cont.snatQueue, cont.netflowQueue,
 				cont.snatNodeInfoQueue, cont.rdConfigQueue, cont.erspanQueue,
 			}

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -262,6 +262,10 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 		func(obj interface{}) bool {
 			return cont.handleNetPolUpdate(obj.(*v1net.NetworkPolicy))
 		}, nil, stopCh)
+	go cont.processMulQueue(cont.mulNetPolQueue, cont.networkPolicyIndexer,
+		func(obj []interface{}) bool {
+			return cont.handleMulNetPolUpdate(obj)
+		}, nil, stopCh)
 	go cont.processQueue(cont.snatNodeInfoQueue, cont.snatNodeInfoIndexer,
 		func(obj interface{}) bool {
 			return cont.handleSnatNodeInfo(obj.(*snatnodeinfo.NodeInfo))

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -176,10 +176,17 @@ func (cont *AciController) initNetPolPodIndex() {
 			cont.queueNetPolUpdate(npobj.(*v1net.NetworkPolicy))
 		}
 	}
+	mulnpupdate := func(npkeys []string) {
+		if len(npkeys) > 0 {
+			cont.queueMulNetPolUpdateByKey(npkeys)
+		}
+	}
+
 	nphash := func(pod *v1.Pod) string {
 		return pod.Status.PodIP
 	}
 	cont.netPolIngressPods.SetObjUpdateCallback(npupdate)
+	cont.netPolIngressPods.SetMulObjUpdateCallback(mulnpupdate)
 	cont.netPolIngressPods.SetPodHashFunc(nphash)
 	cont.netPolEgressPods.SetObjUpdateCallback(npupdate)
 	cont.netPolEgressPods.SetPodHashFunc(nphash)
@@ -314,6 +321,18 @@ func networkPolicyLogger(log *logrus.Logger,
 
 func (cont *AciController) queueNetPolUpdateByKey(key string) {
 	cont.netPolQueue.Add(key)
+}
+
+func (cont *AciController) queueMulNetPolUpdateByKey(keys []string) {
+	var keyString string
+	for i, key := range keys {
+		if i == 0 {
+			keyString = key
+		} else {
+			keyString = keyString + "_" + key
+		}
+	}
+	cont.mulNetPolQueue.Add(keyString)
 }
 
 func (cont *AciController) queueNetPolUpdate(netpol *v1net.NetworkPolicy) {
@@ -1060,12 +1079,12 @@ func (cont *AciController) buildServiceAugment(subj apicapi.ApicObject,
 	}
 }
 
-func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
+func (cont *AciController) dohandleNetPolUpdate(np *v1net.NetworkPolicy) (string, apicapi.ApicSlice) {
 	key, err := cache.MetaNamespaceKeyFunc(np)
 	logger := networkPolicyLogger(cont.log, np)
 	if err != nil {
 		logger.Error("Could not create network policy key: ", err)
-		return false
+		return "", apicapi.ApicSlice{}
 	}
 
 	peerPodKeys := cont.netPolIngressPods.GetPodForObj(key)
@@ -1142,7 +1161,29 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 		cont.buildServiceAugment(subjEgress, portRemoteSubs, logger)
 		hpp.AddChild(subjEgress)
 	}
-	cont.apicConn.WriteApicObjects(labelKey, apicapi.ApicSlice{hpp})
+	return labelKey, apicapi.ApicSlice{hpp}
+}
+
+func (cont *AciController) handleMulNetPolUpdate(nps []interface{}) bool {
+	keyObjects := make(map[string]apicapi.ApicSlice)
+	for _, netp := range nps {
+		np := netp.(*v1net.NetworkPolicy)
+		labelKey, hpp := cont.dohandleNetPolUpdate(np)
+		if labelKey != "" && len(hpp) > 0 {
+			keyObjects[labelKey] = hpp
+		}
+	}
+	if len(keyObjects) > 0 {
+		cont.apicConn.WriteMulApicObjects(keyObjects, cont.config.AciPolicyTenant)
+	}
+	return false
+}
+
+func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
+	labelKey, hpp := cont.dohandleNetPolUpdate(np)
+	if labelKey != "" && len(hpp) > 0 {
+		cont.apicConn.WriteApicObjects(labelKey, hpp)
+	}
 	return false
 }
 

--- a/pkg/index/pod_selector_index.go
+++ b/pkg/index/pod_selector_index.go
@@ -15,15 +15,14 @@
 package index
 
 import (
-	"reflect"
-	"sync"
-
 	"github.com/sirupsen/logrus"
-
 	v1 "k8s.io/api/core/v1"
+	v1net "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
+	"reflect"
+	"sync"
 )
 
 type set map[string]bool
@@ -75,6 +74,9 @@ type GetKeyFunc func(interface{}) (string, error)
 // Callback function for SetPodUpdateCallback or SetObjUpdateCallback
 type UpdateFunc func(key string)
 
+// Callback function for SetPodUpdateCallback or SetObjUpdateCallback
+type MulUpdateFunc func(keys []string)
+
 // Calculate a hash over pod fields to detect pod changes that should
 // trigger an update
 type PodHashFunc func(pod *v1.Pod) string
@@ -95,9 +97,10 @@ type PodSelectorIndex struct {
 	getKey         GetKeyFunc
 	getPodSelector GetPodSelectorFunc
 
-	updatePod   UpdateFunc
-	updateObj   UpdateFunc
-	podHashFunc PodHashFunc
+	updatePod    UpdateFunc
+	updateObj    UpdateFunc
+	updateMulObj MulUpdateFunc
+	podHashFunc  PodHashFunc
 
 	indexMutex sync.Mutex
 
@@ -144,6 +147,12 @@ func (i *PodSelectorIndex) SetPodUpdateCallback(updatePod UpdateFunc) {
 // object change
 func (i *PodSelectorIndex) SetObjUpdateCallback(updateObj UpdateFunc) {
 	i.updateObj = updateObj
+}
+
+// Set a callback that will be called whenever the pods selected by
+// multiple objects change
+func (i *PodSelectorIndex) SetMulObjUpdateCallback(updateMulObj MulUpdateFunc) {
+	i.updateMulObj = updateMulObj
 }
 
 // Set a function to compute a hash over pod fields.  When the pod
@@ -207,6 +216,7 @@ func (i *PodSelectorIndex) UpdatePodNoCallback(pod *v1.Pod) bool {
 		return false
 	}
 
+	var updatedMulObjs []string
 	podUpdated := false
 	matched := make(set)
 	updatedObjs := make(set)
@@ -266,15 +276,31 @@ func (i *PodSelectorIndex) UpdatePodNoCallback(pod *v1.Pod) bool {
 		state.objKeys = matched
 		state.podHash = podHash
 	}
-	i.indexMutex.Unlock()
+	for objkey := range updatedObjs {
+		npobj, exists, err := i.objIndexer.GetByKey(objkey)
+		if err != nil {
+			i.log.Error("Failed to get object from key : ", objkey, " error: ", err)
+		} else if exists {
+			_, ok := npobj.(*v1net.NetworkPolicy)
+			if ok {
+				updatedMulObjs = append(updatedMulObjs, objkey)
+			}
+		}
+	}
 
-	i.updateObjs(updatedObjs)
+	i.indexMutex.Unlock()
+	if len(updatedMulObjs) > 1 && i.updateMulObj != nil {
+		i.updateMulObj(updatedMulObjs)
+	} else {
+		i.updateObjs(updatedObjs)
+	}
 
 	return podUpdated
 }
 
 // Call to update the index when a pod is deleted
 func (i *PodSelectorIndex) DeletePod(pod *v1.Pod) {
+	var updatedMulObjs []string
 	updatedObjs := make(set)
 
 	podkey, err := cache.MetaNamespaceKeyFunc(pod)
@@ -290,7 +316,24 @@ func (i *PodSelectorIndex) DeletePod(pod *v1.Pod) {
 				if len(objm) == 0 {
 					delete(i.objPodIndex, objkey)
 				}
+
+				npobj, exists, err := i.objIndexer.GetByKey(objkey)
+				if err != nil {
+					i.log.Error("Failed to get object from key : ", objkey, " error: ", err)
+				} else if exists {
+					_, ok := npobj.(*v1net.NetworkPolicy)
+					if ok {
+						updatedMulObjs = append(updatedMulObjs, objkey)
+						continue
+					}
+				}
 				updatedObjs[objkey] = true
+			}
+		}
+		if len(updatedMulObjs) == 1 || i.updateMulObj == nil {
+			i.log.Debug("Not using multiple object callback")
+			for _, key := range updatedMulObjs {
+				updatedObjs[key] = true
 			}
 		}
 		delete(i.podIndex, podkey)
@@ -298,6 +341,10 @@ func (i *PodSelectorIndex) DeletePod(pod *v1.Pod) {
 	i.indexMutex.Unlock()
 
 	i.updateObjs(updatedObjs)
+
+	if len(updatedMulObjs) > 1 && i.updateMulObj != nil {
+		i.updateMulObj(updatedMulObjs)
+	}
 }
 
 // Call to update the index when a namespace's labels change


### PR DESCRIPTION
When a router pod is deleted, deletion and addition of individual HPP
rules takes a long time to propagate between the various components
on the APIC and eventually to all the leaf nodes.

Sending multiple hpp updates/deletes as single POST request with all
rules to be modified/deleted in the body