### PR TITLE
Do VLAN programming upfront for OpenShift on OpenStack

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -191,10 +191,12 @@ type AciController struct {
 	sharedEncapNfcVlanMap  map[int]*NfcData
 	sharedEncapNfcLabelMap map[string]*NfcData
 	// nadVlanMap encapLabel to vlan
-	sharedEncapLabelMap map[string][]int
-	lldpIfCache         map[string]string
-	globalVlanConfig    globalVlanConfig
-	fabricVlanPoolMap   map[string]map[string]string
+	sharedEncapLabelMap      map[string][]int
+	lldpIfCache              map[string]string
+	globalVlanConfig         globalVlanConfig
+	fabricVlanPoolMap        map[string]map[string]string
+	openStackFabricPathDnMap map[string]openstackOpflexOdevInfo
+	openStackSystemId        string
 }
 
 type NfcData struct {
@@ -240,6 +242,11 @@ type nodePodNetMeta struct {
 	nodePods            map[string]bool
 	podNetIps           metadata.NetIps
 	podNetIpsAnnotation string
+}
+
+type openstackOpflexOdevInfo struct {
+	opflexODevDn map[string]struct{}
+	fabricPathDn string
 }
 
 type serviceMeta struct {
@@ -403,29 +410,30 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 		nodeACIPodAnnot:  make(map[string]aciPodAnnot),
 		nodeOpflexDevice: make(map[string]apicapi.ApicSlice),
 
-		nodeServiceMetaCache:   make(map[string]*nodeServiceMeta),
-		nodePodNetCache:        make(map[string]*nodePodNetMeta),
-		serviceMetaCache:       make(map[string]*serviceMeta),
-		snatPolicyCache:        make(map[string]*ContSnatPolicy),
-		snatServices:           make(map[string]bool),
-		snatNodeInfoCache:      make(map[string]*nodeinfo.NodeInfo),
-		rdConfigCache:          make(map[string]*rdConfig.RdConfig),
-		rdConfigSubnetCache:    make(map[string]*rdConfig.RdConfigSpec),
-		podIftoEp:              make(map[string]*EndPointData),
-		snatGlobalInfoCache:    make(map[string]map[string]*snatglobalinfo.GlobalInfo),
-		istioCache:             make(map[string]*istiov1.AciIstioOperator),
-		crdHandlers:            make(map[string]func(*AciController, <-chan struct{})),
-		ctrPortNameCache:       make(map[string]*ctrPortNameEntry),
-		nmPortNp:               make(map[string]bool),
-		hppRef:                 make(map[string]hppReference),
-		additionalNetworkCache: make(map[string]*AdditionalNetworkMeta),
-		sharedEncapCache:       make(map[int]*sharedEncapData),
-		sharedEncapNfcCache:    make(map[int]*NfcData),
-		sharedEncapNfcVlanMap:  make(map[int]*NfcData),
-		sharedEncapNfcLabelMap: make(map[string]*NfcData),
-		sharedEncapLabelMap:    make(map[string][]int),
-		lldpIfCache:            make(map[string]string),
-		fabricVlanPoolMap:      make(map[string]map[string]string),
+		nodeServiceMetaCache:     make(map[string]*nodeServiceMeta),
+		nodePodNetCache:          make(map[string]*nodePodNetMeta),
+		serviceMetaCache:         make(map[string]*serviceMeta),
+		snatPolicyCache:          make(map[string]*ContSnatPolicy),
+		snatServices:             make(map[string]bool),
+		snatNodeInfoCache:        make(map[string]*nodeinfo.NodeInfo),
+		rdConfigCache:            make(map[string]*rdConfig.RdConfig),
+		rdConfigSubnetCache:      make(map[string]*rdConfig.RdConfigSpec),
+		podIftoEp:                make(map[string]*EndPointData),
+		snatGlobalInfoCache:      make(map[string]map[string]*snatglobalinfo.GlobalInfo),
+		istioCache:               make(map[string]*istiov1.AciIstioOperator),
+		crdHandlers:              make(map[string]func(*AciController, <-chan struct{})),
+		ctrPortNameCache:         make(map[string]*ctrPortNameEntry),
+		nmPortNp:                 make(map[string]bool),
+		hppRef:                   make(map[string]hppReference),
+		additionalNetworkCache:   make(map[string]*AdditionalNetworkMeta),
+		sharedEncapCache:         make(map[int]*sharedEncapData),
+		sharedEncapNfcCache:      make(map[int]*NfcData),
+		sharedEncapNfcVlanMap:    make(map[int]*NfcData),
+		sharedEncapNfcLabelMap:   make(map[string]*NfcData),
+		sharedEncapLabelMap:      make(map[string][]int),
+		lldpIfCache:              make(map[string]string),
+		fabricVlanPoolMap:        make(map[string]map[string]string),
+		openStackFabricPathDnMap: make(map[string]openstackOpflexOdevInfo),
 	}
 	cont.syncProcessors = map[string]func() bool{
 		"snatGlobalInfo": cont.syncSnatGlobalInfo,
@@ -787,6 +795,9 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	if len(cont.config.ApicHosts) != 0 && !cont.config.ChainedMode {
 		cont.BuildSubnetDnCache(cont.config.AciVrfDn, cont.config.AciVrfDn)
 		cont.scheduleRdConfig()
+		if strings.Contains(cont.config.Flavor, "openstack") {
+			cont.setOpenStackSystemId()
+		}
 	}
 
 	if !cont.config.ChainedMode {


### PR DESCRIPTION
For OpenShift on OpenStack clusters, vnsRsCIfPathAtt is created for each OpenStack compute hosts along with OpenShift nodes so that VLAN will already be there when a vm is migrated from one compute host to other.