### PR TITLE
Fix controller crash on nfna delete

### DIFF
--- a/pkg/apicapi/apic_sync.go
+++ b/pkg/apicapi/apic_sync.go
@@ -142,9 +142,16 @@ func (conn *ApicConnection) apicObjCmp(current ApicObject,
 			for i < len(bodyc.Children) {
 				deletable := true
 				for class := range bodyc.Children[i] {
-					if metadata[class].hints != nil && !metadata[class].hints["deletable"].(bool) {
-						deletable = false
-						break
+					if _, ok := metadata[class]; ok {
+						if metadata[class].hints != nil {
+							if val, ok := metadata[class].hints["deletable"]; ok {
+								deletableValue, ok := val.(bool)
+								if ok && deletableValue == false {
+									deletable = false
+									break
+								}
+							}
+						}
 					}
 				}
 				if !deletable {

--- a/pkg/controller/nodefabricnetworkattachments.go
+++ b/pkg/controller/nodefabricnetworkattachments.go
@@ -261,11 +261,9 @@ func (cont *AciController) nodeFabNetAttDeleted(obj interface{}) {
 			return
 		}
 	}
-	key, err := cache.MetaNamespaceKeyFunc(nodeFabNetAtt)
-	if err != nil {
-		return
-	}
-	cont.queueNodeFabNetAttByKey("DELETED_" + nodeFabNetAtt.Spec.NodeName + "_" + key)
+
+	addNetKey := nodeFabNetAtt.Spec.NetworkRef.Namespace + "/" + nodeFabNetAtt.Spec.NetworkRef.Name
+	cont.queueNodeFabNetAttByKey("DELETED_" + nodeFabNetAtt.Spec.NodeName + "_" + addNetKey)
 }
 
 func (cont *AciController) deleteNodeFabNetAttObj(key string) bool {

--- a/pkg/hostagent/netattachdef.go
+++ b/pkg/hostagent/netattachdef.go
@@ -210,7 +210,7 @@ func (agent *HostAgent) LoadAdditionalNetworkMetadata() error {
 		dir := filepath.Join(agent.config.CniMetadataDir, fabNetAttName)
 		files, err := ioutil.ReadDir(dir)
 		if err != nil {
-			agent.log.Infof("Failed to read podnetmeta for %s: %v", fabNetAttName, err)
+			agent.log.Infof("No local pods for %s: %v", fabNetAttName, err)
 			continue
 		}
 		for _, file := range files {
@@ -408,7 +408,7 @@ func (agent *HostAgent) updateFabricPodNetworkAttachmentLocked(pod *fabattv1.Pod
 			}
 		}
 	}
-	if !adjFound {
+	if !adjFound && !podDeleted {
 		err = fmt.Errorf("LLDP adjacency with ACI fabric not found on interface %v", podIface)
 	}
 	return err


### PR DESCRIPTION
Fix key used for nfna delete
Add null check before accessing metadata in sync path 
Additional cleanup some logs in delete path for host-agent