### PR TITLE
Sort nodes selected for snat service redirect policy

### DIFF
--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1027,6 +1027,11 @@ func (cont *AciController) updateServiceDeviceInstanceSnat(key string) error {
 		return nil
 	}
 	nodeMap := make(map[string]*metadata.ServiceEndpoint)
+	sort.Slice(nodeList, func(i, j int) bool {
+		nodeA := nodeList[i].(*v1.Node)
+		nodeB := nodeList[j].(*v1.Node)
+		return nodeA.ObjectMeta.Name < nodeB.ObjectMeta.Name
+	})
 	for itr, nodeItem := range nodeList {
 		if itr == cont.config.MaxSvcGraphNodes {
 			break


### PR DESCRIPTION
If number of nodes in the cluster is greater than the maximum number of nodes supported for service graph, the nodes selected for the service graph might be different each time if we don't sort the nodes.

Sorted the nodes based on name of node to avoid having a different node list each time.