### PR TITLE
Change GlobalMode Semantics

### DIFF
--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -244,6 +244,7 @@ func testChainedController(aciUseGlobalScopeVlan bool) *testAciController {
 			ChainedMode:           true,
 			AciPhysDom:            "first-physdom",
 			AciAdditionalAep:      "second-aep",
+			AciAdditionalVlans:    "[100-101]",
 			AciUseGlobalScopeVlan: aciUseGlobalScopeVlan,
 		},
 			&K8sEnvironment{}, log, true),

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -265,6 +265,9 @@ type ControllerConfig struct {
 
 	//In chained mode, global l2 port policy has been configured, so enable shared vlan pool
 	AciUseGlobalScopeVlan bool `json:"aci-use-global-scope-vlan,omitempty"`
+
+	// List of secondary-vlans to be used as encaps for additionalnetworks in chained mode
+	AciAdditionalVlans string `json:"aci-additional-vlans,omitempty"`
 }
 
 type netIps struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -178,8 +178,10 @@ type AciController struct {
 	cachedEpgDns             []string
 	vmmClusterFaultSupported bool
 	additionalNetworkCache   map[string]*AdditionalNetworkMeta
-	lldpIfCache              map[string]string
-	globalVlanConfig         globalVlanConfig
+	//Used in Shared mode
+	sharedEncapCache map[int]map[string]*AdditionalNetworkMeta
+	lldpIfCache      map[string]string
+	globalVlanConfig globalVlanConfig
 }
 
 type globalVlanConfig struct {
@@ -376,6 +378,7 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 		nmPortNp:               make(map[string]bool),
 		hppRef:                 make(map[string]hppReference),
 		additionalNetworkCache: make(map[string]*AdditionalNetworkMeta),
+		sharedEncapCache:       make(map[int]map[string]*AdditionalNetworkMeta),
 		lldpIfCache:            make(map[string]string),
 	}
 	cont.syncProcessors = map[string]func() bool{


### PR DESCRIPTION
In globalmode, all NADs using the same
encap, will share a single fabric-wide EPG