### PR TITLE
Fix for port overlap in snat file

### DIFF
--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -631,12 +631,10 @@ func (agent *HostAgent) snaGlobalInfoChanged(snatobj interface{}, logger *logrus
 	logger.Debug("Snat Global info Changed...")
 	globalInfo := snat.Spec.GlobalInfos
 	// This case is possible when all the pods will be deleted from that node
-	if len(globalInfo) < len(agent.opflexSnatGlobalInfos) {
-		for nodename := range agent.opflexSnatGlobalInfos {
-			if _, ok := globalInfo[nodename]; !ok {
-				delete(agent.opflexSnatGlobalInfos, nodename)
-				syncSnat = true
-			}
+	for nodename := range agent.opflexSnatGlobalInfos {
+		if _, ok := globalInfo[nodename]; !ok {
+			delete(agent.opflexSnatGlobalInfos, nodename)
+			syncSnat = true
 		}
 	}
 	for nodename, val := range globalInfo {


### PR DESCRIPTION
When the label in snatpolicy is updated, the snatlocalinfo for previous pod was not getting deleted