### PR TITLE
Fix text file busy error

### DIFF
--- a/docker/launch-hostagent.sh
+++ b/docker/launch-hostagent.sh
@@ -14,6 +14,7 @@ KUBECONFIG=/usr/local/etc/kubeconfig
 if [ -w /mnt/cni-bin ]; then
     # Install CNI plugin binary
     mkdir -p ${CNIBIN}
+    rm -f ${CNIBIN}/*
 if [ -z != $CHAINED_MODE ] && [ "$CHAINED_MODE" == "true" ]; then
     cp ${ACIBIN}/netop-cni $CNIBIN
 fi


### PR DESCRIPTION
- cni binary in use by other containers when restarting host agent will result in the bringup to fail because of the failed copy.