### PR TITLE
Fix for opflex-device-reconnect-wait

### DIFF
--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -511,6 +511,10 @@ func (cont *AciController) nodeDeleted(obj interface{}) {
 			return
 		}
 	}
+
+	if cont.config.AciMultipod {
+		delete(cont.nodeACIPod, node.ObjectMeta.Name)
+	}
 }
 
 // must have index lock


### PR DESCRIPTION
As the poll for olddevices are done in 60s, after detecting the disconnect of opflexodev, the next iteration was done after 60s and thus the dhcp release was triggered after 60s.

Added fix to do dhcp delay after opflex-device-reconnect-wait time after detecting the disconnect of opflexodev