### PR TITLE
Fix CRD scope

### DIFF
--- a/pkg/fabricattachment/apis/aci.fabricattachment/v1/staticfabricnetworkattachment_types.go
+++ b/pkg/fabricattachment/apis/aci.fabricattachment/v1/staticfabricnetworkattachment_types.go
@@ -30,7 +30,6 @@ type StaticFabricNetworkAttachmentSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:shortName=sfna
 // StaticFabricAttachment allows attaching aeps to NAD based and regular vlans created by aci controller
 type StaticFabricNetworkAttachment struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/hostagent/netattachdef_test.go
+++ b/pkg/hostagent/netattachdef_test.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sort"
 	"testing"
 	"time"
 )
@@ -248,7 +249,13 @@ func TestNADMacVlanCRUD(t *testing.T) {
 		actual,
 	)
 	assert.Nil(t, err, "nfna create")
-	assert.Equal(t, expected.Spec, actual.Spec)
+	assert.Equal(t, expected.Spec.EncapVlan, actual.Spec.EncapVlan)
+	assert.Equal(t, expected.Spec.NetworkRef, actual.Spec.NetworkRef)
+	expectedLinks := expected.Spec.AciTopology["bond1"].FabricLink
+	sort.Strings(expectedLinks)
+	actualLinks := actual.Spec.AciTopology["bond1"].FabricLink
+	sort.Strings(actualLinks)
+	assert.Equal(t, expectedLinks, actualLinks)
 	resourceAnnot[vlanAnnot] = "[103-104]"
 	agent.fakeNetAttachDefSource.Modify(testnetattach("macvlan-net2", "default", configJsondata2, resourceAnnot))
 	assert.Eventually(t, func() bool {

--- a/pkg/hostagent/testdata/aci.fabricattachment_staticfabricnetworkattachments.yaml
+++ b/pkg/hostagent/testdata/aci.fabricattachment_staticfabricnetworkattachments.yaml
@@ -11,10 +11,8 @@ spec:
     kind: StaticFabricNetworkAttachment
     listKind: StaticFabricNetworkAttachmentList
     plural: staticfabricnetworkattachments
-    shortNames:
-    - sfna
     singular: staticfabricnetworkattachment
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:


### PR DESCRIPTION
controller-gen changes scope to namespaced if shortname is specified. For now avoid short name.