### PR TITLE
Fix shared aep usage

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -277,6 +277,9 @@ var metadata = map[string]*apicMeta{
 		},
 	},
 	"infraGeneric": {
+		hints: map[string]interface{}{
+			"deletable": false,
+		},
 		attributes: map[string]interface{}{
 			"name":      "",
 			"nameAlias": "",

--- a/pkg/controller/nodefabricnetworkattachments.go
+++ b/pkg/controller/nodefabricnetworkattachments.go
@@ -336,11 +336,14 @@ func (cont *AciController) createNodeFabNetAttEpgStaticAttachments(vlan int, aep
 	secondaryPhysDomDn := "uni/phys-" + physDom
 	infraRsDomP := apicapi.NewInfraRsDomP(aepDn, secondaryPhysDomDn)
 	apicSlice = append(apicSlice, infraRsDomP)
+	// Workaround alert: Due to the fact that infraGeneric cannot take
+	// any other name than default, we have to follow this hack of not adding
+	// infraRsFuncToEpg as a child and making infraGeneric not deletable.
 	infraGeneric := apicapi.NewInfraGeneric(aep)
 	encap := fmt.Sprintf("%d", vlan)
 	infraRsFuncToEpg := apicapi.NewInfraRsFuncToEpg(infraGeneric.GetDn(), epg.GetDn(), encap, "regular")
-	infraGeneric.AddChild(infraRsFuncToEpg)
 	apicSlice = append(apicSlice, infraGeneric)
+	apicSlice = append(apicSlice, infraRsFuncToEpg)
 	return apicSlice
 }
 


### PR DESCRIPTION
In case of infraGeneric MO, although model allows more than one MO, in practice a single MO with name default is allowed - APIC bug?. This is created by aci-containers, but not deleted, to allow for shared usage.