### PR TITLE
Add new ovs db file path for centos-repo based aci containers ovs image.

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -507,7 +507,7 @@ func clusterReport(cmd *cobra.Command, args []string) {
 			cont:     "aci-containers-openvswitch",
 			selector: openvswitchSelector,
 			argFunc:  otherNodeArgs,
-			args:     []string{"cat", "/etc/openvswitch/conf.db"},
+			args:     []string{"cat", "/etc/openvswitch/conf.db", "/usr/local/etc/openvswitch/conf.db"},
 		},
 	}
 


### PR DESCRIPTION
(cherry picked from commit 705e6a402b4ecf623e27951ca8063c61b96440de)