### PR TITLE
Add pod-subet and node ips as remoteIp in hpp

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -181,7 +181,7 @@ type ControllerConfig struct {
 
 	// Pod subnet CIDRs in the form <gateway-address>/<prefix-length> that
 	// cover all pod-ip-pools
-	PodSubnets []string `json:"pod-subnets,omitempty"`
+	PodSubnet []string `json:"pod-subnet,omitempty"`
 
 	// Whether to allocate service IPs or to assume they will be
 	// allocated by another controller

--- a/pkg/controller/config_test.go
+++ b/pkg/controller/config_test.go
@@ -59,7 +59,7 @@ func TestInitFlags(t *testing.T) {
 		AciExtNetworks:                    nil,
 		PodIpPool:                         nil,
 		PodIpPoolChunkSize:                0,
-		PodSubnets:                        nil,
+		PodSubnet:                         nil,
 		AllocateServiceIps:                nil,
 		ServiceIpPool:                     nil,
 		StaticServiceIpPool:               nil,


### PR DESCRIPTION
Add pod-subet and node ips as remoteIp in hpp for the networkpolicies which allow traffic from all pods in all namespaces, ie for the following cases:
	ingress:
	- from:
	  - namespaceSelector: {} podSelector: {}

	ingress:
	- from:
	  - namespaceSelector: {}