### PR TITLE
Support multipod vm migration

### DIFF
--- a/docker/Dockerfile-host-base
+++ b/docker/Dockerfile-host-base
@@ -1,6 +1,7 @@
 ARG basetag=latest
 ARG baserepo=quay.io/noirolabs
 FROM ${baserepo}/aci-containers-base:${basetag}
+RUN yum install -y dhcp-client && yum clean all
 RUN yum --enablerepo=openstack-15-for-rhel-8-x86_64-rpms \
   --enablerepo=fast-datapath-for-rhel-8-x86_64-rpms --enablerepo codeready-builder-for-rhel-8-x86_64-rpms install -y iproute nftables openvswitch2.13 libnetfilter_conntrack-devel \
   && yum clean all

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -141,6 +141,7 @@ type AciController struct {
 	apicConn *apicapi.ApicConnection
 
 	nodeServiceMetaCache map[string]*nodeServiceMeta
+	nodeACIPod           map[string]string
 	nodeOpflexDevice     map[string]apicapi.ApicSlice
 	nodePodNetCache      map[string]*nodePodNetMeta
 	serviceMetaCache     map[string]*serviceMeta
@@ -336,6 +337,7 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 		staticServiceIps:        newNetIps(),
 		nodeServiceIps:          newNetIps(),
 
+		nodeACIPod:       make(map[string]string),
 		nodeOpflexDevice: make(map[string]apicapi.ApicSlice),
 
 		nodeServiceMetaCache: make(map[string]*nodeServiceMeta),

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -48,6 +48,7 @@ type Environment interface {
 	PrepareRun(stopCh <-chan struct{}) error
 	InitStaticAciObjects()
 	NodePodNetworkChanged(nodeName string)
+	NodeAnnotationChanged(nodeName string)
 	NodeServiceChanged(nodeName string)
 	VmmPolicy() string
 	OpFlexDeviceType() string
@@ -193,6 +194,10 @@ func (env *K8sEnvironment) Init(cont *AciController) error {
 func (env *K8sEnvironment) InitStaticAciObjects() {
 	env.cont.initStaticNetPolObjs()
 	env.cont.initStaticServiceObjs()
+}
+
+func (env *K8sEnvironment) NodeAnnotationChanged(nodeName string) {
+	env.cont.nodeChangedByName(nodeName)
 }
 
 func (env *K8sEnvironment) NodePodNetworkChanged(nodeName string) {

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -395,6 +395,15 @@ func (cont *AciController) nodeChanged(obj interface{}) {
 			nodeUpdated = true
 		}
 	}
+
+	nodeAciPod := cont.nodeACIPod[node.ObjectMeta.Name]
+	aciPodAnn := node.ObjectMeta.Annotations[metadata.AciPodAnnotation]
+	if cont.nodeSyncEnabled {
+		if aciPodAnn != nodeAciPod {
+			node.ObjectMeta.Annotations[metadata.AciPodAnnotation] = nodeAciPod
+			nodeUpdated = true
+		}
+	}
 	cont.indexMutex.Unlock()
 
 	cont.createNetPolForNode(node)

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -300,13 +300,152 @@ func deleteDevicesFromList(delDevices apicapi.ApicSlice, devices apicapi.ApicSli
 	}
 	return newDevices
 }
+func (cont *AciController) getNodeName(nodeName string) string {
+	nodeList := cont.nodeIndexer.List()
+	for _, nodeItem := range nodeList {
+		node := nodeItem.(*v1.Node)
+		if nodeName == node.ObjectMeta.Name {
+			ip := getNodeIP(node, v1.NodeInternalIP)
+			return ip
+		}
+	}
+	return ""
+}
+
+func (cont *AciController) getfvRsCEpToPathEptDn(node string) (string, error) {
+	ipFilter := fmt.Sprintf("query-target-filter=and(eq(fvCEp.ip,\"%s\"))", node)
+	args := []string{
+		ipFilter,
+		"rsp-subtree-class=fvRsCEpToPathEp",
+		"rsp-subtree=children",
+	}
+	url := fmt.Sprintf("/api/node/class/fvCEp.json?%s", strings.Join(args, "&"))
+	apicresp, err := cont.apicConn.GetApicResponse(url)
+	if err != nil {
+		cont.log.Debug("Failed to get APIC response, err: ", err.Error())
+		return "", err
+	}
+	for _, obj := range apicresp.Imdata {
+		for _, body := range obj {
+			dn, dnok := body.Attributes["dn"].(string)
+			if !dnok {
+				continue
+			}
+			dnSlices := strings.Split(dn, "/")
+			if len(dnSlices) < 2 {
+				cont.log.Error("Invalid dn ", dn)
+				continue
+			}
+			tenant := "tn-" + cont.config.AciPolicyTenant
+			if dnSlices[1] != tenant {
+				continue
+			}
+			for _, child := range body.Children {
+				for class, cbody := range child {
+					if class == "fvRsCEpToPathEp" {
+						tDn, ok := cbody.Attributes["tDn"].(string)
+						if ok {
+							return tDn, nil
+						}
+					}
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("tDn missing in fvRsCEpToPathEp")
+}
+
+func (cont *AciController) getAciPodSubnet(pod string) (string, error) {
+	podslice := strings.Split(pod, "-")
+	if len(podslice) < 2 {
+		return "", fmt.Errorf("Failed to get podid from pod")
+	}
+	podid := podslice[1]
+	var subnet string
+	args := []string{
+		"query-target=self",
+	}
+	url := fmt.Sprintf("/api/node/mo/uni/controller/setuppol/setupp-%s.json?%s", podid, strings.Join(args, "&"))
+	apicresp, err := cont.apicConn.GetApicResponse(url)
+	if err != nil {
+		cont.log.Debug("Failed to get APIC response, err: ", err.Error())
+		return subnet, err
+	}
+	for _, obj := range apicresp.Imdata {
+		for _, body := range obj {
+			tepPool, ok := body.Attributes["tepPool"].(string)
+			if ok {
+				subnet = tepPool
+				break
+			}
+		}
+	}
+	return subnet, nil
+}
+
+func (cont *AciController) createAciPodAnnotation(fabricPathDn, node string) (string, error) {
+	if fabricPathDn == "" {
+		// for a multipod vm migration, when there is no opflex device connected
+		// get tDn from fvRsCEpToPathEp (which has info of new pod)
+		// and update annotation (pod-<podid>-<subnet of pod>) on node
+		path, err := cont.getfvRsCEpToPathEptDn(node)
+		if err != nil {
+			return "", err
+		} else {
+			pathSlice := strings.Split(path, "/")
+			if len(pathSlice) > 1 {
+				pod := pathSlice[1]
+				subnet, err := cont.getAciPodSubnet(pod)
+				if err != nil {
+					cont.log.Error("Failed to get subnet of aci pod ", err.Error())
+					return "", err
+				} else {
+					annot := pod + "-" + subnet
+					return annot, nil
+				}
+			}
+		}
+	} else {
+		// when there is already a connected opflex device,
+		// fabricPathDn will have latest pod iformation
+		nodeAciPod := cont.nodeACIPod[node]
+		path := fabricPathDn
+		pathSlice := strings.Split(path, "/")
+		if len(pathSlice) > 1 {
+			pod := pathSlice[1]
+			// when there is difference in pod info avaliable from fabricPathDn
+			// and what we have in cache, update info in cache and change annotation on node
+			if !strings.Contains(nodeAciPod, pod) {
+				subnet, err := cont.getAciPodSubnet(pod)
+				if err != nil {
+					cont.log.Error("Failed to get subnet of aci pod ", err.Error())
+					return "", err
+				} else {
+					annot := pod + "-" + subnet
+					return annot, nil
+				}
+			} else {
+				return nodeAciPod, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("Failed to extract pod from path")
+}
 
 func (cont *AciController) deleteOldOpflexDevices() {
 	var nodeUpdates []string
+	var nodeAnnotationUpdates []string
 	cont.indexMutex.Lock()
 	for node, devices := range cont.nodeOpflexDevice {
 		var delDevices apicapi.ApicSlice
 		fabricPathDn := cont.getActiveFabricPathDn(node)
+		annot, err := cont.createAciPodAnnotation(fabricPathDn, node)
+		if err == nil {
+			cont.nodeACIPod[node] = annot
+			nodeAnnotationUpdates = append(nodeAnnotationUpdates, node)
+		} else {
+			cont.log.Error(err.Error())
+		}
 		if fabricPathDn != "" {
 			for _, device := range devices {
 				if device.GetAttrStr("delete") == "true" && device.GetAttrStr("fabricPathDn") != fabricPathDn {
@@ -336,6 +475,10 @@ func (cont *AciController) deleteOldOpflexDevices() {
 	cont.indexMutex.Unlock()
 	if len(nodeUpdates) > 0 {
 		cont.postOpflexDeviceDelete(nodeUpdates)
+	} else if len(nodeAnnotationUpdates) > 0 {
+		for _, updatednode := range nodeAnnotationUpdates {
+			go cont.env.NodeAnnotationChanged(updatednode)
+		}
 	}
 }
 

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -78,6 +78,7 @@ type HostAgent struct {
 	depPods               *index.PodSelectorIndex
 	rcPods                *index.PodSelectorIndex
 	podNetAnnotation      string
+	aciPodAnnotation      string
 	podIps                *ipam.IpCache
 	usedIPs               map[string]string
 

--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -230,6 +230,9 @@ type HostAgentConfig struct {
 	//default is false
 	HppOptimization bool `json:"hpp-optimization,omitempty"`
 
+	// Max number of time dhcp renew will be executed after multi pod vm migration
+	DhcpRenewMaxRetryCount int `json:"dhcp-renew-max-retry-count,omitempty"`
+
 	// enable EndpointSlice
 	EnabledEndpointSlice bool `json:"enable_endpointslice,omitempty"`
 	// Cluster Flavour

--- a/pkg/hostagent/nodes.go
+++ b/pkg/hostagent/nodes.go
@@ -111,6 +111,14 @@ func (agent *HostAgent) nodeChanged(obj ...interface{}) {
 
 	agent.indexMutex.Lock()
 
+	aciPod, acipodok := node.ObjectMeta.Annotations[metadata.AciPodAnnotation]
+	if acipodok && aciPod != "" {
+		if agent.aciPodAnnotation != aciPod {
+			agent.doDhcpRenew(aciPod)
+		}
+		agent.aciPodAnnotation = aciPod
+	}
+
 	pnet, ok := node.ObjectMeta.Annotations[metadata.PodNetworkRangeAnnotation]
 	if ok {
 		agent.updateIpamAnnotation(pnet)

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -16,21 +16,24 @@ package hostagent
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io/ioutil"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"text/template"
-
-	"encoding/json"
+	//	"time"
 
 	uuid "github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 )
+
+const DEFAULT_RETRY_COUNT = 5
 
 type opflexFault struct {
 	FaultUUID   string `json:"fault_uuid"`
@@ -78,6 +81,96 @@ func (agent *HostAgent) createFaultOnAgent(description string, faultCode int) {
 		agent.log.Debug("Created fault files at the location: ", faultFilePath)
 	}
 	return
+}
+
+func (agent *HostAgent) isIpSameSubnet(iface, subnet string) bool {
+	links, err := netlink.LinkList()
+	if err != nil {
+		agent.log.Error("Could not enumerate interfaces: ", err)
+		return false
+	}
+	_, ipnet, _ := net.ParseCIDR(subnet)
+	for _, link := range links {
+		switch link := link.(type) {
+		case *netlink.Vlan:
+			if link.Name == iface {
+				addrs, err := netlink.AddrList(link, 2)
+				if err != nil {
+					agent.log.Error("Could not enumerate addresses: ", err)
+					return false
+				}
+				for _, addr := range addrs {
+					agent.log.Debug("Interface ip address: ", addr.String())
+					addressSlice := strings.Split(addr.String(), " ")
+					if len(addressSlice) > 0 {
+						ipslice := strings.Split(addressSlice[0], "/")
+						if len(ipslice) > 0 {
+							ip := net.ParseIP(ipslice[0])
+							if ipnet.Contains(ip) {
+								return true
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (agent *HostAgent) doDhcpRenew(aciPodSubnet string) {
+	retryCount := agent.config.DhcpRenewMaxRetryCount
+	if retryCount == 0 {
+		retryCount = DEFAULT_RETRY_COUNT
+	}
+	links, err := netlink.LinkList()
+	if err != nil {
+		agent.log.Error("Could not enumerate interfaces: ", err)
+		return
+	}
+	var subnet string
+	subnetSlice := strings.Split(aciPodSubnet, "-")
+	if len(subnetSlice) > 2 {
+		subnet = subnetSlice[2]
+	}
+	for _, link := range links {
+		switch link := link.(type) {
+		case *netlink.Vlan:
+			// find link with matching vlan
+			if link.VlanId != int(agent.config.AciInfraVlan) {
+				continue
+			}
+			if agent.isIpSameSubnet(link.Name, subnet) {
+				agent.log.Debug("Ip already from same subnet ", subnet)
+				break
+			}
+
+			success := false
+			for i := 0; i < retryCount; i++ {
+				cmd := exec.Command("dhclient", "-r", link.Name, "--timeout", "30")
+				opt, err := cmd.Output()
+				if err != nil {
+					agent.log.Error("Failed to release ip : ", err.Error(), " ", string(opt))
+					continue
+				}
+				cmd = exec.Command("dhclient", link.Name, "--timeout", "30")
+				opt, err = cmd.Output()
+				if err != nil {
+					agent.log.Error("Failed to get new ip: ", err.Error(), " ", string(opt))
+					continue
+				}
+				if agent.isIpSameSubnet(link.Name, subnet) {
+					success = true
+					break
+				} else {
+					agent.log.Debug("Interface ip is not from the subnet ", subnet)
+				}
+			}
+			if !success {
+				agent.log.Error("Failed to assign ip from pod subnet after ", retryCount, " tries")
+			}
+		}
+	}
 }
 
 func (agent *HostAgent) discoverHostConfig() (conf *HostAgentNodeConfig) {
@@ -347,7 +440,9 @@ func (agent *HostAgent) updateOpflexConfig() {
 		}
 	}
 
+	agent.indexMutex.Lock()
 	newNodeConfig := agent.discoverHostConfig()
+	agent.indexMutex.Unlock()
 	if newNodeConfig == nil {
 		panic(errors.New("Node configuration autodiscovery failed"))
 	}

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -53,6 +53,8 @@ const ServiceContractScopeAnnotation = "opflex.cisco.com/ext_service_contract_sc
 // List of IP address ranges for use by the pod network
 const PodNetworkRangeAnnotation = "opflex.cisco.com/pod-network-ranges"
 
+const AciPodAnnotation = "opflex.cisco.com/aci-pod"
+
 // Annotation for endpoint group designation for pod, deployment, etc.
 const EgAnnotation = "opflex.cisco.com/endpoint-group"
 


### PR DESCRIPTION
Controller reports hostagent regarding the new aci pod the vm is migarated to and the hostagent will do dhcp relase and renew so that the vlan interface will get new ip from the new pod subnet

(cherry picked from commit 5cc46c7a5b143e873180f76d5f1f731961ddb976)