### PR TITLE
Checked if ns is present before sending update request to apic

### DIFF
--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -182,6 +182,17 @@ func (cont *AciController) writeApicPod(pod *v1.Pod) {
 		podLogger(cont.log, pod).Error("Could not create pod key: ", err)
 		return
 	}
+	podns := pod.ObjectMeta.Namespace
+	_, exists, err := cont.namespaceIndexer.GetByKey(podns)
+	if err != nil {
+		cont.log.Error("Failed to lookup ns : ", podns, " ", err)
+		return
+	}
+	if !exists {
+		cont.log.Debug("Namespace of pod ", pod.ObjectMeta.Name, ": ", podns, " doesn't exist, hence not sending an update to the APIC")
+		return
+	}
+
 	key := cont.aciNameForKey("pod", podkey)
 	if !podFilter(pod) || pod.Spec.NodeName == "" {
 		cont.apicConn.ClearApicObjects(key)

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1147,6 +1147,17 @@ func (cont *AciController) writeApicSvc(key string, service *v1.Service) {
 	aobjDn := aobj.GetDn()
 	aobj.SetAttr("guid", string(service.UID))
 
+	svcns := service.ObjectMeta.Namespace
+	_, exists, err := cont.namespaceIndexer.GetByKey(svcns)
+	if err != nil {
+		cont.log.Error("Failed to lookup ns : ", svcns, " ", err)
+		return
+	}
+	if !exists {
+		cont.log.Debug("Namespace of service ", service.ObjectMeta.Name, ": ", svcns, " doesn't exist, hence not sending an update to the APIC")
+		return
+	}
+
 	if !cont.serviceEndPoints.SetServiceApicObject(aobj, service) {
 		return
 	}


### PR DESCRIPTION
cni was sending update of service and pods request to apic without
creating namespace in apic when ns was not present in k8s and resources were
remaining inside the namespace in terminating state.

Added lookup for ns before sending request to apic

(cherry picked from commit 9f5a559f1ccc46c917ac472ebc2aee0b426789d9)