### PR TITLE
Fix APIC sync not complete when hpp rendering is disabled

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -761,16 +761,14 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		qs := make([]workqueue.RateLimitingInterface, 0)
 		_, ok := cont.env.(*K8sEnvironment)
 		if ok {
+			qs = []workqueue.RateLimitingInterface{cont.podQueue}
 			if !cont.config.ChainedMode {
-				qs = []workqueue.RateLimitingInterface{
-					cont.podQueue, cont.netPolQueue, cont.qosQueue,
-					cont.serviceQueue, cont.snatQueue, cont.netflowQueue,
-					cont.snatNodeInfoQueue, cont.rdConfigQueue, cont.erspanQueue,
+				if !cont.config.DisableHppRendering {
+					qs = append(qs, cont.netPolQueue)
 				}
-			} else {
-				qs = []workqueue.RateLimitingInterface{
-					cont.podQueue,
-				}
+				qs = append(qs, cont.qosQueue, cont.serviceQueue,
+					cont.snatQueue, cont.netflowQueue, cont.snatNodeInfoQueue,
+					cont.rdConfigQueue, cont.erspanQueue)
 			}
 		}
 		for _, q := range qs {


### PR DESCRIPTION
Issue and Root cause:
When disable-hpp-rendering config flag is set to true, processing of the netPolQueue is skipped. Before APIC sync, we put a channel into all the work queues and wait on these channels to check if all the work queues are processed. As netPolQueue is not processed when disable-hpp-rendering is true, the channel is not closed causing the process to wait forever and the checkpoint will not be completed, so APIC sync will not be complete.

Fix:
Skipped adding channel to netPolQueue when disable-hpp-rendering config flag is set to true.