### PR TITLE
Update topology aware routing labels

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -1576,7 +1576,7 @@ func (seps *serviceEndpointSlice) SetNpServiceAugmentForService(servicekey strin
 	for _, port := range ports {
 		portstrings[strconv.Itoa(port)] = true
 	}
-	label := map[string]string{"kubernetes.io/service-name": service.ObjectMeta.Name}
+	label := map[string]string{discovery.LabelServiceName: service.ObjectMeta.Name}
 	selector := labels.SelectorFromSet(label)
 	cache.ListAllByNamespace(cont.endpointSliceIndexer, service.ObjectMeta.Namespace, selector,
 		func(endpointSliceobj interface{}) {

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -2585,7 +2585,7 @@ func (seps *serviceEndpointSlice) GetnodesMetadata(key string,
 	cont := seps.cont
 	// 1. Get all the Endpoint slices matching the label service-name
 	// 2. update the node map matching with endpoints nodes name
-	label := map[string]string{"kubernetes.io/service-name": service.ObjectMeta.Name}
+	label := map[string]string{discovery.LabelServiceName: service.ObjectMeta.Name}
 	selector := labels.SelectorFromSet(label)
 	cache.ListAllByNamespace(cont.endpointSliceIndexer, service.ObjectMeta.Namespace, selector,
 		func(endpointSliceobj interface{}) {
@@ -2634,7 +2634,7 @@ func (sep *serviceEndpoint) SetServiceApicObject(aobj apicapi.ApicObject, servic
 
 func (seps *serviceEndpointSlice) SetServiceApicObject(aobj apicapi.ApicObject, service *v1.Service) bool {
 	cont := seps.cont
-	label := map[string]string{"kubernetes.io/service-name": service.ObjectMeta.Name}
+	label := map[string]string{discovery.LabelServiceName: service.ObjectMeta.Name}
 	selector := labels.SelectorFromSet(label)
 	epcount := 0
 	childs := make(map[string]struct{})


### PR DESCRIPTION
Look for topology.kubernetes.io/zone label not kubernetes.io/zone on Node resource
service.kubernetes.io/topology-mode is the service annotation as of 1.27

Use upstream label key constants