### PR TITLE
Fix for ACI upgrade from 5.2 to 6.0

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -44,6 +44,7 @@ type ApicResponse struct {
 
 type ApicObjectHandler func(ApicObject) bool
 type ApicDnHandler func(string)
+type VersionUpdateHandler func()
 
 type ApicSlice []ApicObject
 
@@ -98,6 +99,7 @@ type ApicConnection struct {
 	vrfTenant string
 	version   string // APIC version
 
+	VersionUpdateHook   VersionUpdateHandler
 	CachedVersion       string
 	ReconnectInterval   time.Duration
 	ReconnectRetryLimit int

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -550,7 +550,15 @@ func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {
 				conn.restart()
 			} else {
 				conn.log.Debug("Cached version:", conn.CachedVersion, " New version:", version)
-				ApicVersion = version
+				if ApicVersion != version {
+					ApicVersion = version
+					if ApicVersion >= "6.0(4c)" {
+						metadata["fvBD"].attributes["serviceBdRoutingDisable"] = "no"
+					} else {
+						delete(metadata["fvBD"].attributes, "serviceBdRoutingDisable")
+					}
+					conn.VersionUpdateHook()
+				}
 				conn.CachedVersion = version
 			}
 		}()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -877,6 +877,11 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 			func(dn string) {
 				cont.opflexDeviceDeleted(dn)
 			})
+
+		cont.apicConn.VersionUpdateHook =
+			func() {
+				cont.initStaticServiceObjs()
+			}
 	}
 	go cont.apicConn.Run(stopCh)
 }


### PR DESCRIPTION
In 6.0 ACI, for proper functioning of SNAT, serviceBdRoutingDisable should be set as yes for service BD created by ACI CNI controller. When ACI is upgraded from 5.2 to 6.0, controller was not recomputing service BD and hence serviceBdRoutingDisable attribute was not updated in APIC and SNAT was not working till the controller was restarted.

Added code to recompute service BD when APIC is reconnected.