### PR TITLE
Fix controller not switching to next APIC

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -100,6 +100,7 @@ type ApicConnection struct {
 
 	CachedVersion       string
 	ReconnectInterval   time.Duration
+	ReconnectRetryLimit int
 	RefreshInterval     time.Duration
 	RefreshTickerAdjust time.Duration
 	SubscriptionDelay   time.Duration

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -293,6 +293,9 @@ type ControllerConfig struct {
 
 	// Add external contract to default epg (contract is created for LoadBalancer Service type), default is false
 	AddExternalContractToDefaultEPG bool `json:"add-external-contract-to-default-epg,omitempty"`
+
+	// Number of times the connection to APIC should be retried before switching to another APIC
+	ApicConnectionRetryLimit int `json:"apic-connection-retry-limit,omitempty"`
 }
 
 type netIps struct {


### PR DESCRIPTION
Root cause:
This occurs when the controller comes up and the first APIC is already down.

The controller tries to get the APIC version, and in the GetVersion method when the APIC login fails we keep on retrying the login hence the rollover is not happening.

Fix:
Add retry limit and rollover to the next APIC.