### PR TITLE
Get OS+arch from go env instead of hard coding

### DIFF
--- a/tools/setup-envtest.bash
+++ b/tools/setup-envtest.bash
@@ -27,8 +27,8 @@ fi
 #To upgrade envtest binaries set the k8sver to 
 # the latest kubecontroller tools version
 k8sver=1.27.1
-goos=linux
-goarch=amd64
+goos=$(go env GOOS)
+goarch=$(go env GOARCH)
 
 FETCHBINARIES=1
 


### PR DESCRIPTION
hostagent UTs were failing for me for a linux VM on arm64