### PR TITLE
Add missing unit tests

### DIFF
--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -200,6 +200,20 @@ func TestServiceIp(t *testing.T) {
 	}
 	{
 		cont.serviceUpdates = nil
+		service1 := service("testns", "service1", "10.4.2.5")
+		service1.Status.Conditions = []metav1.Condition{
+			{
+				Status:  metav1.ConditionTrue,
+				Type:    "LbIpamAllocation",
+				Reason:  "Success",
+				Message: "",
+			},
+		}
+		cont.fakeServiceSource.Add(service1)
+		waitForSStatus(t, cont, []string{"10.4.2.5"}, "Success", "Update request")
+	}
+	{
+		cont.serviceUpdates = nil
 		cont.fakeServiceSource.Add(service("testns", "service4", ""))
 		waitForSStatus(t, cont, []string{"10.4.1.2"}, "Success", "next ip from pool")
 	}

--- a/pkg/hostagent/fabricvlanpools_test.go
+++ b/pkg/hostagent/fabricvlanpools_test.go
@@ -1,0 +1,71 @@
+// Copyright 2023 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hostagent
+
+import (
+	"testing"
+
+	fabattv1 "github.com/noironetworks/aci-containers/pkg/fabricattachment/apis/aci.fabricattachment/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetGlobalFabricVlanPool(t *testing.T) {
+	agent := &HostAgent{
+		fabricVlanPoolMap: map[string]map[string]string{
+			"aci-containers-system": {
+				"default": "[3023,3700-3701,3801,3804-3805,3826-3827,3829-3830,3840,3850-3852,3877-3879]",
+			},
+		},
+	}
+
+	expected := "3023,3700-3701,3801,3804-3805,3826-3827,3829-3830,3840,3850-3852,3877-3879"
+	result := agent.getGlobalFabricVlanPool()
+
+	assert.Equal(t, expected, result, "global fabric vlan pool")
+}
+
+func TestFabricVlanPoolDeleted(t *testing.T) {
+	agent := testAgent()
+	fabricVlanPoolMap := map[string]map[string]string{
+		"aci-containers-system": {
+			"default":    "[3023,3700-3701,3801,3804-3805,3826-3827,3829-3830,3840,3850-3852,3877-3879]",
+			"additional": "[100]",
+		},
+	}
+
+	agent.fabricVlanPoolMap = fabricVlanPoolMap
+
+	obj := &fabattv1.FabricVlanPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "default",
+			Namespace: "aci-containers-system",
+		},
+		Spec: fabattv1.FabricVlanPoolSpec{
+			Vlans: []string{"102", "105"},
+		},
+	}
+
+	agent.fabricVlanPoolDeleted(obj)
+
+	expectedMap := map[string]map[string]string{
+		"aci-containers-system": {"additional": "[100]"},
+	}
+	assert.Equal(t, expectedMap, agent.fabricVlanPoolMap, "fabricVlanPoolMap")
+
+	expectedGlobalPool := "100"
+	result := agent.getGlobalFabricVlanPool()
+	assert.Equal(t, expectedGlobalPool, result, "global fabric vlan pool")
+}

--- a/pkg/hostagent/ipam_test.go
+++ b/pkg/hostagent/ipam_test.go
@@ -1,0 +1,151 @@
+// Copyright 2017 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// IP address management for host agent
+
+package hostagent
+
+import (
+	"net"
+	"reflect"
+	"testing"
+
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/noironetworks/aci-containers/pkg/ipam"
+	"github.com/noironetworks/aci-containers/pkg/metadata"
+	"github.com/sirupsen/logrus"
+)
+
+func TestDeallocateIpsLocked(t *testing.T) {
+	agent := testAgent()
+	agent.run()
+	defer agent.stop()
+
+	agent.usedIPs = make(map[string]string)
+	agent.usedIPs["192.168.0.1"] = "test"
+	agent.usedIPs["2001:db8::1"] = "test"
+
+	iface := &metadata.ContainerIfaceMd{
+		IPs: []metadata.ContainerIfaceIP{
+			{Address: net.IPNet{IP: net.ParseIP("192.168.0.1")}},
+			{Address: net.IPNet{IP: net.ParseIP("2001:db8::1")}},
+		},
+	}
+
+	agent.deallocateIpsLocked(iface)
+
+	for _, ip := range iface.IPs {
+		if _, ok := agent.usedIPs[ip.Address.IP.String()]; ok {
+			t.Errorf("IP %v was not deallocated", ip.Address.IP)
+		}
+	}
+
+	if len(agent.usedIPs) != 0 {
+		t.Errorf("usedIPs map is not empty")
+	}
+}
+func TestConvertRoutes(t *testing.T) {
+	routes := []route{
+		{
+			Dst: cnitypes.IPNet{
+				IP:   net.ParseIP("192.168.0.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			GW: net.ParseIP("192.168.0.1"),
+		},
+		{
+			Dst: cnitypes.IPNet{
+				IP:   net.ParseIP("10.0.0.0"),
+				Mask: net.CIDRMask(16, 32),
+			},
+			GW: net.ParseIP("10.0.0.1"),
+		},
+	}
+
+	expected := []*cnitypes.Route{
+		{
+			Dst: net.IPNet{
+				IP:   net.ParseIP("192.168.0.0"),
+				Mask: net.CIDRMask(24, 32),
+			},
+			GW: net.ParseIP("192.168.0.1"),
+		},
+		{
+			Dst: net.IPNet{
+				IP:   net.ParseIP("10.0.0.0"),
+				Mask: net.CIDRMask(16, 32),
+			},
+			GW: net.ParseIP("10.0.0.1"),
+		},
+	}
+
+	cniroutes := convertRoutes(routes)
+
+	if len(cniroutes) != len(expected) {
+		t.Errorf("Expected %d routes, but got %d", len(expected), len(cniroutes))
+	}
+
+	for i, route := range cniroutes {
+		if !reflect.DeepEqual(route, expected[i]) {
+			t.Errorf("Expected route %v, but got %v", expected[i], route)
+		}
+	}
+}
+func TestRebuildIpam(t *testing.T) {
+	agent := &HostAgent{}
+	log := logrus.New()
+	agent.log = log
+	agent.usedIPs = map[string]string{
+		"192.168.0.1": "test",
+		"50":          "test",
+		"2001:db8::1": "test",
+	}
+
+	agent.podIps = ipam.NewIpCache()
+	agent.podIps.DeallocateIp(net.ParseIP("192.168.0.2"))
+	agent.podIps.DeallocateIp(net.ParseIP("2001:db8::2"))
+
+	agent.rebuildIpam()
+
+	if len(agent.usedIPs) == 0 {
+		t.Errorf("usedIPs map is empty")
+	}
+
+	expectedV4 := []ipam.IpRange{
+		{Start: net.ParseIP("192.168.0.2"), End: net.ParseIP("192.168.0.2")},
+	}
+	expectedV6 := []ipam.IpRange{
+		{Start: net.ParseIP("2001:db8::2"), End: net.ParseIP("2001:db8::2")},
+	}
+
+	if !reflect.DeepEqual(agent.podIps.CombineV4(), expectedV4) {
+		t.Errorf("Expected V4 ranges %v, but got %v", expectedV4, agent.podIps.CombineV4())
+	}
+
+	if !reflect.DeepEqual(agent.podIps.CombineV6(), expectedV6) {
+		t.Errorf("Expected V6 ranges %v, but got %v", expectedV6, agent.podIps.CombineV6())
+	}
+
+	agent.podIps.DeallocateIp(net.ParseIP("192.168.0.1"))
+	agent.podIps.DeallocateIp(net.ParseIP("2001:db8::1"))
+
+	agent.usedIPs["192.168.0.2"] = "test1"
+	agent.usedIPs["2001:db8::2"] = "test1"
+
+	agent.rebuildIpam()
+
+	if len(agent.podIps.CombineV4()) != 0 || len(agent.podIps.CombineV6()) != 0 {
+		t.Errorf("podIps map is not empty")
+	}
+}


### PR DESCRIPTION
Added UTs for hostagent/fabricvlanpools.go, hostagent/ipam.go. Added UT for the case where the static IP of service is updated and the status conditions are not changed.