### PR TITLE
Fix for processing networkpolicy to allow specific protocol traffic

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -754,6 +754,16 @@ func (cont *AciController) buildNetPolSubjRules(ruleName string,
 						"ipv6", proto, port, remoteSubnets, addPodSubnetAsRemIp)
 				}
 			}
+			if len(portList) == 0 && proto != "" {
+				if !cont.configuredPodNetworkIps.V4.Empty() {
+					cont.buildNetPolSubjRule(subj, ruleName+"_"+strconv.Itoa(j), direction,
+						"ipv4", proto, "", remoteSubnets, addPodSubnetAsRemIp)
+				}
+				if !cont.configuredPodNetworkIps.V6.Empty() {
+					cont.buildNetPolSubjRule(subj, ruleName+"_"+strconv.Itoa(j), direction,
+						"ipv6", proto, "", remoteSubnets, addPodSubnetAsRemIp)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Networkpolicy to allow any port traffic to a server on a specific protocol was failing as rule was not created for a networkpolicy with no port number mentioned, but has protocol.

Modified code to add rule for a networkpolicy with protocol without port.