### PR TITLE
version check for serviceBdRoutingDisable metadata

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -328,13 +328,12 @@ var metadata = map[string]*apicMeta{
 	},
 	"fvBD": {
 		attributes: map[string]interface{}{
-			"arpFlood":                "no",
-			"ipLearning":              "yes",
-			"name":                    "",
-			"nameAlias":               "",
-			"unicastRoute":            "yes",
-			"unkMacUcastAct":          "proxy",
-			"serviceBdRoutingDisable": "",
+			"arpFlood":       "no",
+			"ipLearning":     "yes",
+			"name":           "",
+			"nameAlias":      "",
+			"unicastRoute":   "yes",
+			"unkMacUcastAct": "proxy",
 		},
 		children: []string{
 			"fvSubnet",

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -674,6 +674,10 @@ func (conn *ApicConnection) Run(stopCh <-chan struct{}) {
 		return
 	}
 
+	if conn.version >= "6.0(3.84a)" {
+		metadata["fvBD"].attributes["serviceBdRoutingDisable"] = ""
+	}
+
 	for !conn.stopped {
 		func() {
 			defer func() {


### PR DESCRIPTION
Add serviceBdRoutingDisable in metadata of apic only if apic version is 6.0(3.84a) or higher