### PR TITLE
Removed stale --limit-bytes

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -632,7 +632,7 @@ func accprovisionoperatorLogCmdArgs(systemNamespace string) []string {
 
 func acioperatorLogCmdArgs(systemNamespace string) []string {
 	if logFileSize != "" {
-		return []string{"-n", systemNamespace, "logs", "--limit-bytes",
+		return []string{"-n", systemNamespace, "logs",
 			"deployment/aci-containers-operator", "-c", "aci-containers-operator", "|", "tail", "-c", logFileSize}
 	}
 	return []string{"-n", systemNamespace, "logs",


### PR DESCRIPTION
Removed stale --limit-bytes from kubectl los command in cluster report