### PR TITLE
Chaining mode operation #2

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -160,6 +160,7 @@ var metadata = map[string]*apicMeta{
 		children: []string{
 			"fvBD",
 			"fvCtx",
+			"fvAp",
 		},
 	},
 	"cloudAwsProvider": {
@@ -297,12 +298,6 @@ var metadata = map[string]*apicMeta{
 	},
 	"fvRsBd": {
 		attributes: map[string]interface{}{
-			"name":       "",
-			"nameAlias":  "",
-			"tCl":        "fvBD",
-			"tDn":        "",
-			"tRn":        "",
-			"tType":      "name",
 			"tnFvBDName": "",
 		},
 		children: []string{
@@ -341,6 +336,17 @@ var metadata = map[string]*apicMeta{
 			"ip":        "",
 			"virtual":   "no",
 			"preferred": "no",
+		},
+	},
+	"fvRsDomAtt": {
+		attributes: map[string]interface{}{
+			"tDn": "",
+		},
+	},
+	"fvRsPathAtt": {
+		attributes: map[string]interface{}{
+			"tDn":   "",
+			"encap": "",
 		},
 	},
 	"tagInst": {

--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -275,9 +275,11 @@ func (o ApicObject) SetTag(tag string) {
 		}
 		break
 	}
+	if o.GetDn() != "" {
+		o.AddChild(NewTagAnnotation(o.GetDn(), aciContainersAnnotKey).
+			SetAttr("value", tag))
+	}
 
-	o.AddChild(NewTagAnnotation(o.GetDn(), aciContainersAnnotKey).
-		SetAttr("value", tag))
 }
 
 func (o ApicObject) SetAttr(name string, value interface{}) ApicObject {
@@ -370,8 +372,6 @@ func (o ApicObject) Copy() ApicObject {
 func NewFvTenant(name string) ApicObject {
 	ret := newApicObject("fvTenant")
 	ret["fvTenant"].Attributes["name"] = name
-	ret["fvTenant"].Attributes["dn"] =
-		fmt.Sprintf("uni/tn-%s", name)
 	return ret
 }
 
@@ -432,11 +432,52 @@ func NewFvCtx(tenantName string, name string) ApicObject {
 	return ret
 }
 
+func NewFvRsDomAttPhysDom(physDom string) ApicObject {
+	physDomDn := fmt.Sprintf("uni/phys-%s", physDom)
+	ret := newApicObject("fvRsDomAtt")
+	ret["fvRsDomAtt"].Attributes["tDn"] = physDomDn
+	return ret
+
+}
+
+func NewFvAP(ap string) ApicObject {
+	ret := newApicObject("fvAp")
+	ret["fvAp"].Attributes["name"] = ap
+	return ret
+}
+
+func NewFvAEPg(tenant string, ap string, name string) ApicObject {
+	ret := newApicObject("fvAEPg")
+	ret["fvAEPg"].Attributes["dn"] = fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s", tenant, ap, name)
+	ret["fvAEPg"].Attributes["name"] = name
+	return ret
+}
+
+func NewFvRsBD(bdName string) ApicObject {
+	ret := newApicObject("fvRsBd")
+	ret["fvRsBd"].Attributes["tnFvBDName"] = bdName
+	return ret
+}
+
+func NewFvRsPathAtt(path string, encap string) ApicObject {
+	ret := newApicObject("fvRsPathAtt")
+	ret["fvRsPathAtt"].Attributes["tDn"] = path
+	ret["fvRsPathAtt"].Attributes["encap"] = "vlan-" + encap
+	return ret
+
+}
+
 func NewFvBD(tenantName string, name string) ApicObject {
 	ret := newApicObject("fvBD")
 	ret["fvBD"].Attributes["name"] = name
 	ret["fvBD"].Attributes["dn"] =
 		fmt.Sprintf("uni/tn-%s/BD-%s", tenantName, name)
+	return ret
+}
+
+func NewFvRsCtx(vrfName string) ApicObject {
+	ret := newApicObject("fvRsCtx")
+	ret["fvRsCtx"].Attributes["tnFvCtxName"] = vrfName
 	return ret
 }
 

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -1056,6 +1056,10 @@ func (conn *ApicConnection) postDn(dn string, obj ApicObject) bool {
 }
 
 func (conn *ApicConnection) DeleteDn(dn string) bool {
+	if dn == "" {
+		conn.log.Debug("Skip delete for empty Dn: ")
+		return false
+	}
 	conn.logger.WithFields(logrus.Fields{
 		"mod": "APICAPI",
 		"dn":  dn,

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -250,6 +250,15 @@ type ControllerConfig struct {
 
 	// Configure sleep time for global SNAT sync
 	SleepTimeSnatGlobalInfoSync int `json:"sleep-time-snat-global-info-sync,omitempty"`
+
+	// PhysDom for additional networks in chained mode
+	AciPhysDom string `json:"aci-phys-dom,omitempty"`
+
+	// CNI is in chained mode
+	ChainedMode bool `json:"chained-mode,omitempty"`
+
+	// PhysDom for additional networks in chained mode
+	AciAdditionalPhysDom string `json:"aci-additional-phys-dom,omitempty"`
 }
 
 type netIps struct {
@@ -288,6 +297,7 @@ func InitFlags(config *ControllerConfig) {
 	flag.IntVar(&config.MaxCSRTunnels, "max-csr-tunnels", 16, "Number of CSR tunnels")
 	flag.IntVar(&config.CSRTunnelIDBase, "csr-tunnel-id-base", 4001, "CSR starting tunnel ID")
 	flag.BoolVar(&config.EnableVmmInjectedLabels, "enable-vmm-injected-labels", false, "Enable creation of VmmInjectedLabel")
+	flag.BoolVar(&config.ChainedMode, "chained-mode", false, "CNI is in chained mode")
 }
 
 func (cont *AciController) loadIpRanges(v4 *ipam.IpAlloc, v6 *ipam.IpAlloc,

--- a/pkg/controller/deployments.go
+++ b/pkg/controller/deployments.go
@@ -89,6 +89,9 @@ func deploymentLogger(log *logrus.Logger, dep *appsv1.Deployment) *logrus.Entry 
 }
 
 func (cont *AciController) writeApicDepl(dep *appsv1.Deployment) {
+	if cont.config.ChainedMode {
+		return
+	}
 	depkey, err :=
 		cache.MetaNamespaceKeyFunc(dep)
 	if err != nil {

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -192,8 +192,12 @@ func (env *K8sEnvironment) Init(cont *AciController) error {
 }
 
 func (env *K8sEnvironment) InitStaticAciObjects() {
-	env.cont.initStaticNetPolObjs()
-	env.cont.initStaticServiceObjs()
+	if env.cont.config.ChainedMode {
+		env.cont.initStaticChainedModeObjs()
+	} else {
+		env.cont.initStaticNetPolObjs()
+		env.cont.initStaticServiceObjs()
+	}
 }
 
 func (env *K8sEnvironment) NodeAnnotationChanged(nodeName string) {
@@ -301,6 +305,7 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 	cont.registerCRDHook(netflowCRDName, netflowInit)
 	cont.registerCRDHook(nodePodIfCRDName, nodePodIfInit)
 	cont.registerCRDHook(erspanCRDName, erspanInit)
+	cont.registerCRDHook(nodeFabNetAttCRDName, nodeFabNetAttInit)
 	go cont.crdInformer.Run(stopCh)
 
 	cache.WaitForCacheSync(stopCh,

--- a/pkg/controller/namespaces.go
+++ b/pkg/controller/namespaces.go
@@ -66,6 +66,9 @@ func (cont *AciController) updatePodsForNamespace(ns string) {
 }
 
 func (cont *AciController) writeApicNs(ns *v1.Namespace) {
+	if cont.config.ChainedMode {
+		return
+	}
 	aobj := apicapi.NewVmmInjectedNs(cont.vmmDomainProvider(),
 		cont.config.AciVmmDomain, cont.config.AciVmmController,
 		ns.Name)

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -1082,6 +1082,9 @@ func (cont *AciController) buildServiceAugment(subj apicapi.ApicObject,
 }
 
 func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
+	if cont.config.ChainedMode {
+		return false
+	}
 	key, err := cache.MetaNamespaceKeyFunc(np)
 	logger := networkPolicyLogger(cont.log, np)
 	if err != nil {
@@ -1262,6 +1265,9 @@ func (cont *AciController) networkPolicyAdded(obj interface{}) {
 		return
 	}
 	cont.writeApicNP(npkey, np)
+	if cont.config.ChainedMode {
+		return
+	}
 	cont.netPolPods.UpdateSelectorObj(obj)
 	cont.netPolIngressPods.UpdateSelectorObj(obj)
 	cont.netPolEgressPods.UpdateSelectorObj(obj)
@@ -1280,6 +1286,9 @@ func (cont *AciController) networkPolicyAdded(obj interface{}) {
 
 func (cont *AciController) writeApicNP(npKey string, np *v1net.NetworkPolicy) {
 	if cont.config.LBType == lbTypeAci {
+		return
+	}
+	if cont.config.ChainedMode {
 		return
 	}
 

--- a/pkg/controller/nodefabricnetworkattachments.go
+++ b/pkg/controller/nodefabricnetworkattachments.go
@@ -1,0 +1,344 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Handlers for node updates.
+
+package controller
+
+import (
+	"fmt"
+	fabattv1 "github.com/noironetworks/aci-containers/pkg/fabricattachment/apis/aci.fabricattachment/v1"
+	fabattclset "github.com/noironetworks/aci-containers/pkg/fabricattachment/clientset/versioned"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/tools/cache"
+	"strings"
+
+	"github.com/noironetworks/aci-containers/pkg/apicapi"
+)
+
+const (
+	nodeFabNetAttCRDName = "nodefabricnetworkattachments.aci.fabricattachment"
+)
+
+func NodeFabricNetworkAttachmentLogger(log *logrus.Logger, nodeFabNetAtt *fabattv1.NodeFabricNetworkAttachment) *logrus.Entry {
+	return log.WithFields(logrus.Fields{
+		"name": nodeFabNetAtt.ObjectMeta.Name,
+		"spec": nodeFabNetAtt.Spec,
+	})
+}
+
+func nodeFabNetAttInit(cont *AciController, stopCh <-chan struct{}) {
+	cont.log.Debug("Initializing nodefabricnetworkattachment client")
+	restconfig := cont.env.RESTConfig()
+	fabNetAttClient, err := fabattclset.NewForConfig(restconfig)
+	if err != nil {
+		cont.log.Errorf("Failed to intialize nodefabricnetworkattachment client")
+		return
+	}
+	cont.initNodeFabNetAttInformerFromClient(fabNetAttClient)
+	go cont.nodeFabNetAttInformer.Run(stopCh)
+	go cont.processQueue(cont.nodeFabNetAttQueue, cont.nodeFabNetAttIndexer,
+		func(obj interface{}) bool {
+			return cont.handleNodeFabricNetworkAttachmentUpdate(obj)
+		}, func(key string) bool {
+			return cont.handleNodeFabricNetworkAttachmentDelete(key)
+		}, nil, stopCh)
+	cache.WaitForCacheSync(stopCh, cont.nodeFabNetAttInformer.HasSynced)
+}
+
+func (cont *AciController) staticChainedModeObjs() apicapi.ApicSlice {
+	var apicSlice apicapi.ApicSlice
+	tenant := apicapi.NewFvTenant(cont.config.AciPolicyTenant)
+	ap := apicapi.NewFvAP("netop-" + cont.config.AciPolicyTenant)
+	bd := apicapi.NewFvBD(cont.config.AciPolicyTenant, "netop-nodes")
+	bd.SetAttr("arpFlood", "yes")
+	bd.SetAttr("ipLearning", "no")
+	bd.SetAttr("unkMacUcastAct", "flood")
+	fvRsCtx := apicapi.NewFvRsCtx(cont.config.AciVrf)
+	bd.AddChild(fvRsCtx)
+	epg := apicapi.NewFvAEPg(cont.config.AciPolicyTenant, "netop-"+cont.config.AciPolicyTenant, "netop-nodes")
+	fvRsBd := apicapi.NewFvRsBD("netop-nodes")
+	epg.AddChild(fvRsBd)
+	fvRsDomAtt := apicapi.NewFvRsDomAttPhysDom(cont.config.AciPhysDom)
+	epg.AddChild(fvRsDomAtt)
+	ap.AddChild(epg)
+	tenant.AddChild(bd)
+	tenant.AddChild(ap)
+	apicSlice = append(apicSlice, tenant)
+	return apicSlice
+}
+
+func (cont *AciController) initStaticChainedModeObjs() {
+	cont.apicConn.WriteApicObjects(cont.config.AciPrefix+"_chainedmode_static",
+		cont.staticChainedModeObjs())
+}
+
+func (cont *AciController) initNodeFabNetAttInformerFromClient(fabAttClient *fabattclset.Clientset) {
+
+	cont.initNodeFabNetAttInformerBase(
+		cache.NewListWatchFromClient(
+			fabAttClient.AciV1().RESTClient(), "nodefabricnetworkattachments",
+			"aci-containers-system", fields.Everything()))
+}
+
+func (cont *AciController) initNodeFabNetAttInformerBase(listWatch *cache.ListWatch) {
+	cont.nodeFabNetAttIndexer, cont.nodeFabNetAttInformer = cache.NewIndexerInformer(
+		listWatch, &fabattv1.NodeFabricNetworkAttachment{}, 0,
+		cache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				cont.nodeFabNetAttChanged(obj)
+			},
+			UpdateFunc: func(_ interface{}, obj interface{}) {
+				cont.nodeFabNetAttChanged(obj)
+			},
+			DeleteFunc: func(obj interface{}) {
+				cont.nodeFabNetAttDeleted(obj)
+			},
+		},
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+	)
+}
+
+func (cont *AciController) getLLDPIf(fabricLink string) string {
+	var lldpIf, apicIf string
+	if lldpIf, ok := cont.lldpIfCache[fabricLink]; ok {
+		return lldpIf
+	}
+	fabricPathParts := strings.SplitN(fabricLink, "/", 4)
+	if len(fabricPathParts) < 4 {
+		cont.log.Errorf("getLLDPIf: fabricPath(%s) is not formed properly: %d",
+			fabricLink, len(fabricPathParts))
+		return lldpIf
+	}
+	apicPodLeaf := fabricPathParts[0] + "/" + fabricPathParts[1] + "/" + fabricPathParts[2]
+	_, portStr, _ := strings.Cut(fabricPathParts[3], "[")
+	apicIf, _, _ = strings.Cut(portStr, "]")
+	lldpIfQuery := fmt.Sprintf("/api/node/mo/%s/sys/lldp/inst/if-[%s].json?query-target=self", apicPodLeaf, apicIf)
+	apicresp, err := cont.apicConn.GetApicResponse(lldpIfQuery)
+	if err != nil {
+		cont.log.Errorf("getLLDPIf: apic error for lldpIf %s: %v", fabricLink, err)
+		return lldpIf
+	}
+	for _, obj := range apicresp.Imdata {
+		lresp, ok := obj["lldpIf"]
+		if !ok {
+			cont.log.Errorf("getLLDPIf: lldpIf Object not found in response")
+			break
+		}
+		if val, ok := lresp.Attributes["portDesc"]; ok {
+			lldpIf = val.(string)
+		} else {
+			cont.log.Errorf("getLLDPIf: portDesc missing for lldpIf %s: %v", fabricLink, err)
+			break
+		}
+	}
+	if lldpIf != "" {
+		cont.lldpIfCache[fabricLink] = lldpIf
+		cont.log.Infof("getLLDPIf: Found port=>pc/vpc mapping: %s=>%s", fabricLink, lldpIf)
+	}
+	return lldpIf
+}
+
+func (cont *AciController) populateFabricPaths(addNet *AdditionalNetworkMeta, epg apicapi.ApicObject) {
+	for _, localIfaceMap := range addNet.FabricLink {
+		for localIface, fabricLinks := range localIfaceMap {
+			var actualFabricLink, vpcIf string
+			// Check if port is part of a PC
+			for i := range fabricLinks {
+				lldpIf := cont.getLLDPIf(fabricLinks[i])
+				if vpcIf != "" && lldpIf != vpcIf {
+					cont.log.Errorf(" Individual fabricLinks are part of different vpcs(%s): %s %s", localIface, lldpIf, vpcIf)
+					continue
+				}
+				vpcIf = lldpIf
+			}
+			if len(fabricLinks) > 2 {
+				cont.log.Errorf("populate Failed : %d(>2) fabriclinks found ", len(fabricLinks))
+				continue
+			}
+			if vpcIf != "" {
+				actualFabricLink = vpcIf
+			} else {
+				actualFabricLink = strings.Replace(fabricLinks[0], "node-", "paths-", 1)
+			}
+			fvRsPathAtt := apicapi.NewFvRsPathAtt(actualFabricLink, addNet.EncapVlan)
+			epg.AddChild(fvRsPathAtt)
+		}
+	}
+}
+
+func (cont *AciController) updateNodeFabNetAttObj(nodeFabNetAtt *fabattv1.NodeFabricNetworkAttachment) apicapi.ApicSlice {
+	var apicSlice apicapi.ApicSlice
+	var addNet *AdditionalNetworkMeta
+	addNetKey := nodeFabNetAtt.Spec.NetworkRef.Namespace + "/" + nodeFabNetAtt.Spec.NetworkRef.Name
+	addNet, ok := cont.additionalNetworkCache[addNetKey]
+	if !ok {
+		addNet = &AdditionalNetworkMeta{
+			NetworkName: nodeFabNetAtt.Spec.NetworkRef.Namespace + "-" + nodeFabNetAtt.Spec.NetworkRef.Name,
+			EncapVlan:   nodeFabNetAtt.Spec.EncapVlan,
+			FabricLink:  make(map[string]map[string][]string),
+			NodeCache:   make(map[string]*fabattv1.NodeFabricNetworkAttachment)}
+		cont.additionalNetworkCache[addNetKey] = addNet
+	}
+	addNet.EncapVlan = nodeFabNetAtt.Spec.EncapVlan
+	addNet.NodeCache[nodeFabNetAtt.Spec.NodeName] = nodeFabNetAtt
+
+	cont.log.Infof("nfna update: %v", addNetKey)
+	bd := apicapi.NewFvBD(cont.config.AciPolicyTenant, addNet.NetworkName)
+	bd.SetAttr("arpFlood", "yes")
+	bd.SetAttr("ipLearning", "no")
+	bd.SetAttr("unkMacUcastAct", "flood")
+	fvRsCtx := apicapi.NewFvRsCtx(cont.config.AciVrf)
+	bd.AddChild(fvRsCtx)
+	apName := "netop-" + cont.config.AciPolicyTenant
+	apicSlice = append(apicSlice, bd)
+	epg := apicapi.NewFvAEPg(cont.config.AciPolicyTenant, apName, addNet.NetworkName)
+	fvRsBd := apicapi.NewFvRsBD(addNet.NetworkName)
+	epg.AddChild(fvRsBd)
+	fvRsDomAtt := apicapi.NewFvRsDomAttPhysDom(cont.config.AciAdditionalPhysDom)
+	epg.AddChild(fvRsDomAtt)
+	linkPresent := map[string]bool{}
+	for iface, aciLink := range nodeFabNetAtt.Spec.AciTopology {
+		if _, ok := addNet.FabricLink[nodeFabNetAtt.Spec.NodeName]; !ok || (addNet.FabricLink[nodeFabNetAtt.Spec.NodeName] == nil) {
+			addNet.FabricLink[nodeFabNetAtt.Spec.NodeName] = make(map[string][]string)
+		}
+		addNet.FabricLink[nodeFabNetAtt.Spec.NodeName][iface] = aciLink.FabricLink
+		linkPresent[iface] = true
+	}
+	nodeIfaceMap := addNet.FabricLink[nodeFabNetAtt.Spec.NodeName]
+	for iface := range nodeIfaceMap {
+		if _, ok := linkPresent[iface]; !ok {
+			delete(nodeIfaceMap, iface)
+		}
+	}
+	addNet.FabricLink[nodeFabNetAtt.Spec.NodeName] = nodeIfaceMap
+	cont.populateFabricPaths(addNet, epg)
+	apicSlice = append(apicSlice, epg)
+	return apicSlice
+}
+
+func (cont *AciController) nodeFabNetAttChanged(obj interface{}) {
+	fabNetAttDef, ok := obj.(*fabattv1.NodeFabricNetworkAttachment)
+	if !ok {
+		cont.log.Error("nodeFabNetAttChanged: Bad object type")
+		return
+	}
+	key, err := cache.MetaNamespaceKeyFunc(fabNetAttDef)
+	if err != nil {
+		return
+	}
+	cont.queueNodeFabNetAttByKey(key)
+}
+
+func (cont *AciController) nodeFabNetAttDeleted(obj interface{}) {
+	nodeFabNetAtt, ok := obj.(*fabattv1.NodeFabricNetworkAttachment)
+	if !ok {
+		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			NodeFabricNetworkAttachmentLogger(cont.log, nodeFabNetAtt).
+				Error("Received unexpected object: ", obj)
+			return
+		}
+		nodeFabNetAtt, ok = deletedState.Obj.(*fabattv1.NodeFabricNetworkAttachment)
+		if !ok {
+			NodeFabricNetworkAttachmentLogger(cont.log, nodeFabNetAtt).
+				Error("DeletedFinalStateUnknown contained non-nodefabricnetworkattachment object: ", deletedState.Obj)
+			return
+		}
+	}
+	key, err := cache.MetaNamespaceKeyFunc(nodeFabNetAtt)
+	if err != nil {
+		return
+	}
+	cont.queueNodeFabNetAttByKey("DELETED_" + nodeFabNetAtt.Spec.NodeName + "_" + key)
+}
+
+func (cont *AciController) deleteNodeFabNetAttObj(key string) bool {
+	var apicSlice apicapi.ApicSlice
+	parts := strings.Split(key, "_")
+	nodeName := parts[0]
+	nodeFabNetAttKey := parts[1]
+
+	cont.log.Infof("nfna delete: %v", nodeFabNetAttKey)
+	addNet, ok := cont.additionalNetworkCache[nodeFabNetAttKey]
+	if !ok {
+		return true
+	}
+	nodeCache, ok := addNet.NodeCache[nodeName]
+	if !ok {
+		return true
+	}
+	delete(addNet.NodeCache, nodeName)
+
+	if len(addNet.NodeCache) == 0 {
+		labelKey := cont.aciNameForKey("nfna", addNet.NetworkName)
+		cont.apicConn.ClearApicObjects(labelKey)
+		return true
+	}
+
+	for iface := range nodeCache.Spec.AciTopology {
+		if _, ok := addNet.FabricLink[nodeName]; !ok {
+			break
+		}
+		localIfaceMap := addNet.FabricLink[nodeName]
+		delete(localIfaceMap, iface)
+		addNet.FabricLink[nodeName] = localIfaceMap
+	}
+	bd := apicapi.NewFvBD(cont.config.AciPolicyTenant, addNet.NetworkName)
+	bd.SetAttr("arpFlood", "yes")
+	bd.SetAttr("ipLearning", "no")
+	bd.SetAttr("unkMacUcastAct", "flood")
+	fvRsCtx := apicapi.NewFvRsCtx(cont.config.AciVrf)
+	bd.AddChild(fvRsCtx)
+	apName := "netop-" + cont.config.AciPolicyTenant
+	epg := apicapi.NewFvAEPg(cont.config.AciPolicyTenant, apName, addNet.NetworkName)
+	fvRsBd := apicapi.NewFvRsBD(addNet.NetworkName)
+	epg.AddChild(fvRsBd)
+	fvRsDomAtt := apicapi.NewFvRsDomAttPhysDom(cont.config.AciAdditionalPhysDom)
+	epg.AddChild(fvRsDomAtt)
+	cont.populateFabricPaths(addNet, epg)
+	apicSlice = append(apicSlice, bd)
+	apicSlice = append(apicSlice, epg)
+
+	labelKey := cont.aciNameForKey("nfna", addNet.NetworkName)
+	cont.apicConn.WriteApicObjects(labelKey, apicSlice)
+	return true
+}
+
+func (cont *AciController) queueNodeFabNetAttByKey(key string) {
+	cont.nodeFabNetAttQueue.Add(key)
+}
+
+// func returns false if executed without error, true if the caller has to requeue.
+func (cont *AciController) handleNodeFabricNetworkAttachmentUpdate(obj interface{}) bool {
+
+	nodeFabNetAtt, ok := obj.(*fabattv1.NodeFabricNetworkAttachment)
+	if !ok {
+		cont.log.Error("handleNodeFabricNetworkAttUpdate: Bad object type")
+		return false
+	}
+	nodeFabNetAttKey := nodeFabNetAtt.Spec.NetworkRef.Namespace + "-" + nodeFabNetAtt.Spec.NetworkRef.Name
+	labelKey := cont.aciNameForKey("nfna", nodeFabNetAttKey)
+	cont.apicConn.WriteApicObjects(labelKey, cont.updateNodeFabNetAttObj(nodeFabNetAtt))
+
+	return false
+}
+
+func (cont *AciController) handleNodeFabricNetworkAttachmentDelete(key string) bool {
+
+	cont.deleteNodeFabNetAttObj(key)
+
+	return false
+}

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -292,6 +292,9 @@ func (cont *AciController) getTunnelID(node *v1.Node) int64 {
 }
 
 func (cont *AciController) writeApicNode(node *v1.Node) {
+	if cont.config.ChainedMode {
+		return
+	}
 	tunnelID := cont.getTunnelID(node)
 	//cont.log.Infof("=>  Node: %s, tunnelID: %v", node.Name, tunnelID)
 	key := cont.aciNameForKey("node-vmm", node.Name)
@@ -330,6 +333,9 @@ func (cont *AciController) nodeChangedByName(nodeName string) {
 }
 
 func (cont *AciController) nodeChanged(obj interface{}) {
+	if cont.config.ChainedMode {
+		return
+	}
 	cont.indexMutex.Lock()
 
 	node := obj.(*v1.Node)
@@ -434,6 +440,9 @@ func (cont *AciController) nodeChanged(obj interface{}) {
 }
 
 func (cont *AciController) nodeDeleted(obj interface{}) {
+	if cont.config.ChainedMode {
+		return
+	}
 	node, isNode := obj.(*v1.Node)
 	if !isNode {
 		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -157,6 +157,10 @@ func (cont *AciController) handlePodUpdate(pod *v1.Pod) bool {
 	if !podFilter(pod) {
 		return false
 	}
+	if cont.config.ChainedMode {
+		return false
+	}
+
 	logger := podLogger(cont.log, pod)
 
 	podkey, err := cache.MetaNamespaceKeyFunc(pod)
@@ -177,6 +181,9 @@ func (cont *AciController) handlePodUpdate(pod *v1.Pod) bool {
 }
 
 func (cont *AciController) writeApicPod(pod *v1.Pod) {
+	if cont.config.ChainedMode {
+		return
+	}
 	podkey, err := cache.MetaNamespaceKeyFunc(pod)
 	if err != nil {
 		podLogger(cont.log, pod).Error("Could not create pod key: ", err)

--- a/pkg/controller/replicasets.go
+++ b/pkg/controller/replicasets.go
@@ -64,6 +64,9 @@ func replicaSetLogger(log *logrus.Logger, rs *appsv1.ReplicaSet) *logrus.Entry {
 }
 
 func (cont *AciController) writeApicRs(rs *appsv1.ReplicaSet) {
+	if cont.config.ChainedMode {
+		return
+	}
 	rskey, err :=
 		cache.MetaNamespaceKeyFunc(rs)
 	if err != nil {

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1257,6 +1257,9 @@ func (cont *AciController) opflexDeviceDeleted(dn string) {
 }
 
 func (cont *AciController) writeApicSvc(key string, service *v1.Service) {
+	if cont.config.ChainedMode {
+		return
+	}
 	aobj := apicapi.NewVmmInjectedSvc(cont.vmmDomainProvider(),
 		cont.config.AciVmmDomain, cont.config.AciVmmController,
 		service.Namespace, service.Name)


### PR DESCRIPTION
In chained mode, controller watches for nodefabricnetworkattachment CRs to provision APIC with corresponding epg with name <namespace>-<netattdefname>. Static path attachment to corresponding fabriclinks is applied. If fabriclink corresponds to a PC/VPC, corresponding path is pushed instead of the actual link.

TODO: cleanup VMM modedata and reconciliation