### PR TITLE
Added opflex-device-reconnect-wait-timeout parameter

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -230,6 +230,12 @@ type ControllerConfig struct {
 	// Default is false
 	AciMultipod bool `json:"aci-multipod,omitempty"`
 
+	// Timeout in seconds to wait for reconnect when opflexOdev is diconnected for a node
+	// before triggering a dhcp release and renew of vlan interface
+	// Applicable only for multipod case
+	// default is 5s
+	OpflexDeviceReconnectWaitTimeout int `json:"opflex-device-reconnect-wait-timeout,omitempty"`
+
 	// Install Istio ControlPlane components
 	InstallIstio bool `json:"install-istio,omitempty"`
 

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -398,7 +398,8 @@ func (cont *AciController) nodeChanged(obj interface{}) {
 	}
 
 	if cont.config.AciMultipod {
-		nodeAciPod := cont.nodeACIPod[node.ObjectMeta.Name]
+		nodeAciPodAnnot := cont.nodeACIPod[node.ObjectMeta.Name]
+		nodeAciPod := nodeAciPodAnnot.aciPod
 		aciPodAnn := node.ObjectMeta.Annotations[metadata.AciPodAnnotation]
 		if cont.nodeSyncEnabled {
 			if aciPodAnn != nodeAciPod && nodeAciPod != "" {


### PR DESCRIPTION
User can configure opflex-device-reconnect-wait-timeout - the timeout in seconds to wait for reconnect when opflexOdev is diconnected for a node before triggering a dhcp release and renew of vlan interface