### PR TITLE
Delete pbr programming of deleted endpoint right away

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -30,6 +30,7 @@ type OpflexGroup struct {
 }
 
 type delayService struct {
+	Delay     int    `json:"delay,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -173,6 +173,7 @@ type AciController struct {
 }
 
 type DelayedEpSlice struct {
+	ServiceKey  string
 	OldEpSlice  *v1beta1.EndpointSlice
 	NewEpSlice  *v1beta1.EndpointSlice
 	DelayedTime time.Time
@@ -539,6 +540,17 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		cont.config.SnatDefaultPortRangeStart > cont.config.SnatDefaultPortRangeEnd {
 		cont.config.SnatDefaultPortRangeStart = defStart
 		cont.config.SnatDefaultPortRangeEnd = defEnd
+	}
+
+	// Set default value for pbr programming delay if services list is not empty
+	// and delay value is empty
+	if cont.config.ServiceGraphEndpointAddDelay.Delay == 0 &&
+		cont.config.ServiceGraphEndpointAddDelay.Services != nil &&
+		len(cont.config.ServiceGraphEndpointAddDelay.Services) > 0 {
+		cont.config.ServiceGraphEndpointAddDelay.Delay = 90
+	}
+	if cont.config.ServiceGraphEndpointAddDelay.Delay > 0 {
+		cont.log.Info("ServiceGraphEndpointAddDelay set to: ", cont.config.ServiceGraphEndpointAddDelay.Delay)
 	}
 
 	// Set contract scope for snat svc graph to global by default

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -842,6 +842,7 @@ func TestEndpointsliceIpIndex(t *testing.T) {
 // Service annotation test with EndPointSlice
 func TestServiceAnnotationWithEps(t *testing.T) {
 	cont := sgCont()
+	ready := true
 	name := "kube_svc_testns_service1"
 	nameS2 := "kube_svc_testns_service2"
 	graphName := "kube_svc_global"
@@ -918,6 +919,9 @@ func TestServiceAnnotationWithEps(t *testing.T) {
 			Addresses: []string{
 				"1.1.1.1",
 			},
+			Conditions: v1beta1.EndpointConditions{
+				Ready: &ready,
+			},
 			Topology: map[string]string{
 				"kubernetes.io/hostname": "node1",
 			},
@@ -925,6 +929,9 @@ func TestServiceAnnotationWithEps(t *testing.T) {
 		{
 			Addresses: []string{
 				"1.1.1.2",
+			},
+			Conditions: v1beta1.EndpointConditions{
+				Ready: &ready,
 			},
 			Topology: map[string]string{
 				"kubernetes.io/hostname": "node2",
@@ -1032,9 +1039,10 @@ func TestServiceAnnotationWithEps(t *testing.T) {
 	cont.stop()
 }
 
-//Service graph test with EndPoint slices
+// Service graph test with EndPoint slices
 func TestServiceGraphiWithEps(t *testing.T) {
 	cont := sgCont()
+	ready := true
 	graphName := "kube_svc_global"
 	cluster := func(nmap map[string]string) apicapi.ApicObject {
 		var nodes []string
@@ -1122,6 +1130,9 @@ func TestServiceGraphiWithEps(t *testing.T) {
 			Addresses: []string{
 				"1.1.1.1",
 			},
+			Conditions: v1beta1.EndpointConditions{
+				Ready: &ready,
+			},
 			Topology: map[string]string{
 				"kubernetes.io/hostname": "node1",
 			},
@@ -1129,6 +1140,9 @@ func TestServiceGraphiWithEps(t *testing.T) {
 		{
 			Addresses: []string{
 				"1.1.1.2",
+			},
+			Conditions: v1beta1.EndpointConditions{
+				Ready: &ready,
 			},
 			Topology: map[string]string{
 				"kubernetes.io/hostname": "node2",
@@ -1140,6 +1154,9 @@ func TestServiceGraphiWithEps(t *testing.T) {
 		{
 			Addresses: []string{
 				"1.1.1.2",
+			},
+			Conditions: v1beta1.EndpointConditions{
+				Ready: &ready,
 			},
 			Topology: map[string]string{
 				"kubernetes.io/hostname": "node2",


### PR DESCRIPTION
* When an endpointslice is updated, if it is a delete of ip of endpoint delete it right away. Given delay should be added only when there is addition of new ip.
* User can configure per service delay for service-graph-endpoint-add-delay

(cherry picked from commit 9b6ac1358566f96e4519ab7dece7c0b15e8784ba)