### PR TITLE
Add taint if node NotReady, remove after host-agent initialization

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -299,6 +299,9 @@ type ControllerConfig struct {
 
 	// Disable hpp rendering if set to true
 	DisableHppRendering bool `json:"disable-hpp-rendering,omitempty"`
+
+	// Enable/disable making node unschedulable when it's not ready
+	TaintNotReadyNode bool `json:"taint-not-ready-node,omitempty"`
 }
 
 type netIps struct {

--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -233,6 +233,7 @@ func testAgentInit(agent *testHostAgent) *testHostAgent {
 		}
 		agent.FabricDiscoveryPopulateAdjacencies(FabricDiscoveryMethodLLDPNMState, adjs)
 	}
+	agent.taintRemoved.Store(true)
 	return agent
 }
 

--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -281,6 +281,9 @@ type HostAgentConfig struct {
 
 	// Disable hpp rendering if set to true
 	DisableHppRendering bool `json:"disable-hpp-rendering,omitempty"`
+
+	// Enable/disable making node unschedulable when it's not ready
+	TaintNotReadyNode bool `json:"taint-not-ready-node,omitempty"`
 }
 
 func (config *HostAgentConfig) InitFlags() {


### PR DESCRIPTION
Description: To make node unschedulable if it's not in Ready state till the node becomes Ready and host-agent initialization is complete.

Taint:
aci-containers-host/unavailable:NoSchedule