### PR TITLE
coveralls hasn't been getting coverage data for a few months

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
       sudo: false
       go: "1.20"
       before_install:
-        - go get github.com/mattn/goveralls@v0.0.8
+        - go install github.com/mattn/goveralls@v0.0.12
       install:
         - export PATH=$PATH:$GOPATH/bin
       script:

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,6 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.16.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
-	github.com/mattn/goveralls v0.0.8 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect


### PR DESCRIPTION
'go get' doesn't behave the same in recent go versions use 'go install' instead