### PR TITLE
Lock ubi version to 9.3 to fix conflicts in latest

### DIFF
--- a/docker/travis/Dockerfile-certmanager
+++ b/docker/travis/Dockerfile-certmanager
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:9.3
 # Required OpenShift Labels
 LABEL name="ACI Containers Certmanager" \
 vendor="Cisco" \

--- a/docker/travis/Dockerfile-cnideploy
+++ b/docker/travis/Dockerfile-cnideploy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:9.3
 # Required OpenShift Labels
 LABEL name="ACI CNI cnideploy" \
 vendor="Cisco" \

--- a/docker/travis/Dockerfile-controller
+++ b/docker/travis/Dockerfile-controller
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:9.3
 # Required OpenShift Labels
 LABEL name="ACI CNI Containers Controller" \
 vendor="Cisco" \

--- a/docker/travis/Dockerfile-host
+++ b/docker/travis/Dockerfile-host
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest as base
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3 as base
 # Required OpenShift Labels
 LABEL name="ACI CNI Host-Agent" \
 vendor="Cisco" \
@@ -6,6 +6,11 @@ version="v1.1.0" \
 release="1" \
 summary="This is an ACI CNI Host-Agent." \
 description="This will deploy a single instance of ACI CNI Host-Agent."
+# For some reason this prevents the next RUN from installing the incompat fips module
+RUN microdnf install -y yum yum-utils \
+ && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
+ && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
+ && yum --nogpgcheck -y update
 RUN yum update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y && rm -rf /var/cache/yum
 RUN yum install --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms curl -y --allowerasing && rm -rf /var/cache/yum
 RUN yum update --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os -y --nogpgcheck && rm -rf /var/cache/yum

--- a/docker/travis/Dockerfile-openvswitch
+++ b/docker/travis/Dockerfile-openvswitch
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 RUN microdnf install -y yum yum-utils
 RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
 RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \

--- a/docker/travis/Dockerfile-openvswitch-base
+++ b/docker/travis/Dockerfile-openvswitch-base
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
 RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \

--- a/docker/travis/Dockerfile-operator
+++ b/docker/travis/Dockerfile-operator
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:9.3
 # Required OpenShift Labels
 LABEL name="ACI CNI Operator" \
 vendor="Cisco" \

--- a/docker/travis/Dockerfile-webhook
+++ b/docker/travis/Dockerfile-webhook
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:9.3
 # Required OpenShift Labels
 LABEL name="ACI Containers Webhook" \
 vendor="Cisco" \


### PR DESCRIPTION
    ubi base image in 9.4 and latest uses openssl-libs-1:3.2.1-1.el9.x86_64
    that conflicts with openssl-fips-provider-3.0.7-2.el9.x86_64 from
    mirror.stream.centos.org_9-stream_BaseOS_x86_64_os because the centos
    contains openssl-libs-3.2.1-1.el9.x86_64.rpm. we cannot remove the
    older version because systemd depends on it. So lock the version
    until its resolved in upstream

    Signed-off-by: Madhu Challa <challa@gmail.com>