### PR TITLE
Fix to delete metatdata file after upgrade

### DIFF
--- a/pkg/hostagent/setup.go
+++ b/pkg/hostagent/setup.go
@@ -888,10 +888,15 @@ func (agent *HostAgent) unconfigureContainerIfaces(metadataArg *md.ContainerMeta
 	}
 	agent.indexMutex.Unlock()
 
+	networkName := metadata.Network.NetworkName
+	if networkName == "" && !agent.config.ChainedMode {
+		networkName = agent.config.CniNetwork
+	}
 	err := md.ClearMetadata(agent.config.CniMetadataDir,
-		metadata.Network.NetworkName, metadataArg.Id.ContId)
+		networkName, metadataArg.Id.ContId)
 	if isRelevantConfig {
 		if err != nil {
+			logger.Error("Failed to ClearMetadata ")
 			return err
 		}
 	}


### PR DESCRIPTION
Metadata file before 6.0 release doesn't have network field. Deleting a metadata file in 6.0+ releases which is created in an older release was failing as the Network.NetworkName field is empty