### PR TITLE
Add mode for globalvlan l2 port policy

### DIFF
--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -228,7 +228,7 @@ func testController() *testAciController {
 	return cont
 }
 
-func testChainedController() *testAciController {
+func testChainedController(aciUseGlobalScopeVlan bool) *testAciController {
 	log := logrus.New()
 	log.Level = logrus.DebugLevel
 	log.Formatter = &logrus.TextFormatter{
@@ -237,13 +237,14 @@ func testChainedController() *testAciController {
 
 	cont := &testAciController{
 		AciController: *NewController(&ControllerConfig{
-			AciPolicyTenant:  "kubernetes",
-			AciPrefix:        "kube",
-			AciVrf:           "kube-vrf",
-			AciVrfTenant:     "common",
-			ChainedMode:      true,
-			AciPhysDom:       "first-physdom",
-			AciAdditionalAep: "second-aep",
+			AciPolicyTenant:       "kubernetes",
+			AciPrefix:             "kube",
+			AciVrf:                "kube-vrf",
+			AciVrfTenant:          "common",
+			ChainedMode:           true,
+			AciPhysDom:            "first-physdom",
+			AciAdditionalAep:      "second-aep",
+			AciUseGlobalScopeVlan: aciUseGlobalScopeVlan,
 		},
 			&K8sEnvironment{}, log, true),
 	}

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -262,6 +262,9 @@ type ControllerConfig struct {
 
 	//User can provision Static Objects separately, so have a knob
 	ReconcileStaticObjects bool `json:"reconcileStaticObjects,omitempty"`
+
+	//In chained mode, global l2 port policy has been configured, so enable shared vlan pool
+	AciUseGlobalScopeVlan bool `json:"aci-use-global-scope-vlan,omitempty"`
 }
 
 type netIps struct {
@@ -302,6 +305,7 @@ func InitFlags(config *ControllerConfig) {
 	flag.BoolVar(&config.EnableVmmInjectedLabels, "enable-vmm-injected-labels", false, "Enable creation of VmmInjectedLabel")
 	flag.BoolVar(&config.ChainedMode, "chained-mode", false, "CNI is in chained mode")
 	flag.BoolVar(&config.ReconcileStaticObjects, "reconcile-static-objects", false, "controller will reconcile implicit static objects")
+	flag.BoolVar(&config.AciUseGlobalScopeVlan, "aci-use-global-scope-vlan", false, "Use global vlans for NADs in chained mode")
 }
 
 func (cont *AciController) loadIpRanges(v4, v6 *ipam.IpAlloc, ipranges []ipam.IpRange) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -179,6 +179,11 @@ type AciController struct {
 	vmmClusterFaultSupported bool
 	additionalNetworkCache   map[string]*AdditionalNetworkMeta
 	lldpIfCache              map[string]string
+	globalVlanConfig         globalVlanConfig
+}
+
+type globalVlanConfig struct {
+	SharedPhysDom apicapi.ApicObject
 }
 
 type hppReference struct {


### PR DESCRIPTION
Setting AciUseGlobalScopeVlan on controller config, will enable the use of a shared vlan pool.
Trying to reuse an existing NAD's encap is an
error in globalscopevlan mode, this check will
be added in containers-host.