### PR TITLE
Restart host-agent when reboot.conf is updated

### DIFF
--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -181,6 +181,10 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 	env.agent.updateOpflexConfig()
 	go env.agent.runTickers(stopCh)
 
+	if env.agent.integ_test == nil {
+		go env.agent.watchRebootConf(stopCh)
+	}
+
 	env.agent.log.Debug("Starting node informer")
 	go env.agent.nodeInformer.Run(stopCh)
 	env.agent.log.Info("Waiting for node cache sync")


### PR DESCRIPTION
When reboot.conf is updated by opflex-agent, restart the aci-containers-host container