### PR TITLE
Permits user to provide their own Service Graph Template in contract

### DIFF
--- a/pkg/apicapi/apic_sync.go
+++ b/pkg/apicapi/apic_sync.go
@@ -38,6 +38,15 @@ func (conn *ApicConnection) apicBodyAttrCmp(class string,
 		bodyd.Attributes = make(map[string]interface{})
 	}
 	for p, def := range meta.attributes {
+		if class == "vzRsSubjGraphAtt" && p == "tnVnsAbsGraphName" {
+			_, forceResolveExists := bodyc.Attributes["forceResolve"]
+			_, customSGAnnoExists := bodyd.Attributes["customSG"]
+			if forceResolveExists && customSGAnnoExists {
+				bodyd.Attributes["tnVnsAbsGraphName"] = bodyc.Attributes["tnVnsAbsGraphName"]
+				conn.log.Debug("Ignoring comparison of tnVnsAbsGraphName attribute of vzRsSubjGraphAtt class")
+				continue
+			}
+		}
 		ac, ok := bodyc.Attributes[p]
 		if !ok {
 			ac = def

--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -879,9 +879,12 @@ func NewVzRsSubjFiltAtt(parentDn string, tnVzFilterName string) ApicObject {
 	return ret
 }
 
-func NewVzRsSubjGraphAtt(parentDn string, tnVnsAbsGraphName string) ApicObject {
+func NewVzRsSubjGraphAtt(parentDn string, tnVnsAbsGraphName string, customSG bool) ApicObject {
 	ret := newApicObject("vzRsSubjGraphAtt")
 	ret["vzRsSubjGraphAtt"].Attributes["tnVnsAbsGraphName"] = tnVnsAbsGraphName
+	if customSG {
+		ret["vzRsSubjGraphAtt"].Attributes["customSG"] = "true"
+	}
 	ret["vzRsSubjGraphAtt"].Attributes["dn"] =
 		fmt.Sprintf("%s/rsSubjGraphAtt", parentDn)
 	return ret

--- a/pkg/apicapi/apic_types_test.go
+++ b/pkg/apicapi/apic_types_test.go
@@ -144,7 +144,7 @@ func TestTypes(t *testing.T) {
 	assert.Equal(t, "fake/dn/rssubjFiltAtt-flt1",
 		NewVzRsSubjFiltAtt("fake/dn", "flt1").GetDn())
 	assert.Equal(t, "fake/dn/rsSubjGraphAtt",
-		NewVzRsSubjGraphAtt("fake/dn", "dummy").GetDn())
+		NewVzRsSubjGraphAtt("fake/dn", "dummy", false).GetDn())
 	assert.Equal(t, "uni/tn-common/flt-f1",
 		NewVzFilter("common", "f1").GetDn())
 	assert.Equal(t, "fake/dn/e-e1",

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -306,7 +306,7 @@ func TestServiceAnnotation(t *testing.T) {
 		fe.SetAttr("dToPort", "53")
 		filter.AddChild(fe)
 	}
-	s1Dcc := apicDevCtx(name, "common", graphName,
+	s1Dcc := apicDevCtx(name, "common", graphName, graphName,
 		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn(), false)
 	endpoints1 := endpoints("testns", "service1",
 		[]string{"node1", "node2"}, nil, nil)
@@ -405,7 +405,7 @@ func TestServiceAnnotation(t *testing.T) {
 	service1.ObjectMeta.Annotations[metadata.ServiceContractScopeAnnotation] = "global"
 	time.Sleep(2 * time.Second)
 	cont.fakeServiceSource.Modify(service1)
-	contract := apicContract(name, "common", graphName, "global", false)
+	contract := apicContract(name, "common", graphName, "global", false, false)
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
@@ -477,7 +477,7 @@ func TestServiceGraph(t *testing.T) {
 	})
 
 	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, false, false)
-	contract := apicContract(name, "common", graphName, conScope, false)
+	contract := apicContract(name, "common", graphName, conScope, false, false)
 	rsCons := apicExtNetCons(name, "common", "l3out", "ext1")
 
 	filter := apicapi.NewVzFilter("common", name)
@@ -499,7 +499,7 @@ func TestServiceGraph(t *testing.T) {
 		filter.AddChild(fe)
 	}
 
-	s1Dcc := apicDevCtx(name, "common", graphName,
+	s1Dcc := apicDevCtx(name, "common", graphName, graphName,
 		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn(), false)
 
 	endpoints1 := endpoints("testns", "service1",
@@ -912,7 +912,7 @@ func TestServiceAnnotationWithEps(t *testing.T) {
 		fe.SetAttr("dToPort", "53")
 		filter.AddChild(fe)
 	}
-	s1Dcc := apicDevCtx(name, "common", graphName,
+	s1Dcc := apicDevCtx(name, "common", graphName, graphName,
 		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn(), false)
 	node_1 := "node1"
 	node_2 := "node2"
@@ -1024,7 +1024,7 @@ func TestServiceAnnotationWithEps(t *testing.T) {
 	service1.ObjectMeta.Annotations[metadata.ServiceContractScopeAnnotation] = "global"
 	time.Sleep(2 * time.Second)
 	cont.fakeServiceSource.Modify(service1)
-	contract := apicContract(name, "common", graphName, "global", false)
+	contract := apicContract(name, "common", graphName, "global", false, false)
 	expected := map[string]apicapi.ApicSlice{
 		graphName: apicapi.PrepareApicSlice(apicapi.ApicSlice{twoNodeCluster,
 			graph}, "kube", graphName),
@@ -1098,7 +1098,7 @@ func TestServiceGraphiWithEps(t *testing.T) {
 	})
 
 	extNet := apicExtNet(name, "common", "l3out", []string{"10.4.2.2"}, false, false)
-	contract := apicContract(name, "common", graphName, conScope, false)
+	contract := apicContract(name, "common", graphName, conScope, false, false)
 	rsCons := apicExtNetCons(name, "common", "l3out", "ext1")
 
 	filter := apicapi.NewVzFilter("common", name)
@@ -1120,7 +1120,7 @@ func TestServiceGraphiWithEps(t *testing.T) {
 		filter.AddChild(fe)
 	}
 
-	s1Dcc := apicDevCtx(name, "common", graphName,
+	s1Dcc := apicDevCtx(name, "common", graphName, graphName,
 		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn(), false)
 
 	node_1 := "node1"

--- a/pkg/controller/snats_test.go
+++ b/pkg/controller/snats_test.go
@@ -116,10 +116,10 @@ func TestSnatGraph(t *testing.T) {
 			end:   65000,
 		},
 	}
-	contract := apicContract(name, "common", graphName, "global", true)
+	contract := apicContract(name, "common", graphName, "global", true, false)
 	filterIn := apicFilterSnat(name+"_fromCons-toProv", "common", portRanges, false)
 	filterOut := apicFilterSnat(name+"_fromProv-toCons", "common", portRanges, true)
-	cc := apicDevCtx(name, "common", graphName,
+	cc := apicDevCtx(name, "common", graphName, graphName,
 		"kube_bd_kubernetes-service", strings.TrimSuffix(twoNodeRedirectCons.GetDn(), "_Cons"), true)
 
 	snatIp := []string{"10.4.2.2", "10.20.30.40/20"}

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -44,6 +44,9 @@ type NetIps struct {
 	V6 []ipam.IpRange `json:"V6,omitempty"`
 }
 
+// Custom service graph annotation
+const ServiceGraphNameAnnotation = "opflex.cisco.com/service-graph-name"
+
 // Service endpoint annotation
 const ServiceEpAnnotation = "opflex.cisco.com/service-endpoint"
 


### PR DESCRIPTION
If user wants to use their own service graph template for an lb service, they need to annotate the service :
opflex.cisco.com/service-graph-name: <some-value>
and then modify the SG template reference in contract specific to the service to have their own SG template. In that case, controller will not revert back the reference to the default one that is created by cni