### PR TITLE
Fix for network-attachment-definitions error logs

### DIFF
--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -339,7 +339,7 @@ func (config *HostAgentConfig) InitFlags() {
 	flag.StringVar(&config.InstallerProvlbIp, "installer-provisioned-lb-ip", "", "Installer lb ip provisioned for OpenShift on ESX")
 	flag.BoolVar(&config.EnableNodePodIF, "enable-nodepodif", false, "Enable NodePodIF")
 	flag.StringVar(&config.EPRegistry, "ep-registry", "", "Enable PodIF")
-	flag.BoolVar(&config.OvsHardwareOffload, "enable-sriov-config", false, "SRIOV config and ovs hardware offload feature")
+	flag.BoolVar(&config.OvsHardwareOffload, "enable-ovs-hw-offload", false, "SRIOV config and ovs hardware offload feature")
 	flag.StringVar(&config.DpuOvsDBSocket, "dpu-ovsdb-socket", "tcp:192.168.200.2:6640", "TCP socket on DPU to connect to")
 	flag.BoolVar(&config.ChainedMode, "chained_mode", false, "Chained Mode")
 	flag.StringVar(&config.CniNetworksDir, "cni-networks-dir", "/usr/local/var/lib/netop-cni/networks", "Cni Networks Directory")

--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -245,11 +245,13 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 	cache.WaitForCacheSync(stopCh, env.agent.qosPolicyInformer.HasSynced)
 	env.agent.log.Info("qosPolicy cache sync successful")
 
-	env.agent.log.Debug("Starting netAttDef informers")
-	go env.agent.netAttDefInformer.Run(stopCh)
-	env.agent.log.Info("Waiting for netAttDef cache sync")
-	cache.WaitForCacheSync(stopCh, env.agent.netAttDefInformer.HasSynced)
-	env.agent.log.Info("netAttDef cache sync successful")
+	if env.agent.config.OvsHardwareOffload || env.agent.config.ChainedMode {
+		env.agent.log.Debug("Starting netAttDef informers")
+		go env.agent.netAttDefInformer.Run(stopCh)
+		env.agent.log.Info("Waiting for netAttDef cache sync")
+		cache.WaitForCacheSync(stopCh, env.agent.netAttDefInformer.HasSynced)
+		env.agent.log.Info("netAttDef cache sync successful")
+	}
 
 	env.agent.log.Info("Cache sync successful")
 	return true, nil

--- a/pkg/hostagent/netattachdef_test.go
+++ b/pkg/hostagent/netattachdef_test.go
@@ -41,6 +41,7 @@ func TestNetAttachmentDef(t *testing.T) {
 	resourceAnnot := make(map[string]string)
 	resourceAnnot["k8s.v1.cni.cncf.io/resourceName"] = "mellanox.com/cx5_sriov_switchdev"
 	agent := testAgent()
+	agent.config.OvsHardwareOffload = true
 	agent.fakeNetAttachDefSource.Add(testnetattach("default", "kube-system", configJsondata, resourceAnnot))
 	agent.run()
 
@@ -67,6 +68,7 @@ func TestNetAttachmentDefWithoutAcii(t *testing.T) {
 	resourceAnnot := make(map[string]string)
 	resourceAnnot["k8s.v1.cni.cncf.io/resourceName"] = "mellanox.com/cx5_sriov_switchdev"
 	agent := testAgent()
+	agent.config.OvsHardwareOffload = true
 	agent.fakeNetAttachDefSource.Add(testnetattach("default", "kube-system", configJsondata, resourceAnnot))
 	agent.run()
 
@@ -87,6 +89,7 @@ func TestNetAttachmentDefDelete(t *testing.T) {
 	resourceAnnot := make(map[string]string)
 	resourceAnnot["k8s.v1.cni.cncf.io/resourceName"] = "mellanox.com/cx5_sriov_switchdev"
 	agent := testAgent()
+	agent.config.OvsHardwareOffload = true
 	agent.fakeNetAttachDefSource.Add(testnetattach("default", "kube-system", configJsondata, resourceAnnot))
 	agent.run()
 


### PR DESCRIPTION
* Added fix for failed to list NetworkAttachmentDefinition error logs in hostagent when OvsHardwareOffload is not set

* Changed name of flag to set OvsHardwareOffload to enable-ovs-hw-offload for consistency