### PR TITLE
HostAgent fix for populating correct endpoints to the service file

### DIFF
--- a/pkg/hostagent/services_test.go
+++ b/pkg/hostagent/services_test.go
@@ -117,7 +117,9 @@ func endpointslice(namespace string, name string,
 
 	for i, ip := range nextHopIps {
 		var endpoint discovery.Endpoint
+		var condition bool = true
 		endpoint.Addresses = append(endpoint.Addresses, ip)
+		endpoint.Conditions.Ready = &condition
 		e.Endpoints = append(e.Endpoints, endpoint)
 		e.Endpoints[i].NodeName = &nodename
 	}


### PR DESCRIPTION
The solution involves updating the NextHopIps of the servicefile with the IPs of the endpoints that are in the ready state, taken from the endpointslice. This change ensures that only the IPs of the ready endpoints are added to NextHopIps, instead of adding all endpoints.