### PR TITLE
Use external version for serviceBd check

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -674,7 +674,7 @@ func (conn *ApicConnection) Run(stopCh <-chan struct{}) {
 		return
 	}
 
-	if conn.version >= "6.0(3.84a)" {
+	if conn.version >= "6.0(4c)" {
 		metadata["fvBD"].attributes["serviceBdRoutingDisable"] = ""
 	}
 

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -235,7 +235,7 @@ func (cont *AciController) staticServiceObjs() apicapi.ApicSlice {
 	// Service bridge domain
 	bdName := cont.aciNameForKey("bd", cont.env.ServiceBd())
 	bd := apicapi.NewFvBD(cont.config.AciVrfTenant, bdName)
-	if apicapi.ApicVersion >= "6.0(3.84a)" {
+	if apicapi.ApicVersion >= "6.0(4c)" {
 		bd.SetAttr("serviceBdRoutingDisable", "yes")
 	}
 	bd.SetAttr("arpFlood", "yes")


### PR DESCRIPTION
Internal versions cannot be compared against external versions directly. Use external version for comparison.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit a2d9adba2d9e6c0cfa626af3cff0678c9c2b3916)