### PR TITLE
Fix check for deleted endpoint slice

### DIFF
--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1848,7 +1848,7 @@ func (cont *AciController) isDeleteEndpointSlice(oldendpointslice, newendpointsl
 	del := false
 
 	// if any endpoint is removed from endpontslice
-	if len(newendpointslice.Endpoints) < len(newendpointslice.Endpoints) {
+	if len(newendpointslice.Endpoints) < len(oldendpointslice.Endpoints) {
 		del = true
 	}
 


### PR DESCRIPTION
I'm not sure if there's a functional issue here but the linter pointed out the existing check is useless

@akhilamohanan please take a look. Another option would to just remove the check if it's not needed and the case is handled elsewhere