### PR TITLE
Touch endpoint file after adding port

### DIFF
--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -53,6 +53,7 @@ type HostAgent struct {
 	indexMutex           sync.Mutex
 	vethMutex            sync.Mutex
 	ipamMutex            sync.Mutex
+	epfileMutex          sync.Mutex
 	snatPolicyLabelMutex sync.RWMutex
 	snatPolicyCacheMutex sync.RWMutex
 

--- a/pkg/hostagent/ovs.go
+++ b/pkg/hostagent/ovs.go
@@ -223,6 +223,19 @@ func (agent *HostAgent) diffPorts(bridges map[string]ovsBridge) []libovsdb.Opera
 						agent.log.Error(err)
 					}
 					ops = append(ops, adds...)
+					epUuid, ok := agent.cniToPodID[id]
+					if ok {
+						epfilename := epUuid + "_" + meta.Id.ContId + "_" + iface.HostVethName
+						epfile := agent.FormEPFilePath(epfilename)
+						agent.epfileMutex.Lock()
+						touch, err := touchFileIfExists(epfile)
+						agent.epfileMutex.Unlock()
+						if err != nil {
+							agent.log.Error("Failed to touch file ", epfile, " : ", err)
+						} else if touch {
+							agent.log.Debug("Touched endpoint file for pod ", id, " : ", epfilename)
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When endpoint file for a pod is created first and if the ports for the interface are added later, the endpoint updates will not create any flows as the port is missing and when the port is added opflex-agent will not be notified

Added code to touch endpoint file when port is added so that opflex-agent will get notified