### PR TITLE
Continue addressing linter complaints

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,12 +25,18 @@ linters-settings:
       - performance
       - style
     disabled-checks:
+      - appendCombine
       - commentFormatting
       - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - emptyStringTest
+      - equalFold
       - ifElseChain
+      - importShadow
       - nestingReduce
       - octalLiteral
+      - sloppyReassign
       - unnamedResult
+      - unnecessaryBlock
       - whyNoLint
       - wrapperFunc
   gocyclo:

--- a/cmd/acicontainersoperator/main.go
+++ b/cmd/acicontainersoperator/main.go
@@ -15,15 +15,17 @@
 package main
 
 import (
-	accprovisioninputclientset "github.com/noironetworks/aci-containers/pkg/accprovisioninput/clientset/versioned"
-	operatorclientset "github.com/noironetworks/aci-containers/pkg/acicontainersoperator/clientset/versioned"
-	"github.com/noironetworks/aci-containers/pkg/controller"
-	log "github.com/sirupsen/logrus"
-	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
 	"os"
 	"os/signal"
 	"syscall"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+
+	accprovisioninputclientset "github.com/noironetworks/aci-containers/pkg/accprovisioninput/clientset/versioned"
+	operatorclientset "github.com/noironetworks/aci-containers/pkg/acicontainersoperator/clientset/versioned"
+	"github.com/noironetworks/aci-containers/pkg/controller"
 )
 
 // Create Aci Operator Client

--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -516,33 +516,33 @@ func clusterReport(cmd *cobra.Command, args []string) {
 	}
 
 	nodePodMap := make(map[string]string)
-	for _, node := range nodes.Items {
-		for _, nodeItem := range nodeItems {
-			key := node.Name + ";" + nodeItem.selector
+	for ix := range nodes.Items {
+		for ix := range nodeItems {
+			key := nodes.Items[ix].Name + ";" + nodeItems[ix].selector
 			podName, cached := nodePodMap[key]
 			if !cached {
 				podName, err = podForNode(kubeClient, systemNamespace,
-					node.Name, nodeItem.selector)
+					nodes.Items[ix].Name, nodeItems[ix].selector)
 				if err != nil {
 					fmt.Fprintln(os.Stderr, err)
 					continue
 				}
 			}
 			// Prepare kubectl cp command for opflex-agent-ovs
-			tempName := fmt.Sprintf("hostfiles/node-%s/opflex-agent-ovs/", node.Name)
+			tempName := fmt.Sprintf("hostfiles/node-%s/opflex-agent-ovs/", nodes.Items[ix].Name)
 			cmds = append(cmds, reportCmdElem{
 				name: tempName,
 				args: []string{"cp", systemNamespace + "/" + podName + ":" +
 					"/usr/local/var/lib/opflex-agent-ovs", tempName},
 				skipOutputFile: true,
 			}, reportCmdElem{
-				name: fmt.Sprintf(nodeItem.path, node.Name),
-				args: nodeItem.argFunc(systemNamespace, podName,
-					nodeItem.cont, nodeItem.args),
+				name: fmt.Sprintf(nodeItems[ix].path, nodes.Items[ix].Name),
+				args: nodeItems[ix].argFunc(systemNamespace, podName,
+					nodeItems[ix].cont, nodeItems[ix].args),
 			})
 
 			//Prepare kubectl cp command for aci-conatiners-host
-			tempName = fmt.Sprintf("hostfiles/node-%s/aci-containers/k8s-pod-network/", node.Name)
+			tempName = fmt.Sprintf("hostfiles/node-%s/aci-containers/k8s-pod-network/", nodes.Items[ix].Name)
 			cmds = append(cmds, reportCmdElem{
 				name: tempName,
 				args: []string{"cp", systemNamespace + "/" + podName + ":" +
@@ -551,7 +551,7 @@ func clusterReport(cmd *cobra.Command, args []string) {
 			})
 		}
 		//Prepare kubectl exec command for aci-conatiners-host version
-		tempName := fmt.Sprintf("cluster-report/logs/node-%s/aci-containers-host-version.log", node.Name)
+		tempName := fmt.Sprintf("cluster-report/logs/node-%s/aci-containers-host-version.log", nodes.Items[ix].Name)
 		cmds = append(cmds, reportCmdElem{
 			name: tempName,
 			args: aciContainerHostVersionCmdArgs(systemNamespace),
@@ -688,8 +688,8 @@ func findSystemNamespace(kubeClient kubernetes.Interface) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for _, namespace := range namespaces.Items {
-		return namespace.Name, nil
+	for ix := range namespaces.Items {
+		return namespaces.Items[ix].Name, nil
 	}
 	return "kube-system", nil
 }
@@ -704,9 +704,9 @@ func podForNode(kubeClient kubernetes.Interface,
 	if err != nil {
 		return "", err
 	}
-	for _, pod := range pods.Items {
-		if pod.Spec.NodeName == node {
-			return pod.Name, nil
+	for ix := range pods.Items {
+		if pods.Items[ix].Spec.NodeName == node {
+			return pods.Items[ix].Name, nil
 		}
 	}
 	return "", errors.New("Could not find pod on node: " + node)

--- a/cmd/acikubectl/cmd/version.go
+++ b/cmd/acikubectl/cmd/version.go
@@ -52,10 +52,10 @@ func getVersion(cmd *cobra.Command, args []string) {
 	if err1 != nil {
 		fmt.Fprintln(os.Stderr, "Could not list pods:", err1)
 	}
-	for _, pod := range systemNamespacePods.Items {
-		if strings.Contains(pod.Name, "aci-containers-controller") {
+	for ix := range systemNamespacePods.Items {
+		if strings.Contains(systemNamespacePods.Items[ix].Name, "aci-containers-controller") {
 			buffer := new(bytes.Buffer)
-			mylist := []string{"exec", "-c" + "aci-containers-controller", "-n" + systemNamespace, pod.Name,
+			mylist := []string{"exec", "-c" + "aci-containers-controller", "-n" + systemNamespace, systemNamespacePods.Items[ix].Name,
 				"--", "/bin/sh", "-c", "aci-containers-controller -version"}
 			execKubectl(mylist, buffer)
 			trimString := strings.TrimSpace(buffer.String())

--- a/cmd/hostagent/main.go
+++ b/cmd/hostagent/main.go
@@ -177,8 +177,8 @@ func getNodeIP() (string, error) {
 		return "", fmt.Errorf("Error listing nodes: %w", err)
 	}
 
-	for _, node := range nodeList.Items {
-		for _, a := range node.Status.Addresses {
+	for ix := range nodeList.Items {
+		for _, a := range nodeList.Items[ix].Status.Addresses {
 			if a.Type == v1.NodeInternalIP {
 				return a.Address, nil
 			}

--- a/docker/gbp_update.sh
+++ b/docker/gbp_update.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-DST=/usr/local/var/lib/opflex-server/policy.json
-POD=$(kubectl get pods -n kube-system --field-selector status.podIP=$1 -l name=aci-containers-host -o custom-columns=":metadata.name" | grep aci)
-kubectl cp /tmp/gen_policy.$1.json kube-system/$POD:$DST -c opflex-server

--- a/pkg/apicapi/apicapi_test.go
+++ b/pkg/apicapi/apicapi_test.go
@@ -889,13 +889,13 @@ func TestReconcile(t *testing.T) {
 		}
 
 		for _, deleteDn := range test.deletes {
-			delete := test.deleteBody[deleteDn]
-			for _, d := range delete {
+			deleteMo := test.deleteBody[deleteDn]
+			for _, d := range deleteMo {
 				d.SetAttr("status", "deleted")
 			}
 			data := map[string]interface{}{
 				"subscriptionId": []string{"42"},
-				"imdata":         delete,
+				"imdata":         deleteMo,
 			}
 			server.sh.socketConn.WriteJSON(data)
 		}

--- a/pkg/controller/acicontainersoperator.go
+++ b/pkg/controller/acicontainersoperator.go
@@ -1185,11 +1185,11 @@ func (c *Controller) updatednsOperator() error {
 	log.Info("NodeAddress: ", nodeAddress)
 	// compute the dns servers info
 	var servers []operatorv1.Server
-	for _, route := range routes.Items {
+	for ix := range routes.Items {
 		var server operatorv1.Server
-		key := route.ObjectMeta.Namespace + "/" + route.ObjectMeta.Name
+		key := routes.Items[ix].ObjectMeta.Namespace + "/" + routes.Items[ix].ObjectMeta.Name
 		server.Name = key
-		server.Zones = append(server.Zones, route.Spec.Host)
+		server.Zones = append(server.Zones, routes.Items[ix].Spec.Host)
 		server.ForwardPlugin.Upstreams = nodeAddress
 		servers = append(servers, server)
 	}
@@ -1202,8 +1202,8 @@ func (c *Controller) updatednsOperator() error {
 		}
 	}
 	c.indexMutex.Lock()
-	for _, route := range routes.Items {
-		key := route.ObjectMeta.Namespace + "/" + route.ObjectMeta.Name
+	for ix := range routes.Items {
+		key := routes.Items[ix].ObjectMeta.Namespace + "/" + routes.Items[ix].ObjectMeta.Name
 		log.Infof("Route added to cache: %s", key)
 		c.routes[key] = true
 	}
@@ -1220,14 +1220,14 @@ func (c *Controller) getNodeOS() (string, error) {
 		log.Info("Failed to List the nodes: ", err)
 		return osImage, err
 	}
-	for _, node := range nodelist.Items {
-		if node.DeletionTimestamp != nil {
+	for ix := range nodelist.Items {
+		if nodelist.Items[ix].DeletionTimestamp != nil {
 			continue
 		}
-		if _, ok := node.ObjectMeta.Labels["node-role.kubernetes.io/master"]; ok {
+		if _, ok := nodelist.Items[ix].ObjectMeta.Labels["node-role.kubernetes.io/master"]; ok {
 			continue
 		}
-		osImage = node.Status.NodeInfo.OSImage
+		osImage = nodelist.Items[ix].Status.NodeInfo.OSImage
 		break
 	}
 	return osImage, nil
@@ -1241,14 +1241,14 @@ func (c *Controller) getNodeAddress() ([]string, error) {
 		return []string{}, err
 	}
 	var nodeAddress []string
-	for _, node := range nodelist.Items {
-		if node.DeletionTimestamp != nil {
+	for ix := range nodelist.Items {
+		if nodelist.Items[ix].DeletionTimestamp != nil {
 			continue
 		}
-		if _, ok := node.ObjectMeta.Labels["node-role.kubernetes.io/master"]; ok {
+		if _, ok := nodelist.Items[ix].ObjectMeta.Labels["node-role.kubernetes.io/master"]; ok {
 			continue
 		}
-		address := node.Status.Addresses
+		address := nodelist.Items[ix].Status.Addresses
 		for _, val := range address {
 			if val.Type == v1.NodeInternalIP {
 				nodeAddress = append(nodeAddress, val.Address)

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -59,7 +59,6 @@ type testAciController struct {
 }
 
 func (cont *testAciController) InitController() {
-
 	cont.env.(*K8sEnvironment).cont = &cont.AciController
 	cont.serviceEndPoints = &serviceEndpoint{}
 	cont.serviceEndPoints.(*serviceEndpoint).cont = &cont.AciController

--- a/pkg/controller/deployments.go
+++ b/pkg/controller/deployments.go
@@ -22,8 +22,6 @@ import (
 	"strconv"
 
 	"github.com/sirupsen/logrus"
-
-	"github.com/noironetworks/aci-containers/pkg/metadata"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +31,7 @@ import (
 
 	"github.com/noironetworks/aci-containers/pkg/apicapi"
 	"github.com/noironetworks/aci-containers/pkg/index"
+	"github.com/noironetworks/aci-containers/pkg/metadata"
 )
 
 func (cont *AciController) initDeploymentInformerFromClient(

--- a/pkg/controller/epgcache.go
+++ b/pkg/controller/epgcache.go
@@ -103,7 +103,6 @@ func (cont *AciController) checkEpgCache(epGroup, comment string) (bool, metadat
 	}
 
 	if len(egval.Name) != 0 {
-
 		if len(cont.cachedEpgDns) != 0 {
 			if egval.Tenant != "" && egval.AppProfile != "" {
 				dn := fmt.Sprintf("uni/tn-%s/ap-%s/epg-%s", egval.Tenant, egval.AppProfile, egval.Name)

--- a/pkg/controller/erspan_test.go
+++ b/pkg/controller/erspan_test.go
@@ -99,7 +99,6 @@ func buildSpanObjs(name string, dstIP string, flowID int, adminSt string,
 func checkDeleteErspan(t *testing.T, spanTest erspanTest, cont *testAciController) {
 	tu.WaitFor(t, "delete", 500*time.Millisecond,
 		func(last bool) (bool, error) {
-			//span := spanTests[0]
 			key := cont.aciNameForKey("span",
 				spanTest.erspanPol.Namespace+"_"+spanTest.erspanPol.Name)
 			if !tu.WaitEqual(t, last, 0,

--- a/pkg/controller/netflow_test.go
+++ b/pkg/controller/netflow_test.go
@@ -63,7 +63,6 @@ func makeNf(name string, dstAddr string, dstPort int,
 func checkDeleteNf(t *testing.T, nt nfTest, cont *testAciController) {
 	tu.WaitFor(t, "delete", 500*time.Millisecond,
 		func(last bool) (bool, error) {
-			//nf := nfTests[0]
 			key := cont.aciNameForKey("nf", nt.netflowPol.Name)
 			if !tu.WaitEqual(t, last, 0,
 				len(cont.apicConn.GetDesiredState(key)), "delete") {

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -172,15 +172,10 @@ func addPods(cont *testAciController, incIps bool, ips []string, ipv4 bool) {
 			podLabel("testnsv6", "pod2", map[string]string{"l1": "v2"}),
 		}
 	}
-	pods = append(pods, podLabel("ns1", "pod3", map[string]string{"l1": "v1"}))
-	pods = append(pods, podLabel("ns1", "pod4", map[string]string{"l1": "v2"}))
-	pods = append(pods, podLabel("ns2", "pod5", map[string]string{"l1": "v1"}))
-	pods = append(pods, podLabel("ns2", "pod6", map[string]string{"l1": "v2"}))
-	/*
-		ips := []string{
-			"1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4", "1.1.1.5", "",
-		}
-	*/
+	pods = append(pods, podLabel("ns1", "pod3", map[string]string{"l1": "v1"}),
+		podLabel("ns1", "pod4", map[string]string{"l1": "v2"}),
+		podLabel("ns2", "pod5", map[string]string{"l1": "v1"}),
+		podLabel("ns2", "pod6", map[string]string{"l1": "v2"}))
 	if incIps {
 		for i := range pods {
 			pods[i].Status.PodIP = ips[i]
@@ -281,7 +276,6 @@ func checkNp(t *testing.T, nt *npTest, category string, cont *testAciController)
 func checkDelete(t *testing.T, nt npTest, cont *testAciController) {
 	tu.WaitFor(t, "delete", 500*time.Millisecond,
 		func(last bool) (bool, error) {
-			//nt := npTests[0]
 			key := cont.aciNameForKey("np",
 				nt.netPol.Namespace+"_"+nt.netPol.Name)
 			if !tu.WaitEqual(t, last, 0,
@@ -924,29 +918,29 @@ func TestNetworkPolicy(t *testing.T) {
 	ips := []string{
 		"1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4", "1.1.1.5", "",
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting podsfirst ", nt.desc)
+		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
 		addPods(cont, true, ips, true)
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		cont.run()
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
-		checkNp(t, &nt, "podsfirst", cont)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
+		checkNp(t, &npTests[ix], "podsfirst", cont)
 
-		cont.log.Info("Starting delete ", nt.desc)
-		cont.fakeNetworkPolicySource.Delete(nt.netPol)
+		cont.log.Info("Starting delete ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Delete(npTests[ix].netPol)
 		checkDelete(t, npTests[0], cont)
 		cont.stop()
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting npfirst ", nt.desc)
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
+		cont.log.Info("Starting npfirst ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		addPods(cont, false, ips, true)
 		addPods(cont, true, ips, true)
-		checkNp(t, &nt, "npfirst", cont)
+		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
 }
@@ -1607,29 +1601,29 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 	ips := []string{
 		"1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4", "1.1.1.5", "",
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting podsfirst ", nt.desc)
+		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
 		addPods(cont, true, ips, true)
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		cont.run()
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
-		checkNp(t, &nt, "podsfirst", cont)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
+		checkNp(t, &npTests[ix], "podsfirst", cont)
 
-		cont.log.Info("Starting delete ", nt.desc)
-		cont.fakeNetworkPolicySource.Delete(nt.netPol)
+		cont.log.Info("Starting delete ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Delete(npTests[ix].netPol)
 		checkDelete(t, npTests[0], cont)
 		cont.stop()
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting npfirst ", nt.desc)
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
+		cont.log.Info("Starting npfirst ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		addPods(cont, false, ips, true)
 		addPods(cont, true, ips, true)
-		checkNp(t, &nt, "npfirst", cont)
+		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
 }
@@ -2186,30 +2180,30 @@ func TestNetworkPolicyv6(t *testing.T) {
 	ips := []string{
 		"2001::2", "2001::3", "2001::4", "2001::5", "2001::6", "",
 	}
-	for _, nt := range np6Tests {
+	for ix := range np6Tests {
 		cont := initCont()
-		cont.log.Info("Starting podsfirst ", nt.desc)
+		cont.log.Info("Starting podsfirst ", np6Tests[ix].desc)
 		addPods(cont, true, ips, false)
-		addServices(cont, nt.augment)
+		addServices(cont, np6Tests[ix].augment)
 		cont.run()
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
-		checkNp(t, &nt, "podsfirst", cont)
+		cont.fakeNetworkPolicySource.Add(np6Tests[ix].netPol)
+		checkNp(t, &np6Tests[ix], "podsfirst", cont)
 
-		cont.log.Info("Starting delete ", nt.desc)
-		cont.fakeNetworkPolicySource.Delete(nt.netPol)
+		cont.log.Info("Starting delete ", np6Tests[ix].desc)
+		cont.fakeNetworkPolicySource.Delete(np6Tests[ix].netPol)
 		checkDelete(t, np6Tests[0], cont)
 		cont.stop()
 	}
 
-	for _, nt := range np6Tests {
+	for ix := range np6Tests {
 		cont := initCont()
-		cont.log.Info("Starting npfirst ", nt.desc)
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
+		cont.log.Info("Starting npfirst ", np6Tests[ix].desc)
+		cont.fakeNetworkPolicySource.Add(np6Tests[ix].netPol)
 		cont.run()
-		addServices(cont, nt.augment)
+		addServices(cont, np6Tests[ix].augment)
 		addPods(cont, false, ips, false)
 		addPods(cont, true, ips, false)
-		checkNp(t, &nt, "npfirst", cont)
+		checkNp(t, &np6Tests[ix], "npfirst", cont)
 		cont.stop()
 	}
 }
@@ -2754,30 +2748,30 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 	ips := []string{
 		"2001::2", "2001::3", "2001::4", "2001::5", "2001::6", "",
 	}
-	for _, nt := range np6Tests {
+	for ix := range np6Tests {
 		cont := initCont()
-		cont.log.Info("Starting podsfirst ", nt.desc)
+		cont.log.Info("Starting podsfirst ", np6Tests[ix].desc)
 		addPods(cont, true, ips, false)
-		addServices(cont, nt.augment)
+		addServices(cont, np6Tests[ix].augment)
 		cont.run()
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
-		checkNp(t, &nt, "podsfirst", cont)
+		cont.fakeNetworkPolicySource.Add(np6Tests[ix].netPol)
+		checkNp(t, &np6Tests[ix], "podsfirst", cont)
 
-		cont.log.Info("Starting delete ", nt.desc)
-		cont.fakeNetworkPolicySource.Delete(nt.netPol)
+		cont.log.Info("Starting delete ", np6Tests[ix].desc)
+		cont.fakeNetworkPolicySource.Delete(np6Tests[ix].netPol)
 		checkDelete(t, np6Tests[0], cont)
 		cont.stop()
 	}
 
-	for _, nt := range np6Tests {
+	for ix := range np6Tests {
 		cont := initCont()
-		cont.log.Info("Starting npfirst ", nt.desc)
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
+		cont.log.Info("Starting npfirst ", np6Tests[ix].desc)
+		cont.fakeNetworkPolicySource.Add(np6Tests[ix].netPol)
 		cont.run()
-		addServices(cont, nt.augment)
+		addServices(cont, np6Tests[ix].augment)
 		addPods(cont, false, ips, false)
 		addPods(cont, true, ips, false)
-		checkNp(t, &nt, "npfirst", cont)
+		checkNp(t, &np6Tests[ix], "npfirst", cont)
 		cont.stop()
 	}
 }
@@ -3207,29 +3201,29 @@ func TestNetworkPolicyWithEndPointSlice(t *testing.T) {
 	ips := []string{
 		"1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4", "1.1.1.5", "",
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting podsfirst ", nt.desc)
+		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
 		addPods(cont, true, ips, true)
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		cont.run()
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
-		checkNp(t, &nt, "podsfirst", cont)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
+		checkNp(t, &npTests[ix], "podsfirst", cont)
 
-		cont.log.Info("Starting delete ", nt.desc)
-		cont.fakeNetworkPolicySource.Delete(nt.netPol)
+		cont.log.Info("Starting delete ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Delete(npTests[ix].netPol)
 		checkDelete(t, npTests[0], cont)
 		cont.stop()
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting npfirst ", nt.desc)
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
+		cont.log.Info("Starting npfirst ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		addPods(cont, false, ips, true)
 		addPods(cont, true, ips, true)
-		checkNp(t, &nt, "npfirst", cont)
+		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
 }
@@ -3631,29 +3625,29 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 	ips := []string{
 		"1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4", "1.1.1.5", "",
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting podsfirst ", nt.desc)
+		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
 		addPods(cont, true, ips, true)
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		cont.run()
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
-		checkNp(t, &nt, "podsfirst", cont)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
+		checkNp(t, &npTests[ix], "podsfirst", cont)
 
-		cont.log.Info("Starting delete ", nt.desc)
-		cont.fakeNetworkPolicySource.Delete(nt.netPol)
+		cont.log.Info("Starting delete ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Delete(npTests[ix].netPol)
 		checkDelete(t, npTests[0], cont)
 		cont.stop()
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting npfirst ", nt.desc)
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
+		cont.log.Info("Starting npfirst ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		addPods(cont, false, ips, true)
 		addPods(cont, true, ips, true)
-		checkNp(t, &nt, "npfirst", cont)
+		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
 }
@@ -3793,29 +3787,29 @@ func TestNetworkPolicyEgressNmPort(t *testing.T) {
 		}
 		cont.fakePodSource.Add(pod)
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting podsfirst ", nt.desc)
+		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
 		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
 		addPod(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1)
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		cont.run()
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
-		checkNp(t, &nt, "podsfirst", cont)
-		cont.log.Info("Starting delete ", nt.desc)
-		cont.fakeNetworkPolicySource.Delete(nt.netPol)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
+		checkNp(t, &npTests[ix], "podsfirst", cont)
+		cont.log.Info("Starting delete ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Delete(npTests[ix].netPol)
 		checkDelete(t, npTests[0], cont)
 		cont.stop()
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting npfirst ", nt.desc)
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
+		cont.log.Info("Starting npfirst ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
 		addPod(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1)
-		checkNp(t, &nt, "npfirst", cont)
+		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
 }
@@ -3948,29 +3942,29 @@ func TestNetworkPolicyEgressNmPortHppOptimize(t *testing.T) {
 		}
 		cont.fakePodSource.Add(pod)
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting podsfirst ", nt.desc)
+		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
 		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
 		addPod(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1)
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		cont.run()
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
-		checkNp(t, &nt, "podsfirst", cont)
-		cont.log.Info("Starting delete ", nt.desc)
-		cont.fakeNetworkPolicySource.Delete(nt.netPol)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
+		checkNp(t, &npTests[ix], "podsfirst", cont)
+		cont.log.Info("Starting delete ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Delete(npTests[ix].netPol)
 		checkDelete(t, npTests[0], cont)
 		cont.stop()
 	}
-	for _, nt := range npTests {
+	for ix := range npTests {
 		cont := initCont()
-		cont.log.Info("Starting npfirst ", nt.desc)
-		cont.fakeNetworkPolicySource.Add(nt.netPol)
+		cont.log.Info("Starting npfirst ", npTests[ix].desc)
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, nt.augment)
+		addServices(cont, npTests[ix].augment)
 		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
 		addPod(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1)
-		checkNp(t, &nt, "npfirst", cont)
+		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
 }

--- a/pkg/controller/nodefabricnetworkattachments_test.go
+++ b/pkg/controller/nodefabricnetworkattachments_test.go
@@ -88,7 +88,6 @@ func CreateNFNAEPG(nfna *fabattv1.NodeFabricNetworkAttachment, vlan int) apicapi
 	fvRsDomAtt := apicapi.NewFvRsDomAttPhysDom(epg.GetDn(), "second-physdom")
 	epg.AddChild(fvRsDomAtt)
 	return epg
-
 }
 
 func TestNFNACRUD(t *testing.T) {

--- a/pkg/controller/nodepodif.go
+++ b/pkg/controller/nodepodif.go
@@ -70,17 +70,17 @@ func (cont *AciController) initNodePodIfInformerBase(listWatch *cache.ListWatch)
 	cont.log.Debug("Initializing nodepodif Informers")
 }
 
-func getPodifKey(podif nodePodIf.PodIF) string {
+func getPodifKey(podif *nodePodIf.PodIF) string {
 	return podif.PodNS + "/" + podif.PodName
 }
 
-func getPodifEPG(podif nodePodIf.PodIF) string {
+func getPodifEPG(podif *nodePodIf.PodIF) string {
 	deconcatenate := strings.Split(podif.EPG, "|")
 	deconEPG := deconcatenate[len(deconcatenate)-1]
 	return deconEPG
 }
 
-func getPodifAppProfile(podif nodePodIf.PodIF) string {
+func getPodifAppProfile(podif *nodePodIf.PodIF) string {
 	deconcatenate := strings.Split(podif.EPG, "|")
 	deconAppProfile := deconcatenate[0]
 	return deconAppProfile
@@ -95,15 +95,15 @@ func (cont *AciController) nodePodIFAdded(obj interface{}) {
 	cont.log.Infof("nodepodif Added: %s", np.ObjectMeta.Name)
 	podifs := np.Spec.PodIFs
 
-	for _, podif := range podifs {
+	for ix := range podifs {
 		cont.indexMutex.Lock()
 		podifdata := &EndPointData{
-			MacAddr:    podif.MacAddr,
-			EPG:        getPodifEPG(podif),
-			Namespace:  podif.PodNS,
-			AppProfile: getPodifAppProfile(podif),
+			MacAddr:    podifs[ix].MacAddr,
+			EPG:        getPodifEPG(&podifs[ix]),
+			Namespace:  podifs[ix].PodNS,
+			AppProfile: getPodifAppProfile(&podifs[ix]),
 		}
-		podifKey := getPodifKey(podif)
+		podifKey := getPodifKey(&podifs[ix])
 		cont.podIftoEp[podifKey] = podifdata
 		cont.indexMutex.Unlock()
 	}
@@ -115,15 +115,15 @@ func (cont *AciController) nodePodIFUpdated(oldobj, newobj interface{}) {
 	cont.log.Infof("nodepodif updated: %s", oldnp.ObjectMeta.Name)
 	if !reflect.DeepEqual(oldnp.Spec.PodIFs, newnp.Spec.PodIFs) {
 		podifs := newnp.Spec.PodIFs
-		for _, newpodif := range podifs {
+		for ix := range podifs {
 			cont.indexMutex.Lock()
 			podifdata := &EndPointData{
-				MacAddr:    newpodif.MacAddr,
-				EPG:        getPodifEPG(newpodif),
-				Namespace:  newpodif.PodNS,
-				AppProfile: getPodifAppProfile(newpodif),
+				MacAddr:    podifs[ix].MacAddr,
+				EPG:        getPodifEPG(&podifs[ix]),
+				Namespace:  podifs[ix].PodNS,
+				AppProfile: getPodifAppProfile(&podifs[ix]),
 			}
-			podifKey := getPodifKey(newpodif)
+			podifKey := getPodifKey(&podifs[ix])
 			cont.podIftoEp[podifKey] = podifdata
 			cont.indexMutex.Unlock()
 			spankeys := cont.erspanPolPods.GetObjForPod(podifKey)
@@ -151,9 +151,9 @@ func (cont *AciController) nodePodIFDeleted(obj interface{}) {
 	}
 	cont.log.Infof("nodepodif Deleted: %s", np.ObjectMeta.Name)
 	podifs := np.Spec.PodIFs
-	for _, podif := range podifs {
+	for ix := range podifs {
 		cont.indexMutex.Lock()
-		delete(cont.podIftoEp, getPodifKey(podif))
+		delete(cont.podIftoEp, getPodifKey(&podifs[ix]))
 		cont.indexMutex.Unlock()
 	}
 }

--- a/pkg/controller/nodes_stress_test.go
+++ b/pkg/controller/nodes_stress_test.go
@@ -101,17 +101,17 @@ func (nr *nodeRec) ValidatePodNets(verbose bool) error {
 	// look for overlaps, duplicates
 	var prev ipam.IpRange
 
-	for _, ipr := range podIpr.IPRanges {
-		if bytes.Compare(ipr.Start, ipr.End) > 0 {
-			return fmt.Errorf("Bad range %+v", ipr)
+	for ix := range podIpr.IPRanges {
+		if bytes.Compare(podIpr.IPRanges[ix].Start, podIpr.IPRanges[ix].End) > 0 {
+			return fmt.Errorf("Bad range %+v", podIpr.IPRanges[ix])
 		}
 
-		err := checkOverlap(&prev, &ipr, verbose)
+		err := checkOverlap(&prev, &podIpr.IPRanges[ix], verbose)
 		if err != nil {
 			return err
 		}
 
-		prev = ipr
+		prev = podIpr.IPRanges[ix]
 	}
 
 	logrus.Infof("Validated %d net ranges", len(podIpr.IPRanges))
@@ -132,7 +132,7 @@ func checkOverlap(first, second *ipam.IpRange, verbose bool) error {
 		logrus.Infof("checkOverlap: %s vs %s", string(raw1), string(raw2))
 	}
 
-	if net.IP.Equal(first.Start, second.Start) {
+	if first.Start.Equal(second.Start) {
 		return fmt.Errorf("Duplicate found %+v, %+v", first, second)
 	}
 

--- a/pkg/controller/nodes_test.go
+++ b/pkg/controller/nodes_test.go
@@ -215,15 +215,12 @@ func TestPodNetV6Annotation(t *testing.T) {
 	cont.AciController.initIpam()
 	cont.run()
 
-	{
-		cont.nodeUpdates = nil
-		cont.fakeNodeSource.Add(node("node1"))
-		waitForPodNetAnnot(t, cont, &metadata.NetIps{
-			V6: []ipam.IpRange{
-				{Start: net.ParseIP("1:1:1:1::2"), End: net.ParseIP("1:1:1:1::3")},
-			},
-		}, "simple")
-	}
+	cont.nodeUpdates = nil
+	cont.fakeNodeSource.Add(node("node1"))
+	waitForPodNetAnnot(t, cont, &metadata.NetIps{
+		V6: []ipam.IpRange{
+			{Start: net.ParseIP("1:1:1:1::2"), End: net.ParseIP("1:1:1:1::3")}},
+	}, "simple")
 
 	cont.stop()
 }

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -307,8 +307,8 @@ func (cont *AciController) podDeleted(obj interface{}) {
 func (cont *AciController) updateCtrNmPortForPod(pod *v1.Pod, podkey string) {
 	cont.indexMutex.Lock()
 	nmport := false
-	for _, ctr := range pod.Spec.Containers {
-		for _, ctrportspec := range ctr.Ports {
+	for ix := range pod.Spec.Containers {
+		for _, ctrportspec := range pod.Spec.Containers[ix].Ports {
 			if ctrportspec.Name != "" {
 				key := portProto(&ctrportspec.Protocol) + "-" + strconv.Itoa(int(ctrportspec.ContainerPort))
 				ctrNmpEntry, ok := cont.ctrPortNameCache[ctrportspec.Name]
@@ -352,8 +352,8 @@ func (cont *AciController) deleteCtrNmPortForPod(pod *v1.Pod, podkey string) {
 	cont.indexMutex.Lock()
 	cont.removePodFromNode(pod.Spec.NodeName, podkey)
 	nmport := false
-	for _, ctr := range pod.Spec.Containers {
-		for _, ctrportspec := range ctr.Ports {
+	for ix := range pod.Spec.Containers {
+		for _, ctrportspec := range pod.Spec.Containers[ix].Ports {
 			if ctrportspec.Name != "" {
 				ctrNmpEntry, ok := cont.ctrPortNameCache[ctrportspec.Name]
 				if ok {

--- a/pkg/controller/qos_test.go
+++ b/pkg/controller/qos_test.go
@@ -90,7 +90,6 @@ func makeQr(ingress apicapi.ApicSlice, egress apicapi.ApicSlice, name string, po
 func checkDeleteQr(t *testing.T, qt qrTest, cont *testAciController) {
 	tu.WaitFor(t, "delete", 500*time.Millisecond,
 		func(last bool) (bool, error) {
-			//qr := qrTests[0]
 			key := cont.aciNameForKey("qr",
 				qt.qosPol.Namespace+"_"+qt.qosPol.Name)
 			if !tu.WaitEqual(t, last, 0,

--- a/pkg/controller/rdconfig_test.go
+++ b/pkg/controller/rdconfig_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func rdConfigdata(usersubnets []string, discoveredsubnets []string) *rdconfig.RdConfig {
+func rdConfigdata(usersubnets, discoveredsubnets []string) *rdconfig.RdConfig {
 	ns := os.Getenv("ACI_SNAT_NAMESPACE")
 	name := os.Getenv("ACI_RDCONFIG_NAME")
 	rdcon := &rdconfig.RdConfig{

--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -375,7 +375,7 @@ func (cont *AciController) syncSnatGlobalInfo() bool {
 	snatglobalInfo.Spec.GlobalInfos = glInfoCache
 	cont.log.Debug("Update GlobalInfo cache: ", glInfoCache)
 	cont.log.Debug("Updating GlobalInfo CR")
-	err = util.UpdateGlobalInfoCR(*globalcl, snatglobalInfo)
+	err = util.UpdateGlobalInfoCR(*globalcl, &snatglobalInfo)
 	if err != nil {
 		cont.log.Error("GlobalInfo CR Update Failed: ", err)
 		return true

--- a/pkg/controller/snatglobalinfo_test.go
+++ b/pkg/controller/snatglobalinfo_test.go
@@ -48,7 +48,7 @@ func snatpolicydata(name string, namespace string,
 	return policy
 }
 
-func Nodeinfodata(name string, namespace string, macaddr string, snatplcy map[string]bool) *nodeinfo.NodeInfo {
+func Nodeinfodata(name, namespace, macaddr string, snatplcy map[string]bool) *nodeinfo.NodeInfo {
 	info := &nodeinfo.NodeInfo{
 		Spec: nodeinfo.NodeInfoSpec{
 			SnatPolicyNames: snatplcy,
@@ -163,7 +163,7 @@ func snatdeleted(t *testing.T, desc string, actual map[string]map[string]*snatgl
 		return true, nil
 	})
 }
-func snatWaitForIpUpdated(t *testing.T, desc string, snatIp string, actual map[string]map[string]*snatglobalinfo.GlobalInfo) {
+func snatWaitForIpUpdated(t *testing.T, desc, snatIp string, actual map[string]map[string]*snatglobalinfo.GlobalInfo) {
 	tu.WaitFor(t, desc, 100*time.Millisecond, func(last bool) (bool, error) {
 		_, ok := actual[snatIp]
 		if !ok {

--- a/pkg/controller/snats_test.go
+++ b/pkg/controller/snats_test.go
@@ -167,7 +167,6 @@ func TestSnatGraph(t *testing.T) {
 	cont.config.MaxSvcGraphNodes = 2
 	cont.fakeNodeSource.Add(node1)
 	cont.fakeNodeSource.Add(node2)
-	//cont.fakeNodeSource.Add(node3)
 
 	cont.run()
 	cont.fakeSnatPolicySource.Add(policy)

--- a/pkg/gbpserver/config.go
+++ b/pkg/gbpserver/config.go
@@ -66,8 +66,6 @@ type GBPServerConfig struct {
 	Apic       *ApicInfo `json:"apic,omitempty"`
 	SyncRemEps bool      `json:"sync-rem-eps,omitempty"`
 	CSRList    string    `json:"csr-list,omitempty"`
-
-	PushJsonFile bool `json:"push-json-file,omitempty"`
 }
 
 type ApicInfo struct {
@@ -115,7 +113,6 @@ func InitConfig(config *GBPServerConfig) {
 	flag.IntVar(&config.EtcdPort, "etcd-port", 12379, "port for internal kv store")
 	flag.StringVar(&config.PodSubnet, "pod-subnet", "10.2.56.1/21", "pod subnet")
 	flag.StringVar(&config.NodeSubnet, "node-subnet", "1.100.201.0/24", "node subnet")
-	flag.BoolVar(&config.PushJsonFile, "push-json-file", false, "push file to opflexserver (testing)")
 	flag.BoolVar(&config.SyncRemEps, "sync-rem-eps", true, "sync remote eps")
 	flag.StringVar(&config.CSRList, "csr-list", "", "comma separated list of csr vteps")
 	flag.IntVar(&config.VrfEncapID, "vrf-encap-id", RdEncapID, "encap-id for vrf")

--- a/pkg/gbpserver/inventory.go
+++ b/pkg/gbpserver/inventory.go
@@ -45,8 +45,6 @@ const (
 	csrDefMac       = "00:00:5e:00:52:13"
 )
 
-var InvDB = make(map[string]map[string]*gbpInvMo)
-
 func (g *gbpInvMo) save(vtep string) {
 	db := getInvDB(vtep)
 	db[g.Uri] = g
@@ -485,7 +483,6 @@ func postEndpoint(w http.ResponseWriter, r *http.Request, vars map[string]string
 	}
 
 	uri, err := ep.Add()
-	DoAll()
 	return &PostResp{URI: uri}, err
 }
 
@@ -551,7 +548,6 @@ func deleteEndpoint(w http.ResponseWriter, r *http.Request, vars map[string]stri
 
 	log.Debugf("deleteEndpoint - VTEP: %s", ep.VTEP)
 	err = ep.Delete()
-	DoAll()
 	return nil, err
 }
 

--- a/pkg/gbpserver/policy.go
+++ b/pkg/gbpserver/policy.go
@@ -19,14 +19,16 @@ package gbpserver
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/noironetworks/aci-containers/pkg/apicapi"
-	"github.com/noironetworks/aci-containers/pkg/gbpcrd/apis/acipolicy/v1"
-	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/noironetworks/aci-containers/pkg/apicapi"
+	"github.com/noironetworks/aci-containers/pkg/gbpcrd/apis/acipolicy/v1"
 )
 
 const revClassify = "rev"
@@ -558,7 +560,6 @@ func postEpg(w http.ResponseWriter, r *http.Request, vars map[string]string) (in
 		return nil, errors.Wrap(err, "epg.Make")
 	}
 
-	DoAll()
 	return &PostResp{URI: epg.getURI()}, nil
 }
 
@@ -622,7 +623,6 @@ func postContract(w http.ResponseWriter, r *http.Request, vars map[string]string
 		return nil, errors.Wrap(err, "c.Make")
 	}
 
-	DoAll()
 	return &PostResp{URI: c.getURI()}, nil
 }
 
@@ -678,7 +678,6 @@ func deleteObject(w http.ResponseWriter, r *http.Request, vars map[string]string
 	k := strings.Replace(uri[0], "|", "%7c", -1)
 	delete(getMoDB(), k)
 	log.Debugf("%s deleted", k)
-	DoAll()
 	return nil, nil
 }
 
@@ -972,7 +971,6 @@ func postNP(w http.ResponseWriter, r *http.Request, vars map[string]string) (int
 	for _, fn := range theServer.listeners {
 		fn(GBPOperation_REPLACE, c.getAllURIs())
 	}
-	DoAll()
 	log.Infof("Created %+v", c)
 	return &PostResp{URI: c.getURI()}, nil
 }
@@ -1001,7 +999,6 @@ func deleteNP(w http.ResponseWriter, r *http.Request, vars map[string]string) (i
 	npMo.delRecursive()
 	log.Infof("Deleted %s", key)
 
-	DoAll()
 	return nil, nil
 }
 

--- a/pkg/gbpserver/server.go
+++ b/pkg/gbpserver/server.go
@@ -652,8 +652,6 @@ func (s *Server) handleMsgs() {
 			log.Errorf("Unknown msg type: %d", m.op)
 			continue
 		}
-
-		DoAll()
 	}
 }
 

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -128,7 +128,7 @@ type ServiceEndPointType interface {
 	InitClientInformer(kubeClient *kubernetes.Clientset)
 	Run(stopCh <-chan struct{})
 	SetOpflexService(ofas *opflexService, as *v1.Service,
-		external bool, key string, sp v1.ServicePort) bool
+		external bool, key string, sp *v1.ServicePort) bool
 }
 
 type serviceEndpoint struct {

--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -19,6 +19,7 @@ import (
 	"net"
 
 	cnitypes "github.com/containernetworking/cni/pkg/types"
+
 	"github.com/noironetworks/aci-containers/pkg/metadata"
 )
 

--- a/pkg/hostagent/event_poster.go
+++ b/pkg/hostagent/event_poster.go
@@ -79,7 +79,7 @@ func (agent *HostAgent) submitEvent(pod *v1.Pod, message, dropReason string) err
 }
 
 // Check if given PacketEvent should be ignored
-func (agent *HostAgent) shouldIgnore(packetEvent PacketEvent, currTime time.Time) bool {
+func (agent *HostAgent) shouldIgnore(packetEvent *PacketEvent, currTime time.Time) bool {
 	// ignore if the given packetDrop is out of date
 	logTime, err := time.Parse(time.UnixDate, packetEvent.TimeStamp)
 	if (err != nil) || (currTime.Sub(logTime).Minutes() > float64(agent.config.DropLogExpiryTime)) {
@@ -103,7 +103,7 @@ func getPacketDropMessage(etherType, srcIp, dstIp string) string {
 }
 
 // Handle the given PacketDrop, return error if api server does not work
-func (agent *HostAgent) processPacketEvent(packetEvent PacketEvent, currTime time.Time) error {
+func (agent *HostAgent) processPacketEvent(packetEvent *PacketEvent, currTime time.Time) error {
 	if packetEvent.SourceIP == "" || packetEvent.DestinationIP == "" {
 		return nil
 	}

--- a/pkg/hostagent/event_poster_test.go
+++ b/pkg/hostagent/event_poster_test.go
@@ -43,7 +43,7 @@ func TestShouldIgnoreDelayed(t *testing.T) {
 	agent.config.DropLogExpiryTime = 10
 	agent.config.DropLogRepeatIntervalTime = 2
 	currTime, _ := time.Parse(time.UnixDate, "Sun Mar 08 20:13:59 EDT 2020")
-	assert.Equal(t, true, agent.shouldIgnore(packetEvent, currTime), "late event prune test failed")
+	assert.Equal(t, true, agent.shouldIgnore(&packetEvent, currTime), "late event prune test failed")
 }
 
 // Check if ignoring PacketEvent based on frequency works
@@ -95,14 +95,14 @@ func TestShouldIgnoreRepeated(t *testing.T) {
 	}
 	time.Sleep(3000 * time.Millisecond)
 	currTime, _ := time.Parse(time.UnixDate, "Sun Mar 08 20:03:59 EDT 2020")
-	err = agent.processPacketEvent(packetEvent, currTime)
+	err = agent.processPacketEvent(&packetEvent, currTime)
 	assert.Nil(t, err, "Failed to process event")
 	packetEvent.TimeStamp = "Sun Mar 08 20:04:59 EDT 2020"
 	currTime = currTime.Add(time.Minute * 1)
-	assert.Equal(t, true, agent.shouldIgnore(packetEvent, currTime), "repeated event prune test failed")
+	assert.Equal(t, true, agent.shouldIgnore(&packetEvent, currTime), "repeated event prune test failed")
 	packetEvent.TimeStamp = "Sun Mar 08 20:06:59 EDT 2020"
 	currTime = currTime.Add(time.Minute * 5)
-	assert.Equal(t, false, agent.shouldIgnore(packetEvent, currTime), "post event test failed")
+	assert.Equal(t, false, agent.shouldIgnore(&packetEvent, currTime), "post event test failed")
 	for _, pt := range podTests {
 		pod := pod(pt.uuid, pt.namespace, pt.name, pt.eg, pt.sg, pt.qp)
 		agent.fakePodSource.Delete(pod)

--- a/pkg/hostagent/integ_test.go
+++ b/pkg/hostagent/integ_test.go
@@ -154,7 +154,7 @@ func (it *integ) tearDown() {
 	os.RemoveAll(it.hcf.OpFlexSnatDir)
 }
 
-func (it *integ) setupNode(ipam buildIpam, wait bool) {
+func (it *integ) setupNode(ipam *buildIpam, wait bool) {
 	it.ta.indexMutex.Lock()
 
 	if it.ta.epMetadata == nil {
@@ -364,8 +364,8 @@ func TestIPAM(t *testing.T) {
 		return total
 	}
 
-	for ix, am := range updIpams {
-		it.setupNode(am, true)
+	for ix := range updIpams {
+		it.setupNode(&updIpams[ix], true)
 		poolSizes[ix] = ipCounter()
 		log.Infof("IP pool size is %v", poolSizes[ix])
 	}
@@ -379,7 +379,7 @@ func TestIPAM(t *testing.T) {
 			case <-stopCh:
 				return
 			case <-time.After(2 * time.Millisecond):
-				it.setupNode(updIpams[ix], false)
+				it.setupNode(&updIpams[ix], false)
 			}
 
 			ix++
@@ -425,10 +425,11 @@ func TestIPAM(t *testing.T) {
 func TestEPDelete(t *testing.T) {
 	ncf := cniNetConfig{Subnet: cnitypes.IPNet{IP: net.ParseIP("10.128.2.0"), Mask: net.CIDRMask(24, 32)}}
 	hcf := &HostAgentConfig{
-		NodeName:  "node1",
-		EpRpcSock: "/tmp/aci-containers-ep-rpc.sock",
-		NetConfig: []cniNetConfig{ncf},
-		AciPrefix: "it",
+		NodeName:       "node1",
+		EpRpcSock:      "/tmp/aci-containers-ep-rpc.sock",
+		EpRpcSockPerms: "0600",
+		NetConfig:      []cniNetConfig{ncf},
+		AciPrefix:      "it",
 		GroupDefaults: GroupDefaults{
 			DefaultEg: metadata.OpflexGroup{
 				PolicySpace: "tenantA",
@@ -449,7 +450,7 @@ func TestEPDelete(t *testing.T) {
 	}
 
 	it := SetupInteg(t, hcf)
-	it.setupNode(itIpam, true)
+	it.setupNode(&itIpam, true)
 	defer it.tearDown()
 
 	// Add pods intf via cni
@@ -508,7 +509,7 @@ func TestGroupAssign(t *testing.T) {
 	}
 
 	it := SetupInteg(t, hcf)
-	it.setupNode(itIpam, true)
+	it.setupNode(&itIpam, true)
 	defer it.tearDown()
 
 	// add an annotated namespace
@@ -616,7 +617,7 @@ func TestNPGroupAssign(t *testing.T) {
 	}
 
 	it := SetupInteg(t, hcf)
-	it.setupNode(itIpam, true)
+	it.setupNode(&itIpam, true)
 	defer it.tearDown()
 
 	// add an annotated namespace
@@ -672,21 +673,21 @@ func TestNPGroupAssign(t *testing.T) {
 
 func mkSnatGlobalObj() *snatglobal.SnatGlobalInfo {
 	var newglobal []snatglobal.GlobalInfo
-	for i, pt := range snatGlobals {
+	for i := range snatGlobals {
 		var globalinfo snatglobal.GlobalInfo
 		portrange := make([]snatglobal.PortRange, 1)
-		portrange[0].Start = pt.port_range.start
-		portrange[0].End = pt.port_range.end
-		globalinfo.MacAddress = pt.mac
-		globalinfo.SnatIp = pt.ip
-		globalinfo.SnatIpUid = pt.uuid
+		portrange[0].Start = snatGlobals[i].port_range.start
+		portrange[0].End = snatGlobals[i].port_range.end
+		globalinfo.MacAddress = snatGlobals[i].mac
+		globalinfo.SnatIp = snatGlobals[i].ip
+		globalinfo.SnatIpUid = snatGlobals[i].uuid
 		globalinfo.PortRanges = portrange
-		globalinfo.SnatPolicyName = pt.policyname
+		globalinfo.SnatPolicyName = snatGlobals[i].policyname
 		if i == 0 {
 			newglobal = append(newglobal, globalinfo)
 		}
 		for _, v := range newglobal {
-			if v.MacAddress != pt.mac {
+			if v.MacAddress != snatGlobals[i].mac {
 				newglobal = append(newglobal, globalinfo)
 			}
 		}
@@ -730,7 +731,7 @@ func TestSnatPolicy(t *testing.T) {
 	}
 	it := SetupInteg(t, hcf)
 	it.ta.config.NodeName = "test-node"
-	it.setupNode(itIpam, true)
+	it.setupNode(&itIpam, true)
 	defer it.tearDown()
 
 	// add an annotated namespace
@@ -788,7 +789,7 @@ func TestSnatPolicyDep(t *testing.T) {
 	}
 
 	it := SetupInteg(t, hcf)
-	it.setupNode(itIpam, true)
+	it.setupNode(&itIpam, true)
 	defer it.tearDown()
 
 	// add an annotated namespace
@@ -859,7 +860,7 @@ func TestEPUpdateContainerId(t *testing.T) {
 	}
 
 	it := SetupInteg(t, hcf)
-	it.setupNode(itIpam, true)
+	it.setupNode(&itIpam, true)
 	defer it.tearDown()
 
 	// Add pods intf via cni
@@ -947,7 +948,7 @@ func TestSnatPolicyService(t *testing.T) {
 	}
 
 	it := SetupInteg(t, hcf)
-	it.setupNode(itIpam, true)
+	it.setupNode(&itIpam, true)
 	defer it.tearDown()
 
 	// add an annotated namespace
@@ -1010,7 +1011,7 @@ func TestSnatPolicylabelUpdate(t *testing.T) {
 	}
 
 	it := SetupInteg(t, hcf)
-	it.setupNode(itIpam, true)
+	it.setupNode(&itIpam, true)
 	defer it.tearDown()
 
 	// add an annotated namespace

--- a/pkg/hostagent/ipam.go
+++ b/pkg/hostagent/ipam.go
@@ -146,12 +146,13 @@ func (agent *HostAgent) allocateIps(iface *metadata.ContainerIfaceMd, podKey str
 		if err != nil {
 			result =
 				fmt.Errorf("Could not allocate IPv4 address: %w", err)
+			agent.log.Error(result)
 			return false
 		} else {
 			gateway, mask := agent.getIPMetadata(ip)
 			if mask == nil {
 				err := errors.New("Unable to find Mask")
-				fmt.Errorf("Could not allocate address: %w", err)
+				agent.log.Error(fmt.Errorf("Could not allocate address: %w", err))
 				return false
 			}
 			oldKey, found := agent.usedIPs[ip.String()]
@@ -166,12 +167,12 @@ func (agent *HostAgent) allocateIps(iface *metadata.ContainerIfaceMd, podKey str
 	}
 
 	var v4Allocated, v6Allocated bool
-	for _, nc := range agent.config.NetConfig {
-		if nc.Subnet.IP != nil {
-			if nc.Subnet.IP.To4() != nil && !v4Allocated {
-				v4Allocated = allocIP(true, &nc)
-			} else if nc.Subnet.IP.To16() != nil && !v6Allocated {
-				v6Allocated = allocIP(false, &nc)
+	for ix := range agent.config.NetConfig {
+		if agent.config.NetConfig[ix].Subnet.IP != nil {
+			if agent.config.NetConfig[ix].Subnet.IP.To4() != nil && !v4Allocated {
+				v4Allocated = allocIP(true, &agent.config.NetConfig[ix])
+			} else if agent.config.NetConfig[ix].Subnet.IP.To16() != nil && !v6Allocated {
+				v6Allocated = allocIP(false, &agent.config.NetConfig[ix])
 			}
 		}
 	}

--- a/pkg/hostagent/nodes_test.go
+++ b/pkg/hostagent/nodes_test.go
@@ -135,13 +135,13 @@ func TestBuildIpam(t *testing.T) {
 		agent.epMetadata =
 			make(map[string]map[string]*metadata.ContainerMetadata)
 		agent.podNetAnnotation = ""
-		for _, ep := range test.existingEps {
-			podid := "ns/pod" + ep.Id.ContId
+		for ix := range test.existingEps {
+			podid := "ns/pod" + test.existingEps[ix].Id.ContId
 			if _, ok := agent.epMetadata[podid]; !ok {
 				agent.epMetadata[podid] =
 					make(map[string]*metadata.ContainerMetadata)
 			}
-			agent.epMetadata[podid][ep.Id.ContId] = &ep
+			agent.epMetadata[podid][test.existingEps[ix].Id.ContId] = &test.existingEps[ix]
 		}
 		agent.buildUsedIPs()
 		agent.indexMutex.Unlock()

--- a/pkg/hostagent/packet_event.go
+++ b/pkg/hostagent/packet_event.go
@@ -66,8 +66,8 @@ func (agent *HostAgent) RunPacketEventListener(stopCh <-chan struct{}) {
 						agent.log.Debug("Unmarshaling error ", err1)
 						continue
 					}
-					for _, event := range m {
-						err2 := agent.processPacketEvent(event, time.Now())
+					for ix := range m {
+						err2 := agent.processPacketEvent(&m[ix], time.Now())
 						if err2 != nil {
 							agent.log.Debugf("Failed to post event %d", err2)
 						}

--- a/pkg/hostagent/pod_relatives.go
+++ b/pkg/hostagent/pod_relatives.go
@@ -173,8 +173,8 @@ func (agent *HostAgent) networkPolicyChanged(oldobj, newobj interface{}) {
 	}
 	if !sameSpec {
 		peerPodKeys := agent.netPolPods.GetPodForObj(npkey)
-		for _, podkey := range peerPodKeys {
-			agent.podChanged(&podkey)
+		for i := range peerPodKeys {
+			agent.podChanged(&peerPodKeys[i])
 		}
 	}
 }
@@ -267,14 +267,14 @@ func (agent *HostAgent) qosPolicyChanged(oldobj, newobj interface{}) {
 
 	if !reflect.DeepEqual(oldqp.Spec.Ingress, newqp.Spec.Ingress) {
 		peerPodKeys := agent.qosPolPods.GetPodForObj(qpkey)
-		for _, podkey := range peerPodKeys {
-			agent.podChanged(&podkey)
+		for ix := range peerPodKeys {
+			agent.podChanged(&peerPodKeys[ix])
 		}
 	}
 	if !reflect.DeepEqual(oldqp.Spec.Egress, newqp.Spec.Egress) {
 		peerPodKeys := agent.qosPolPods.GetPodForObj(qpkey)
-		for _, podkey := range peerPodKeys {
-			agent.podChanged(&podkey)
+		for ix := range peerPodKeys {
+			agent.podChanged(&peerPodKeys[ix])
 		}
 	}
 }
@@ -400,8 +400,8 @@ func (agent *HostAgent) deploymentChanged(oldobj interface{},
 				Error("Could not create key: ", err)
 			return
 		}
-		for _, podkey := range agent.depPods.GetPodForObj(depkey) {
-			agent.podChanged(&podkey)
+		for ix := range agent.depPods.GetPodForObj(depkey) {
+			agent.podChanged(&agent.depPods.GetPodForObj(depkey)[ix])
 		}
 	}
 	if !reflect.DeepEqual(olddep.ObjectMeta.Labels,
@@ -467,12 +467,12 @@ func (agent *HostAgent) initRCPodIndex() {
 		cache.MetaNamespaceKeyFunc,
 		func(obj interface{}) []index.PodSelector {
 			rc := obj.(*v1.ReplicationController)
-			labels := rc.Spec.Selector
-			if len(labels) == 0 {
+			podLabels := rc.Spec.Selector
+			if len(podLabels) == 0 {
 				agent.log.Infof("RC %s/%s has no selector. Using template", rc.ObjectMeta.Namespace, rc.ObjectMeta.Name)
-				labels = rc.Spec.Template.Labels
+				podLabels = rc.Spec.Template.Labels
 			}
-			ls := &metav1.LabelSelector{MatchLabels: labels}
+			ls := &metav1.LabelSelector{MatchLabels: podLabels}
 			return index.PodSelectorFromNsAndSelector(rc.ObjectMeta.Namespace, ls)
 		},
 	)
@@ -515,8 +515,8 @@ func (agent *HostAgent) rcChanged(oldobj interface{},
 				Error("Could not create key: ", err)
 			return
 		}
-		for _, podkey := range agent.rcPods.GetPodForObj(rckey) {
-			agent.podChanged(&podkey)
+		for ix := range agent.rcPods.GetPodForObj(rckey) {
+			agent.podChanged(&agent.rcPods.GetPodForObj(rckey)[ix])
 		}
 	}
 }

--- a/pkg/hostagent/pods_test.go
+++ b/pkg/hostagent/pods_test.go
@@ -197,11 +197,11 @@ func TestPodSync(t *testing.T) {
 				cnimd.Id.ContId: cnimd,
 			}
 		agent.fakePodSource.Add(pod)
-		agent.doTestPod(t, tempdir, &pt, "create")
+		agent.doTestPod(t, tempdir, &podTests[i], "create")
 		agent.log.Info("Created ##### ", i, pt.uuid)
 	}
 
-	for _, pt := range podTests {
+	for i, pt := range podTests {
 		pod := pod(pt.uuid, pt.namespace, pt.name, pt.eg, pt.sg, pt.qp)
 		cnimd := cnimd(pt.namespace, pt.name, pt.ip, pt.cont, pt.veth)
 		cnimd.Ifaces[0].Mac = pt.mac
@@ -210,7 +210,7 @@ func TestPodSync(t *testing.T) {
 				cnimd.Id.ContId: cnimd,
 			}
 		agent.fakePodSource.Add(pod)
-		agent.doTestPod(t, tempdir, &pt, "update")
+		agent.doTestPod(t, tempdir, &podTests[i], "update")
 		agent.log.Info("Updated ##### ", pt.uuid)
 	}
 

--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -396,8 +396,8 @@ func (agent *HostAgent) updateServiceDesc(external bool, as *v1.Service, key str
 		ofas.Uuid += "-external"
 	}
 	hasValidMapping := false
-	for _, sp := range as.Spec.Ports {
-		hasValidMapping = agent.serviceEndPoints.SetOpflexService(ofas, as, external, key, sp)
+	for ix := range as.Spec.Ports {
+		hasValidMapping = agent.serviceEndPoints.SetOpflexService(ofas, as, external, key, &as.Spec.Ports[ix])
 	}
 
 	id := fmt.Sprintf("%s_%s", as.ObjectMeta.Namespace, as.ObjectMeta.Name)
@@ -640,7 +640,7 @@ func (agent *HostAgent) setOpenShfitService(as *v1.Service, external bool, ofas 
 }
 
 func (sep *serviceEndpoint) SetOpflexService(ofas *opflexService, as *v1.Service,
-	external bool, key string, sp v1.ServicePort) bool {
+	external bool, key string, sp *v1.ServicePort) bool {
 	agent := sep.agent
 	endpointsobj, exists, err :=
 		agent.endpointsInformer.GetStore().GetByKey(key)
@@ -748,7 +748,7 @@ func getSessionAffinity(as *v1.Service) *opflexSessionAffinityConfig {
 }
 
 func (seps *serviceEndpointSlice) SetOpflexService(ofas *opflexService, as *v1.Service,
-	external bool, key string, sp v1.ServicePort) bool {
+	external bool, key string, sp *v1.ServicePort) bool {
 	agent := seps.agent
 	hasValidMapping := false
 	var endpointSlices []*discovery.EndpointSlice

--- a/pkg/hostagent/services_test.go
+++ b/pkg/hostagent/services_test.go
@@ -303,7 +303,7 @@ func TestServiceSync(t *testing.T) {
 		endpoints := endpoints(st.namespace, st.name, st.nextHopIps, st.ports)
 		agent.fakeServiceSource.Add(service)
 		agent.fakeEndpointsSource.Add(endpoints)
-		agent.doTestService(t, tempdir, &st, "create")
+		agent.doTestService(t, tempdir, &serviceTests[i], "create")
 	}
 
 	for _, st := range serviceTests {
@@ -381,7 +381,7 @@ func TestServiceSyncWithEps(t *testing.T) {
 		endpoints := endpointslice(st.namespace, st.name, st.nextHopIps, st.ports, "test-node")
 		agent.fakeServiceSource.Add(service)
 		agent.fakeEndpointSliceSource.Add(endpoints)
-		agent.doTestService(t, tempdir, &st, "create")
+		agent.doTestService(t, tempdir, &serviceTests[i], "create")
 	}
 
 	for _, st := range serviceTests {
@@ -460,7 +460,7 @@ func TestServiceWithTopoKeys(t *testing.T) {
 		endpoints := endpointslice(st.namespace, st.name, st.nextHopIps, st.ports, agent.config.NodeName)
 		agent.fakeServiceSource.Add(service)
 		agent.fakeEndpointSliceSource.Add(endpoints)
-		agent.doTestService(t, tempdir, &st, "create")
+		agent.doTestService(t, tempdir, &serviceTests[i], "create")
 	}
 
 	for _, st := range serviceTests {

--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -718,12 +718,12 @@ func (agent *HostAgent) configureContainerIfaces(metadata *md.ContainerMetadata)
 	}
 	agent.indexMutex.Unlock()
 
-	for _, v := range StaleContMetadata {
-		err := agent.cleanStatleMetadata(v.Id.ContId)
+	for ix := range StaleContMetadata {
+		err := agent.cleanStatleMetadata(StaleContMetadata[ix].Id.ContId)
 		if err == nil {
-			agent.deallocateMdIps(&v)
+			agent.deallocateMdIps(&StaleContMetadata[ix])
 			agent.ipamMutex.Lock()
-			delete(agent.epMetadata[podid], v.Id.ContId)
+			delete(agent.epMetadata[podid], StaleContMetadata[ix].Id.ContId)
 			agent.ipamMutex.Unlock()
 		}
 	}

--- a/pkg/hostagent/snats_test.go
+++ b/pkg/hostagent/snats_test.go
@@ -21,13 +21,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+
 	"github.com/noironetworks/aci-containers/pkg/metadata"
 	snatglobal "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/apis/aci.snat/v1"
 	snatpolicy "github.com/noironetworks/aci-containers/pkg/snatpolicy/apis/aci.snat/v1"
 	tu "github.com/noironetworks/aci-containers/pkg/testutil"
-	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	apitypes "k8s.io/apimachinery/pkg/types"
 )
 
 type portRange struct {
@@ -235,7 +236,7 @@ func TestSnatSync(t *testing.T) {
 		snatglobalinfo = snatglobaldata(pt.uuid, pt.name, pt.nodename, pt.namespace, newglobal)
 		agent.fakeSnatGlobalSource.Add(snatglobalinfo)
 		agent.log.Info("Complete Globale Info #### ", snatglobalinfo)
-		agent.doTestSnat(t, tempdir, &pt, "create")
+		agent.doTestSnat(t, tempdir, &snatGlobals[i], "create")
 	}
 	agent.stop()
 }

--- a/pkg/index/pod_selector_index_test.go
+++ b/pkg/index/pod_selector_index_test.go
@@ -181,21 +181,21 @@ func (i *testIndex) stop() {
 	close(i.stopCh)
 }
 
-func pod(namespace string, name string, labels map[string]string) *v1.Pod {
+func pod(namespace, name string, podLabels map[string]string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      name,
-			Labels:    labels,
+			Labels:    podLabels,
 		},
 	}
 }
 
-func namespace(namespace string, labels map[string]string) *v1.Namespace {
+func namespace(namespace string, nsLabels map[string]string) *v1.Namespace {
 	return &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   namespace,
-			Labels: labels,
+			Labels: nsLabels,
 		},
 	}
 }

--- a/pkg/loadbalancer/aws.go
+++ b/pkg/loadbalancer/aws.go
@@ -233,15 +233,15 @@ func getSvcKey(s *v1.Service) string {
 	return fmt.Sprintf("%s-%s", s.ObjectMeta.Namespace, s.ObjectMeta.Name)
 }
 
-func targetsDiff(old, new []string) ([]*elbv2.TargetDescription, []*elbv2.TargetDescription) {
+func targetsDiff(oldTgt, newTgt []string) ([]*elbv2.TargetDescription, []*elbv2.TargetDescription) {
 	// new - old
 	r := make(map[string]bool)
 
-	for _, o := range old {
+	for _, o := range oldTgt {
 		r[o] = false
 	}
 
-	for _, n := range new {
+	for _, n := range newTgt {
 		if _, found := r[n]; found {
 			delete(r, n)
 		} else {

--- a/pkg/loadbalancer/nslb.go
+++ b/pkg/loadbalancer/nslb.go
@@ -17,6 +17,9 @@ package loadbalancer
 import (
 	"context"
 	"fmt"
+	"strings"
+	"sync"
+
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,8 +29,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/controller"
-	"strings"
-	"sync"
 )
 
 type LBProvider interface {

--- a/pkg/util/snat.go
+++ b/pkg/util/snat.go
@@ -16,16 +16,18 @@ package util
 
 import (
 	"context"
+	"os"
+	"sort"
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
 	nodeinfoclset "github.com/noironetworks/aci-containers/pkg/nodeinfo/clientset/versioned"
 	snatglobal "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/apis/aci.snat/v1"
 	snatglobalclset "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/clientset/versioned"
 	snatpolicy "github.com/noironetworks/aci-containers/pkg/snatpolicy/apis/aci.snat/v1"
 	snatpolicyclset "github.com/noironetworks/aci-containers/pkg/snatpolicy/clientset/versioned"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-	"os"
-	"sort"
-	"strconv"
 )
 
 type StartSorter []snatglobal.PortRange
@@ -77,9 +79,9 @@ func CreateSnatGlobalInfoCR(c snatglobalclset.Clientset,
 }
 
 // UpdateSnatGlobalInfoCR Updates a SnatGlobalInfo CR
-func UpdateGlobalInfoCR(c snatglobalclset.Clientset, globalInfo snatglobal.SnatGlobalInfo) error {
+func UpdateGlobalInfoCR(c snatglobalclset.Clientset, globalInfo *snatglobal.SnatGlobalInfo) error {
 	ns := os.Getenv("ACI_SNAT_NAMESPACE")
-	_, err := c.AciV1().SnatGlobalInfos(ns).Update(context.TODO(), &globalInfo, metav1.UpdateOptions{})
+	_, err := c.AciV1().SnatGlobalInfos(ns).Update(context.TODO(), globalInfo, metav1.UpdateOptions{})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Most fixes are focused on avoiding unnecessary copies or avoiding implicit mem aliasing in for loops
Remove unused func to push full policy file to opflex-server Minor change to UT to increase coverage