### PR TITLE
Handled DeletedFinalStateUnknown

### DIFF
--- a/pkg/controller/aci_istio.go
+++ b/pkg/controller/aci_istio.go
@@ -213,7 +213,19 @@ func (cont *AciController) handleIstioUpdate(istiospec *istiov1.AciIstioOperator
 }
 
 func (cont *AciController) istioSpecDeleted(obj interface{}) {
-	istiospec := obj.(*istiov1.AciIstioOperator)
+	istiospec, isIstiospec := obj.(*istiov1.AciIstioOperator)
+	if !isIstiospec {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			cont.log.Error("Received unexpected object: ", obj)
+			return
+		}
+		istiospec, ok = deletedState.Obj.(*istiov1.AciIstioOperator)
+		if !ok {
+			cont.log.Error("DeletedFinalStateUnknown contained non-AciIstioOperator object: ", deletedState.Obj)
+			return
+		}
+	}
 	istiospeckey, err := cache.MetaNamespaceKeyFunc(istiospec)
 	if err != nil {
 		IstioLogger(cont.log, istiospec).Error("Could not create key:" + err.Error())

--- a/pkg/controller/nodepodif.go
+++ b/pkg/controller/nodepodif.go
@@ -134,10 +134,18 @@ func (cont *AciController) nodePodIFUpdated(oldobj interface{}, newobj interface
 }
 
 func (cont *AciController) nodePodIFDeleted(obj interface{}) {
-	np, ok := obj.(*nodePodIf.NodePodIF)
-	if !ok {
-		cont.log.Errorf("nodePodIFDeleted: Bad object type")
-		return
+	np, isNp := obj.(*nodePodIf.NodePodIF)
+	if !isNp {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			cont.log.Error("Received unexpected object: ", obj)
+			return
+		}
+		np, ok = deletedState.Obj.(*nodePodIf.NodePodIF)
+		if !ok {
+			cont.log.Error("DeletedFinalStateUnknown contained non-NodePodIF object: ", deletedState.Obj)
+			return
+		}
 	}
 	cont.log.Infof("nodepodif Deleted: %s", np.ObjectMeta.Name)
 	podifs := np.Spec.PodIFs

--- a/pkg/controller/rdconfig.go
+++ b/pkg/controller/rdconfig.go
@@ -111,7 +111,19 @@ func (cont *AciController) RdConfigUpdated(oldobj interface{}, newobj interface{
 }
 
 func (cont *AciController) RdConfigDeleted(obj interface{}) {
-	rdcon := obj.(*rdConfigv1.RdConfig)
+	rdcon, isRdCon := obj.(*rdConfigv1.RdConfig)
+	if !isRdCon {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			cont.log.Error("Received unexpected object: ", obj)
+			return
+		}
+		rdcon, ok = deletedState.Obj.(*rdConfigv1.RdConfig)
+		if !ok {
+			cont.log.Error("DeletedFinalStateUnknown contained non-RdConfig object: ", deletedState.Obj)
+			return
+		}
+	}
 	rdconkey, err := cache.MetaNamespaceKeyFunc(rdcon)
 	if err != nil {
 		RdConfigLogger(cont.log, rdcon).Error("Could not create key:" + err.Error())

--- a/pkg/hostagent/pod_relatives.go
+++ b/pkg/hostagent/pod_relatives.go
@@ -100,7 +100,19 @@ func (agent *HostAgent) namespaceChanged(oldobj interface{},
 }
 
 func (agent *HostAgent) namespaceDeleted(obj interface{}) {
-	ns := obj.(*v1.Namespace)
+	ns, isNs := obj.(*v1.Namespace)
+	if !isNs {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			agent.log.Error("Received unexpected object: ", obj)
+			return
+		}
+		ns, ok = deletedState.Obj.(*v1.Namespace)
+		if !ok {
+			agent.log.Error("DeletedFinalStateUnknown contained non-Namespace object: ", deletedState.Obj)
+			return
+		}
+	}
 	agent.handleObjectDeleteForSnat(obj)
 	agent.netPolPods.DeleteNamespace(ns)
 	agent.log.Infof("Namespace %+v deleted", ns)
@@ -171,7 +183,19 @@ func (agent *HostAgent) networkPolicyChanged(oldobj, newobj interface{}) {
 }
 
 func (agent *HostAgent) networkPolicyDeleted(obj interface{}) {
-	np := obj.(*v1net.NetworkPolicy)
+	np, isNp := obj.(*v1net.NetworkPolicy)
+	if !isNp {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			agent.log.Error("Received unexpected object: ", obj)
+			return
+		}
+		np, ok = deletedState.Obj.(*v1net.NetworkPolicy)
+		if !ok {
+			agent.log.Error("DeletedFinalStateUnknown contained non-NetworkPolicy object: ", deletedState.Obj)
+			return
+		}
+	}
 	agent.netPolPods.DeleteSelectorObj(obj)
 	agent.log.Infof("Network policy deleted: %s", np.ObjectMeta.Name)
 }
@@ -260,7 +284,19 @@ func (agent *HostAgent) qosPolicyChanged(oldobj, newobj interface{}) {
 }
 
 func (agent *HostAgent) qosPolicyDeleted(obj interface{}) {
-	qp := obj.(*qospolicy.QosPolicy)
+	qp, isQp := obj.(*qospolicy.QosPolicy)
+	if !isQp {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			agent.log.Error("Received unexpected object: ", obj)
+			return
+		}
+		qp, ok = deletedState.Obj.(*qospolicy.QosPolicy)
+		if !ok {
+			agent.log.Error("DeletedFinalStateUnknown contained non-QosPolicy object: ", deletedState.Obj)
+			return
+		}
+	}
 	agent.qosPolPods.DeleteSelectorObj(obj)
 	agent.log.Infof("qos policy deleted: %s", qp.ObjectMeta.Name)
 }
@@ -381,7 +417,19 @@ func (agent *HostAgent) deploymentChanged(oldobj interface{},
 }
 
 func (agent *HostAgent) deploymentDeleted(obj interface{}) {
-	depObj := obj.(*appsv1.Deployment)
+	depObj, isDep := obj.(*appsv1.Deployment)
+	if !isDep {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			agent.log.Error("Received unexpected object: ", obj)
+			return
+		}
+		depObj, ok = deletedState.Obj.(*appsv1.Deployment)
+		if !ok {
+			agent.log.Error("DeletedFinalStateUnknown contained non-Deployment object: ", deletedState.Obj)
+			return
+		}
+	}
 	agent.handleObjectDeleteForSnat(obj)
 	agent.indexMutex.Lock()
 	agent.depPods.DeleteSelectorObj(obj)
@@ -482,7 +530,19 @@ func (agent *HostAgent) rcChanged(oldobj interface{},
 }
 
 func (agent *HostAgent) rcDeleted(obj interface{}) {
-	rc := obj.(*v1.ReplicationController)
+	rc, isRc := obj.(*v1.ReplicationController)
+	if !isRc {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			agent.log.Error("Received unexpected object: ", obj)
+			return
+		}
+		rc, ok = deletedState.Obj.(*v1.ReplicationController)
+		if !ok {
+			agent.log.Error("DeletedFinalStateUnknown contained non-ReplicationController object: ", deletedState.Obj)
+			return
+		}
+	}
 	agent.rcPods.DeleteSelectorObj(obj)
 	rcLogger(agent.log, rc).Info("rcDeleted:")
 }


### PR DESCRIPTION
When cache package has a diconnect from apiserver and deletion of some resources happen while it is disconnected, it places DeletedFinalStateUnknown object in DeltaFIFO. Modified code to handle such case - If received object is of type DeletedFinalStateUnknown, extracted actual object from it and then proceeded with cleanup