### PR TITLE
Fix concurrency issue when adding ports

### DIFF
--- a/pkg/hostagent/ovs.go
+++ b/pkg/hostagent/ovs.go
@@ -127,18 +127,22 @@ func (agent *HostAgent) syncPorts(socket string) error {
 	brNames :=
 		[]string{agent.config.AccessBridgeName, agent.config.IntBridgeName}
 
+	agent.indexMutex.Lock()
 	bridges, err := loadBridges(ovs, brNames)
 	if err != nil {
+		agent.indexMutex.Unlock()
 		return err
 	}
 
 	for _, brName := range brNames {
 		if _, ok := bridges[brName]; !ok {
-			return fmt.Errorf("Bridge %s not found", brName)
+			agent.indexMutex.Unlock()
+			return fmt.Errorf("bridge %s not found", brName)
 		}
 	}
 
 	ops := agent.diffPorts(bridges)
+	agent.indexMutex.Unlock()
 	return execTransaction(ovs, ops)
 }
 
@@ -155,7 +159,6 @@ func (agent *HostAgent) diffPorts(bridges map[string]ovsBridge) []libovsdb.Opera
 		}
 	}
 
-	agent.indexMutex.Lock()
 	opid := 0
 	for id, metas := range agent.epMetadata {
 		for _, meta := range metas {
@@ -340,7 +343,6 @@ func (agent *HostAgent) diffPorts(bridges map[string]ovsBridge) []libovsdb.Opera
 			ops = append(ops, delBrPortOp(br.uuid, delports))
 		}
 	}
-	agent.indexMutex.Unlock()
 	return ops
 }
 


### PR DESCRIPTION
Root cause: Concurrency issue when adding ports

Fix: Added locks to serialize the code to get
the bridges and check for new ports.