### PR TITLE
Handling delete service by adding in queue

### DIFF
--- a/pkg/controller/erspan.go
+++ b/pkg/controller/erspan.go
@@ -58,7 +58,7 @@ func erspanInit(cont *AciController, stopCh <-chan struct{}) {
 	go cont.processQueue(cont.erspanQueue, cont.erspanIndexer,
 		func(obj interface{}) bool {
 			return cont.handleErspanUpdate(obj.(*erspanpolicy.ErspanPolicy))
-		}, nil, stopCh)
+		}, nil, nil, stopCh)
 	cache.WaitForCacheSync(stopCh, cont.erspanInformer.HasSynced)
 	cont.erspanSyncOpflexDev()
 }

--- a/pkg/controller/netflow.go
+++ b/pkg/controller/netflow.go
@@ -53,7 +53,7 @@ func netflowInit(cont *AciController, stopCh <-chan struct{}) {
 	go cont.processQueue(cont.netflowQueue, cont.netflowIndexer,
 		func(obj interface{}) bool {
 			return cont.handleNetflowPolUpdate(obj)
-		}, nil, stopCh)
+		}, nil, nil, stopCh)
 	cache.WaitForCacheSync(stopCh, cont.netflowInformer.HasSynced)
 }
 

--- a/pkg/controller/qos.go
+++ b/pkg/controller/qos.go
@@ -50,7 +50,7 @@ func qosInit(cont *AciController, stopCh <-chan struct{}) {
 	go cont.processQueue(cont.qosQueue, cont.qosIndexer,
 		func(obj interface{}) bool {
 			return cont.handleQosPolUpdate(obj)
-		}, nil, stopCh)
+		}, nil, nil, stopCh)
 	cache.WaitForCacheSync(stopCh, cont.qosInformer.HasSynced)
 }
 

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -102,12 +102,14 @@ func TestServiceIpV6(t *testing.T) {
 	{
 		cont.serviceUpdates = nil
 		cont.serviceDeleted(v6service("testns", "service2", "2002::1"))
+		cont.handleServiceDelete("testns/service2")
 		assert.True(t, ipam.HasIp(cont.staticServiceIps.V6, net.ParseIP("2002::1")),
 			"delete static return")
 	}
 	{
 		cont.serviceUpdates = nil
 		cont.serviceDeleted(v6service("testns", "service5", ""))
+		cont.handleServiceDelete("testns/service5")
 		assert.True(t, ipam.HasIp(cont.serviceIps.GetV6IpCache()[1], net.ParseIP("2001::32")),
 			"delete pool return")
 	}
@@ -172,12 +174,14 @@ func TestServiceIp(t *testing.T) {
 	{
 		cont.serviceUpdates = nil
 		cont.serviceDeleted(service("testns", "service1", "10.4.2.2"))
+		cont.handleServiceDelete("testns/service1")
 		assert.True(t, ipam.HasIp(cont.staticServiceIps.V4, net.ParseIP("10.4.2.2")),
 			"delete static return")
 	}
 	{
 		cont.serviceUpdates = nil
 		cont.serviceDeleted(service("testns", "service5", ""))
+		cont.handleServiceDelete("testns/service5")
 		assert.True(t, ipam.HasIp(cont.serviceIps.GetV4IpCache()[1], net.ParseIP("10.4.1.32")),
 			"delete pool return")
 	}


### PR DESCRIPTION
Sometimes preparing the apic object and updating cache was happening for delete ahead of update. This was because handling of delete was done immediately and that of update was done by adding in queue.

Modified code to process the delete also in queue.

(cherry picked from commit 3b87c4781bf0b2e846d3c0ba8f649df4ea6b1a93)