### PR TITLE
Support to provide lb ip via annotation

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -217,7 +217,7 @@ type nodePodNetMeta struct {
 }
 
 type serviceMeta struct {
-	requestedIp      net.IP
+	requestedIps     []net.IP
 	ingressIps       []net.IP
 	staticIngressIps []net.IP
 }

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -50,6 +50,9 @@ const ServiceGraphNameAnnotation = "opflex.cisco.com/service-graph-name"
 // Service endpoint annotation
 const ServiceEpAnnotation = "opflex.cisco.com/service-endpoint"
 
+// Static lb ip annotations
+const LbIpAnnotation = "opflex.cisco.com/lb-ipam-ips"
+
 // Annotation to set service contract scope values. If unset or "", defaults to "context"(VRF). Other valid values: "context", "tenant", and "global"
 const ServiceContractScopeAnnotation = "opflex.cisco.com/ext_service_contract_scope"
 


### PR DESCRIPTION
Static lp ip can be provided to the loadbalancer service via annotation in the below format:
"opflex.cisco.com/lb-ipam-ips": "<ipv4>,<ipv6>"

More than one ipv4 or ipv6 is not supported