### PR TITLE
Do not wait for service ep to be ready for conformance tests

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -199,6 +199,11 @@ type ControllerConfig struct {
 	// periodically
 	DisablePeriodicSnatGlobalInfoSync bool `json:"disable-periodic-snat-global-info-sync,omitempty"`
 
+	// True when we dont want to wait for service ep to be ready
+	// before adding it to service graph
+	// Default is false
+	NoWaitForServiceEpReadiness bool `json:"no-wait-for-service-ep-readiness,omitempty"`
+
 	// Install Istio ControlPlane components
 	InstallIstio bool `json:"install-istio,omitempty"`
 

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1663,15 +1663,17 @@ func (cont *AciController) endpointSliceUpdated(oldobj interface{}, newobj inter
 		cont.log.Error("error processing Endpointslice object: ", newobj)
 		return
 	}
-	proceed := true
-	for _, endpoint := range newendpointslice.Endpoints {
-		if endpoint.Conditions.Ready == nil || !*endpoint.Conditions.Ready {
-			proceed = false
+	if cont.config.NoWaitForServiceEpReadiness == false {
+		proceed := true
+		for _, endpoint := range newendpointslice.Endpoints {
+			if endpoint.Conditions.Ready == nil || !*endpoint.Conditions.Ready {
+				proceed = false
+			}
 		}
-	}
-	if !proceed {
-		cont.log.Debug("New enpoints are not in ready state")
-		return
+		if !proceed {
+			cont.log.Debug("New enpoints are not in ready state")
+			return
+		}
 	}
 	servicekey, valid := getServiceKey(newendpointslice)
 	if !valid {
@@ -1684,7 +1686,7 @@ func (cont *AciController) endpointSliceUpdated(oldobj interface{}, newobj inter
 	}
 	service, ok := serviceobj.(*v1.Service)
 	if !ok {
-		cont.log.Error("error processing Service object: ", service)
+		cont.log.Error("error processing Service object: ", serviceobj)
 		return
 	}
 	var delay int64


### PR DESCRIPTION
Made waiting for serice ep to be ready before adding it to the service
graph configurable. Default behaviour is to wait for ep to be ready.
For conformance tests, it will not wait.