### PR TITLE
NFC CRD fixes and enhancements

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -470,9 +470,10 @@ func NewFvRsDomAttPhysDom(parentDn, physDom string) ApicObject {
 	return ret
 }
 
-func NewFvAP(ap string) ApicObject {
+func NewFvAP(tenant, ap string) ApicObject {
 	ret := newApicObject("fvAp")
 	ret["fvAp"].Attributes["name"] = ap
+	ret["fvAp"].HintDn = fmt.Sprintf("uni/tn-%s/ap-%s", tenant, ap)
 	return ret
 }
 

--- a/pkg/apicapi/apic_types_test.go
+++ b/pkg/apicapi/apic_types_test.go
@@ -597,7 +597,7 @@ func TestNewFvRsDomAttPhysDom(t *testing.T) {
 
 func TestNewFvAP(t *testing.T) {
 	ap := "testAp"
-	obj := NewFvAP(ap)
+	obj := NewFvAP("testTenant", ap)
 	assert.NotNil(t, obj)
 
 	assert.Equal(t, ap, obj.GetAttr("name"))

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -187,9 +187,10 @@ type AciController struct {
 	//Used in Shared mode
 	sharedEncapCache map[int]*sharedEncapData
 	// vlan to propertiesList
-	sharedEncapNfcCache    map[int]*NfcData
-	sharedEncapNfcVlanMap  map[int]*NfcData
-	sharedEncapNfcLabelMap map[string]*NfcData
+	sharedEncapNfcCache         map[int]*NfcData
+	sharedEncapNfcVlanMap       map[int]*NfcData
+	sharedEncapNfcLabelMap      map[string]*NfcData
+	sharedEncapNfcAppProfileMap map[string]map[int]bool
 	// nadVlanMap encapLabel to vlan
 	sharedEncapLabelMap      map[string][]int
 	lldpIfCache              map[string]string
@@ -410,30 +411,31 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 		nodeACIPodAnnot:  make(map[string]aciPodAnnot),
 		nodeOpflexDevice: make(map[string]apicapi.ApicSlice),
 
-		nodeServiceMetaCache:     make(map[string]*nodeServiceMeta),
-		nodePodNetCache:          make(map[string]*nodePodNetMeta),
-		serviceMetaCache:         make(map[string]*serviceMeta),
-		snatPolicyCache:          make(map[string]*ContSnatPolicy),
-		snatServices:             make(map[string]bool),
-		snatNodeInfoCache:        make(map[string]*nodeinfo.NodeInfo),
-		rdConfigCache:            make(map[string]*rdConfig.RdConfig),
-		rdConfigSubnetCache:      make(map[string]*rdConfig.RdConfigSpec),
-		podIftoEp:                make(map[string]*EndPointData),
-		snatGlobalInfoCache:      make(map[string]map[string]*snatglobalinfo.GlobalInfo),
-		istioCache:               make(map[string]*istiov1.AciIstioOperator),
-		crdHandlers:              make(map[string]func(*AciController, <-chan struct{})),
-		ctrPortNameCache:         make(map[string]*ctrPortNameEntry),
-		nmPortNp:                 make(map[string]bool),
-		hppRef:                   make(map[string]hppReference),
-		additionalNetworkCache:   make(map[string]*AdditionalNetworkMeta),
-		sharedEncapCache:         make(map[int]*sharedEncapData),
-		sharedEncapNfcCache:      make(map[int]*NfcData),
-		sharedEncapNfcVlanMap:    make(map[int]*NfcData),
-		sharedEncapNfcLabelMap:   make(map[string]*NfcData),
-		sharedEncapLabelMap:      make(map[string][]int),
-		lldpIfCache:              make(map[string]string),
-		fabricVlanPoolMap:        make(map[string]map[string]string),
-		openStackFabricPathDnMap: make(map[string]openstackOpflexOdevInfo),
+		nodeServiceMetaCache:        make(map[string]*nodeServiceMeta),
+		nodePodNetCache:             make(map[string]*nodePodNetMeta),
+		serviceMetaCache:            make(map[string]*serviceMeta),
+		snatPolicyCache:             make(map[string]*ContSnatPolicy),
+		snatServices:                make(map[string]bool),
+		snatNodeInfoCache:           make(map[string]*nodeinfo.NodeInfo),
+		rdConfigCache:               make(map[string]*rdConfig.RdConfig),
+		rdConfigSubnetCache:         make(map[string]*rdConfig.RdConfigSpec),
+		podIftoEp:                   make(map[string]*EndPointData),
+		snatGlobalInfoCache:         make(map[string]map[string]*snatglobalinfo.GlobalInfo),
+		istioCache:                  make(map[string]*istiov1.AciIstioOperator),
+		crdHandlers:                 make(map[string]func(*AciController, <-chan struct{})),
+		ctrPortNameCache:            make(map[string]*ctrPortNameEntry),
+		nmPortNp:                    make(map[string]bool),
+		hppRef:                      make(map[string]hppReference),
+		additionalNetworkCache:      make(map[string]*AdditionalNetworkMeta),
+		sharedEncapCache:            make(map[int]*sharedEncapData),
+		sharedEncapNfcCache:         make(map[int]*NfcData),
+		sharedEncapNfcVlanMap:       make(map[int]*NfcData),
+		sharedEncapNfcLabelMap:      make(map[string]*NfcData),
+		sharedEncapNfcAppProfileMap: make(map[string]map[int]bool),
+		sharedEncapLabelMap:         make(map[string][]int),
+		lldpIfCache:                 make(map[string]string),
+		fabricVlanPoolMap:           make(map[string]map[string]string),
+		openStackFabricPathDnMap:    make(map[string]openstackOpflexOdevInfo),
 	}
 	cont.syncProcessors = map[string]func() bool{
 		"snatGlobalInfo": cont.syncSnatGlobalInfo,

--- a/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricconfiguration_types.go
+++ b/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricconfiguration_types.go
@@ -32,10 +32,13 @@ type Contracts struct {
 }
 
 type Epg struct {
-	Name      string       `json:"name,omitempty"`
-	Tenant    string       `json:"tenant,omitempty"`
-	Contracts Contracts    `json:"contracts,omitempty"`
-	BD        BridgeDomain `json:"bd,omitempty"`
+	ApplicationProfile string       `json:"applicationProfile,omitempty"`
+	Name               string       `json:"name,omitempty"`
+	Tenant             string       `json:"tenant,omitempty"`
+	Contracts          Contracts    `json:"contracts,omitempty"`
+	BD                 BridgeDomain `json:"bd,omitempty"`
+	// +kubebuilder:default=true
+	LLDPDiscovery bool `json:"lldpDiscovery,omitempty"`
 }
 
 type VlanRef struct {

--- a/pkg/fabricattachment/applyconfiguration/aci.fabricattachment/v1/epg.go
+++ b/pkg/fabricattachment/applyconfiguration/aci.fabricattachment/v1/epg.go
@@ -20,16 +20,26 @@ package v1
 // EpgApplyConfiguration represents an declarative configuration of the Epg type for use
 // with apply.
 type EpgApplyConfiguration struct {
-	Name      *string                         `json:"name,omitempty"`
-	Tenant    *string                         `json:"tenant,omitempty"`
-	Contracts *ContractsApplyConfiguration    `json:"contracts,omitempty"`
-	BD        *BridgeDomainApplyConfiguration `json:"bd,omitempty"`
+	ApplicationProfile *string                         `json:"applicationProfile,omitempty"`
+	Name               *string                         `json:"name,omitempty"`
+	Tenant             *string                         `json:"tenant,omitempty"`
+	Contracts          *ContractsApplyConfiguration    `json:"contracts,omitempty"`
+	BD                 *BridgeDomainApplyConfiguration `json:"bd,omitempty"`
+	LLDPDiscovery      *bool                           `json:"lldpDiscovery,omitempty"`
 }
 
 // EpgApplyConfiguration constructs an declarative configuration of the Epg type for use with
 // apply.
 func Epg() *EpgApplyConfiguration {
 	return &EpgApplyConfiguration{}
+}
+
+// WithApplicationProfile sets the ApplicationProfile field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ApplicationProfile field is set to the value of the last call.
+func (b *EpgApplyConfiguration) WithApplicationProfile(value string) *EpgApplyConfiguration {
+	b.ApplicationProfile = &value
+	return b
 }
 
 // WithName sets the Name field in the declarative configuration to the given value
@@ -61,5 +71,13 @@ func (b *EpgApplyConfiguration) WithContracts(value *ContractsApplyConfiguration
 // If called multiple times, the BD field is set to the value of the last call.
 func (b *EpgApplyConfiguration) WithBD(value *BridgeDomainApplyConfiguration) *EpgApplyConfiguration {
 	b.BD = value
+	return b
+}
+
+// WithLLDPDiscovery sets the LLDPDiscovery field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the LLDPDiscovery field is set to the value of the last call.
+func (b *EpgApplyConfiguration) WithLLDPDiscovery(value bool) *EpgApplyConfiguration {
+	b.LLDPDiscovery = &value
 	return b
 }

--- a/pkg/hostagent/testdata/aci.fabricattachment_networkfabricconfigurations.yaml
+++ b/pkg/hostagent/testdata/aci.fabricattachment_networkfabricconfigurations.yaml
@@ -59,6 +59,8 @@ spec:
                       type: array
                     epg:
                       properties:
+                        applicationProfile:
+                          type: string
                         bd:
                           properties:
                             common-tenant:
@@ -88,6 +90,9 @@ spec:
                                 type: string
                               type: array
                           type: object
+                        lldpDiscovery:
+                          default: true
+                          type: boolean
                         name:
                           type: string
                         tenant:


### PR DESCRIPTION
Make application profile in custom epg configurable. Allow use of ports not in secondary aep for LLDP discovery, with the use of lldpDiscovery flag in NFC CRD.