### PR TITLE
Fail pod creation if adjacency is missing

### DIFF
--- a/pkg/hostagent/fabricdiscovery.go
+++ b/pkg/hostagent/fabricdiscovery.go
@@ -15,6 +15,7 @@ type FabricAttachmentData struct {
 type FabricDiscoveryAgent interface {
 	Init(agent *HostAgent) error
 	CollectDiscoveryData(stopCh <-chan struct{})
+	TriggerCollectionDiscoveryData()
 	GetNeighborData(iface string) ([]*FabricAttachmentData, error)
 }
 

--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -556,6 +556,21 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 				if err != nil {
 					errorMsg := fmt.Sprintf("Could not create Pod Fabric Attachment: %v", err)
 					agent.indexMutex.Unlock()
+
+					logger.Infof("Forcing refresh of LLDP data for iface %s", metadata.Network.PFName)
+					for i := 0; i < 3; i++ {
+						agent.fabricDiscoveryAgent.TriggerCollectionDiscoveryData()
+						if fabAttData, err2 := agent.fabricDiscoveryAgent.GetNeighborData(metadata.Network.PFName); err2 == nil {
+							if fabAttData != nil {
+								for _, nbr := range fabAttData {
+									if nbr.StaticPath != "" {
+										return result, nil
+									}
+								}
+
+							}
+						}
+					}
 					return result, errors.New(errorMsg)
 				}
 			} else {


### PR DESCRIPTION
On Pod create, host-agent checks for LLDP fabric
adjacency on the pod physical interface. If it is
missing, it will trigger LLDP collection three times before giving up and pod creation will fail.