### PR TITLE
Fix inadvertent shared epg delete

### DIFF
--- a/pkg/controller/nodefabricnetworkattachments.go
+++ b/pkg/controller/nodefabricnetworkattachments.go
@@ -374,8 +374,10 @@ func (cont *AciController) deleteNodeFabNetAttGlobalEncapVlan(vlan int, nodeFabN
 		delete(cont.sharedEncapCache, vlan)
 		return
 	}
+	var apicSlice apicapi.ApicSlice
 	epg := cont.createNodeFabNetAttEpg(vlan, globalScopeVlanEpgPrefix)
-	apicSlice := cont.depopulateFabricPaths(epg, vlan, nodeFabNetAttKey)
+	apicSlice = append(apicSlice, epg)
+	apicSlice = append(apicSlice, cont.depopulateFabricPaths(epg, vlan, nodeFabNetAttKey)...)
 	progMap[labelKey] = apicSlice
 }
 


### PR DESCRIPTION
In cases where 2 NFNa share the same encap, deleting one was deleting the shared epg.