### PR TITLE
Adding OCP 4.11 flavor for Openstack/ESX/Baremetal

### DIFF
--- a/pkg/controller/acicontainersoperator.go
+++ b/pkg/controller/acicontainersoperator.go
@@ -98,6 +98,7 @@ var Version = map[string]bool{
 	"openshift-4.8-openstack":  true,
 	"openshift-4.9-openstack":  true,
 	"openshift-4.10-openstack": true,
+	"openshift-4.11-openstack": true,
 	"openshift-4.6-baremetal":  true,
 	"openshift-4.7-baremetal":  true,
 	"openshift-4.8-baremetal":  true,

--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -113,6 +113,7 @@ var Version = map[string]bool{
 	"openshift-4.8-baremetal":  true,
 	"openshift-4.9-baremetal":  true,
 	"openshift-4.10-baremetal": true,
+	"openshift-4.11-baremetal": true,
 	"openshift-4.4-esx":        true,
 	"openshift-4.5-esx":        true,
 	"openshift-4.6-esx":        true,
@@ -120,6 +121,7 @@ var Version = map[string]bool{
 	"openshift-4.8-esx":        true,
 	"openshift-4.9-esx":        true,
 	"openshift-4.10-esx":       true,
+	"openshift-4.11-esx":       true,
 }
 
 func (agent *HostAgent) initEndpointsInformerFromClient(


### PR DESCRIPTION
(cherry picked from commit 82a5afa830201029fce1784d4a7314950db4e00c)