### PR TITLE
Check for stale ports and start fresh if present

### DIFF
--- a/docker/launch-ovs.sh
+++ b/docker/launch-ovs.sh
@@ -12,6 +12,15 @@ ${OVSCTL} start --system-id=${SYS_ID}
 ${VSCTL} set Open_vSwitch . other_config:hw-offload=true
 ${OVSCTL} restart --system-id=${SYS_ID}
 
+# Cleanup
+if ovs-vsctl show | grep "No such device"; then
+    echo "Found Stale devices, cleaning up"
+    ${OVSCTL} stop
+    rm $PREFIX/etc/openvswitch/conf.db
+    rm $PREFIX/var/lib/opflex-agent-ovs/endpoints/*.ep
+    ${OVSCTL} start --system-id=${SYS_ID}
+fi
+
 # Create OVS bridges if needed
 dpid=0
 for i in br-int br-access; do

--- a/docker/travis/build-openvswitch-travis.sh
+++ b/docker/travis/build-openvswitch-travis.sh
@@ -42,6 +42,7 @@ docker cp -L $id:/usr/local/bin build/openvswitch/dist/usr/local
 docker cp -L $id:/usr/local/sbin build/openvswitch/dist/usr/local
 docker cp -L $id:/usr/local/share build/openvswitch/dist/usr/local
 docker rm -v $id
+cp $DOCKER_DIR/init-ovs.sh build/openvswitch/dist/usr/local/bin
 cp $DOCKER_DIR/launch-ovs.sh build/openvswitch/dist/usr/local/bin
 cp $DOCKER_DIR/liveness-ovs.sh build/openvswitch/dist/usr/local/bin
 mkdir build/openvswitch/dist/licenses
@@ -49,5 +50,7 @@ cp $DOCKER_DIR/../licenses/* build/openvswitch/dist/licenses
 cp dist-static/ovsresync build/openvswitch/dist/usr/local/bin
 
 echo "building final image"
+cp $DOCKER_DIR/Dockerfile-openvswitch-init build/openvswitch
 cp $DOCKER_DIR/Dockerfile-openvswitch build/openvswitch
+docker build $BUILDARG -t $DOCKER_HUB_ID/init-openvswitch:$DOCKER_TAG -f ./build/openvswitch/Dockerfile-openvswitch-init build/openvswitch/dist
 docker build $BUILDARG -t $DOCKER_HUB_ID/openvswitch:$DOCKER_TAG -f ./build/openvswitch/Dockerfile-openvswitch build/openvswitch/dist

--- a/docker/travis/launch-ovs.sh
+++ b/docker/travis/launch-ovs.sh
@@ -11,6 +11,15 @@ export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
 # Start OVS
 ${OVSCTL} start --system-id=${SYS_ID}
 
+# Cleanup
+if ovs-vsctl show | grep "No such device"; then
+    echo "Found Stale devices, cleaning up"
+    ${OVSCTL} stop
+    rm $PREFIX/etc/openvswitch/conf.db
+    rm $PREFIX/var/lib/opflex-agent-ovs/endpoints/*.ep
+    ${OVSCTL} start --system-id=${SYS_ID}
+fi
+
 # Create OVS bridges if needed
 dpid=0
 for i in br-int br-access; do


### PR DESCRIPTION
- stale ports can show up on reboot because we do not have any reboot cleanup triggers. This causes extra work for host-agent pod and by cleaning up database we can avoid the extra work
- the host-agent is resiliant enough that a sync is not needed. so say if host-ag came up first and added anything it will be redone. However we can use the same reboot.conf.d logic used in opflex for host-agent since it has access to the same file structure.