### PR TITLE
Support for adding an annotation on service to delay processing of eps

### DIFF
--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -311,5 +311,6 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 		go cont.snatGlobalInfoSync(stopCh, 60)
 	}
 	go cont.syncOpflexDevices(stopCh, 60)
+	go cont.syncDelayedEpSlices(stopCh, 1)
 	return nil
 }

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -724,6 +724,10 @@ func TestEndpointsIpIndex(t *testing.T) {
 }
 func TestEndpointsliceIpIndex(t *testing.T) {
 	ready := true
+	service1 := service("ns1", "service1", "")
+	service1.Spec.Type = ""
+	service2 := service("ns1", "service2", "")
+	service2.Spec.Type = ""
 	endpoints := []v1beta1.Endpoint{
 		{
 			Addresses: []string{
@@ -748,6 +752,9 @@ func TestEndpointsliceIpIndex(t *testing.T) {
 	eps2 := endpointslice("ns1", "name2", endpoints, "service1")
 
 	cont := testController()
+
+	cont.fakeServiceSource.Add(service1)
+	cont.fakeServiceSource.Add(service2)
 	cont.serviceEndPoints = &serviceEndpointSlice{}
 	cont.serviceEndPoints.(*serviceEndpointSlice).cont = &cont.AciController
 	cont.fakeEndpointSliceSource.Add(eps1)


### PR DESCRIPTION
To allow an application to bootstrap completely, support is added to
have an annotation(opflex.cisco.com/service-graph-endpoint-add-delay: 30) on service sunch that the eps will be processed after the delay.  The value of delay is considered in seconds

(cherry picked from commit ca3c0474662d47d7abd3381386fd0342c368b6cc)