### PR TITLE
Corresponding changes to support sleep time for global SNAT sync

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -240,6 +240,9 @@ type ControllerConfig struct {
 
 	// Timeout to delete old opflex devices
 	OpflexDeviceDeleteTimeout float64 `json:"opflex-device-delete-timeout,omitempty"`
+
+	// Configure sleep time for global SNAT sync
+	SleepTimeSnatGlobalInfoSync int `json:"sleep-time-snat-global-info-sync,omitempty"`
 }
 
 type netIps struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -513,6 +513,11 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		cont.config.OpflexDeviceDeleteTimeout = 1800
 	}
 
+	// If SleepTimeSnatGlobalInfoSync is not defined, default to 60
+	if cont.config.SleepTimeSnatGlobalInfoSync == 0 {
+		cont.config.SleepTimeSnatGlobalInfoSync = 60
+	}
+
 	// If not defined, default to 32
 	if cont.config.PodIpPoolChunkSize == 0 {
 		cont.config.PodIpPoolChunkSize = 32
@@ -734,8 +739,8 @@ func (cont *AciController) syncDelayedEpSlices(stopCh <-chan struct{}, seconds t
 	}
 }
 
-func (cont *AciController) snatGlobalInfoSync(stopCh <-chan struct{}, seconds time.Duration) {
-	time.Sleep(seconds * time.Second)
+func (cont *AciController) snatGlobalInfoSync(stopCh <-chan struct{}, seconds int) {
+	time.Sleep(time.Duration(seconds) * time.Second)
 	cont.log.Debug("Go routine to periodically sync globalinfo and nodeinfo started")
 	iteration := 0
 	for {
@@ -809,7 +814,7 @@ func (cont *AciController) snatGlobalInfoSync(stopCh <-chan struct{}, seconds ti
 				}
 			}
 		}
-		time.Sleep(seconds * time.Second)
+		time.Sleep(time.Duration(seconds) * time.Second)
 		iteration = iteration + 1
 	}
 }

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -304,7 +304,7 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 		cont.networkPolicyInformer.HasSynced)
 	cont.log.Info("Cache sync successful")
 	if !cont.config.DisablePeriodicSnatGlobalInfoSync {
-		go cont.snatGlobalInfoSync(stopCh, 60)
+		go cont.snatGlobalInfoSync(stopCh, cont.config.SleepTimeSnatGlobalInfoSync)
 	}
 	go cont.syncOpflexDevices(stopCh, 60)
 	go cont.syncDelayedEpSlices(stopCh, 1)


### PR DESCRIPTION
(cherry picked from commit d9e629680e6252fb1fc42bd2396e6d53c5ec6b54)