### PR TITLE
create startup dir in opflex-agent-ovs

### DIFF
--- a/docker/launch-hostagent.sh
+++ b/docker/launch-hostagent.sh
@@ -124,6 +124,7 @@ if [ -w ${PREFIX} ]; then
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/ids
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/droplog
     mkdir -p ${VARDIR}/lib/opflex-agent-ovs/faults
+    mkdir -p ${VARDIR}/lib/opflex-agent-ovs/startup
 fi
 
 if [ "$OPFLEX_MODE" == "overlay" ]; then


### PR DESCRIPTION
create startup dir in /var/lib/opflex-agent-ovs/ while launching hostagent. This will be the location of policy-file used by opflex-agent during opflex startup