### PR TITLE
Never reconsider a failed snatpolicy

### DIFF
--- a/pkg/controller/snats.go
+++ b/pkg/controller/snats.go
@@ -128,7 +128,7 @@ func (cont *AciController) handleSnatUpdate(snatPolicy *snatpolicy.SnatPolicy) b
 	}
 	cont.log.Info("Handle update for snatpolicy: ", snatPolicy.ObjectMeta.Name)
 	policyName := snatPolicy.ObjectMeta.Name
-	if snatPolicy.Status.State != snatpolicy.Ready {
+	if snatPolicy.Status.State == "" {
 		if snatPolicy.Status.State == snatpolicy.IpPortsExhausted {
 			cont.indexMutex.Lock()
 			if snatInfo, ok := cont.snatPolicyCache[policyName]; ok {
@@ -144,6 +144,10 @@ func (cont *AciController) handleSnatUpdate(snatPolicy *snatpolicy.SnatPolicy) b
 			return cont.setSnatPolicyStatus(policyName, snatpolicy.Failed)
 		}
 		return cont.setSnatPolicyStatus(policyName, snatpolicy.Ready)
+	}
+	if snatPolicy.Status.State != snatpolicy.Ready {
+		cont.log.Debug("snatpolicy not in Ready state: ", snatPolicy.ObjectMeta.Name)
+		return false
 	}
 	cont.updateSnatPolicyCache(policyName, snatPolicy)
 	var requeue bool


### PR DESCRIPTION
When multiple namespace snatpolicies have overlapping ips, State of
snatpolicies are correct when we configure but later Failed snatpolicies
go to Ready state.

Never reconsider a Failed policy (the only option would be to delete and recreate it)

(cherry picked from commit 0af14dc87fe56ad4923f8f06007111cd90573d20)