### PR TITLE
Fix Service with dynamic allocation takes IP out of static pool

### DIFF
--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1767,7 +1767,9 @@ func (cont *AciController) allocateServiceIps(servicekey string,
 		cont.removeIpFromIngressIPList(&ingressIps, ipv6)
 	}
 
-	meta.ingressIps = ingressIps
+	if len(requestedIps) < 1 {
+		meta.ingressIps = ingressIps
+	}
 	if ipv4 == nil && ipv6 == nil {
 		logger.Error("No IP addresses available for service")
 		cont.indexMutex.Unlock()
@@ -1776,6 +1778,9 @@ func (cont *AciController) allocateServiceIps(servicekey string,
 	cont.indexMutex.Unlock()
 	var newIngress []v1.LoadBalancerIngress
 	for _, ip := range meta.ingressIps {
+		newIngress = append(newIngress, v1.LoadBalancerIngress{IP: ip.String()})
+	}
+	for _, ip := range meta.staticIngressIps {
 		newIngress = append(newIngress, v1.LoadBalancerIngress{IP: ip.String()})
 	}
 
@@ -1796,7 +1801,7 @@ func (cont *AciController) allocateServiceIps(servicekey string,
 	success := true
 	reason := "Success"
 	message := ""
-	if len(requestedIps) > 0 && len(requestedIps) != len(meta.ingressIps) {
+	if len(requestedIps) > 0 && len(requestedIps) != len(meta.staticIngressIps) {
 		success = false
 		reason = "OneIpNotAllocatable"
 		message = "One of the requested Ips is not allocatable"


### PR DESCRIPTION
Root Cause:
The IP of statically allocated service was getting added to the list of ingress IPs which are dynamically allocated, and from there added to the list of avaialble service IPs, so this new added IP was allocated to the service with dynamic allocation.

Added check to add only the dynamic allocation IPs to the corresponding list.