### PR TITLE
Separate queue for svcRedirectPol and lDevVip

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -134,8 +134,9 @@ type ApicConnection struct {
 	pendingSubDnUpdate map[string]pendingChange
 	CachedSubnetDns    map[string]string
 
-	deltaQueue workqueue.RateLimitingInterface
-	odevQueue  workqueue.RateLimitingInterface
+	deltaQueue    workqueue.RateLimitingInterface
+	odevQueue     workqueue.RateLimitingInterface
+	priorityQueue workqueue.RateLimitingInterface
 }
 
 func (s ApicSlice) Len() int {


### PR DESCRIPTION
When vm migration is completed, fabricPath of opflexODev gets updated and controller recomputes lDevVip and svcRedirectPol. The updates of these objects are sent with higher priority to apic for uninterupted snat traffic.