### PR TITLE
Fix shared AEP physdom association

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -185,7 +185,8 @@ type AciController struct {
 	vmmClusterFaultSupported bool
 	additionalNetworkCache   map[string]*AdditionalNetworkMeta
 	//Used in Shared mode
-	sharedEncapCache map[int]*sharedEncapData
+	sharedEncapCache    map[int]*sharedEncapData
+	sharedEncapAepCache map[string]map[int]bool
 	// vlan to propertiesList
 	sharedEncapNfcCache         map[int]*NfcData
 	sharedEncapNfcVlanMap       map[int]*NfcData
@@ -209,6 +210,7 @@ type sharedEncapData struct {
 	//node to NAD to pods
 	Pods   map[string]map[string][]string
 	NetRef map[string]*AdditionalNetworkMeta
+	Aeps   map[string]bool
 }
 
 type globalVlanConfig struct {
@@ -428,6 +430,7 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 		hppRef:                      make(map[string]hppReference),
 		additionalNetworkCache:      make(map[string]*AdditionalNetworkMeta),
 		sharedEncapCache:            make(map[int]*sharedEncapData),
+		sharedEncapAepCache:         make(map[string]map[int]bool),
 		sharedEncapNfcCache:         make(map[int]*NfcData),
 		sharedEncapNfcVlanMap:       make(map[int]*NfcData),
 		sharedEncapNfcLabelMap:      make(map[string]*NfcData),

--- a/pkg/controller/networkfabricconfigurations.go
+++ b/pkg/controller/networkfabricconfigurations.go
@@ -219,7 +219,6 @@ func (cont *AciController) updateNfcCombinedCache() (affectedVlans []int) {
 			affectedVlans = append(affectedVlans, vlan)
 		}
 	}
-
 	cont.indexMutex.Unlock()
 
 	return affectedVlans
@@ -288,7 +287,7 @@ func (cont *AciController) handleNetworkFabricConfigurationDelete(key string) bo
 }
 
 // Internal API - Only used in GlobalScopeVlan mode
-func (cont *AciController) getSharedEncapNfcCacheEpgLocked(encap int) (nfcEpgTenant, nfcBd, nfcEpgAp, nfcEpg string, nfcEpgConsumers, nfcEpgProviders []string, lldpDiscovery bool) {
+func (cont *AciController) getSharedEncapNfcCacheEpgLocked(encap int) (nfcEpgTenant, nfcBd, nfcEpgAp, nfcEpg string, nfcEpgConsumers, nfcEpgProviders []string, discoveryType fabattv1.StaticPathMgmtType) {
 	if nfcData, nfcExists := cont.sharedEncapNfcCache[encap]; nfcExists {
 		nfcEpgTenant = nfcData.Epg.Tenant
 		nfcEpgAp = ""
@@ -299,9 +298,9 @@ func (cont *AciController) getSharedEncapNfcCacheEpgLocked(encap int) (nfcEpgTen
 		nfcEpg = nfcData.Epg.Name
 		nfcEpgConsumers = nfcData.Epg.Contracts.Consumer
 		nfcEpgProviders = nfcData.Epg.Contracts.Provider
-		lldpDiscovery = nfcData.Epg.LLDPDiscovery
+		discoveryType = nfcData.Epg.DiscoveryType
 	} else {
-		lldpDiscovery = true
+		discoveryType = fabattv1.StaticPathMgmtTypeAll
 	}
 	return
 

--- a/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricconfiguration_types.go
+++ b/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricconfiguration_types.go
@@ -4,6 +4,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+type StaticPathMgmtType string
+
+const (
+	StaticPathMgmtTypeAll  StaticPathMgmtType = ""
+	StaticPathMgmtTypeLLDP StaticPathMgmtType = "LLDP"
+	StaticPathMgmtTypeAEP  StaticPathMgmtType = "AEP"
+)
+
 // NetworkFabricConfigurationStatus defines the observed state of NetworkFabricConfiguration
 type NetworkFabricConfigurationStatus struct {
 	State string `json:"state,omitempty"`
@@ -32,13 +40,12 @@ type Contracts struct {
 }
 
 type Epg struct {
-	ApplicationProfile string       `json:"applicationProfile,omitempty"`
-	Name               string       `json:"name,omitempty"`
-	Tenant             string       `json:"tenant,omitempty"`
-	Contracts          Contracts    `json:"contracts,omitempty"`
-	BD                 BridgeDomain `json:"bd,omitempty"`
-	// +kubebuilder:default=true
-	LLDPDiscovery bool `json:"lldpDiscovery,omitempty"`
+	ApplicationProfile string             `json:"applicationProfile,omitempty"`
+	Name               string             `json:"name,omitempty"`
+	Tenant             string             `json:"tenant,omitempty"`
+	Contracts          Contracts          `json:"contracts,omitempty"`
+	BD                 BridgeDomain       `json:"bd,omitempty"`
+	DiscoveryType      StaticPathMgmtType `json:"discoveryType,omitempty"`
 }
 
 type VlanRef struct {

--- a/pkg/fabricattachment/applyconfiguration/aci.fabricattachment/v1/epg.go
+++ b/pkg/fabricattachment/applyconfiguration/aci.fabricattachment/v1/epg.go
@@ -17,15 +17,19 @@ limitations under the License.
 
 package v1
 
+import (
+	acifabricattachmentv1 "github.com/noironetworks/aci-containers/pkg/fabricattachment/apis/aci.fabricattachment/v1"
+)
+
 // EpgApplyConfiguration represents an declarative configuration of the Epg type for use
 // with apply.
 type EpgApplyConfiguration struct {
-	ApplicationProfile *string                         `json:"applicationProfile,omitempty"`
-	Name               *string                         `json:"name,omitempty"`
-	Tenant             *string                         `json:"tenant,omitempty"`
-	Contracts          *ContractsApplyConfiguration    `json:"contracts,omitempty"`
-	BD                 *BridgeDomainApplyConfiguration `json:"bd,omitempty"`
-	LLDPDiscovery      *bool                           `json:"lldpDiscovery,omitempty"`
+	ApplicationProfile *string                                   `json:"applicationProfile,omitempty"`
+	Name               *string                                   `json:"name,omitempty"`
+	Tenant             *string                                   `json:"tenant,omitempty"`
+	Contracts          *ContractsApplyConfiguration              `json:"contracts,omitempty"`
+	BD                 *BridgeDomainApplyConfiguration           `json:"bd,omitempty"`
+	DiscoveryType      *acifabricattachmentv1.StaticPathMgmtType `json:"discoveryType,omitempty"`
 }
 
 // EpgApplyConfiguration constructs an declarative configuration of the Epg type for use with
@@ -74,10 +78,10 @@ func (b *EpgApplyConfiguration) WithBD(value *BridgeDomainApplyConfiguration) *E
 	return b
 }
 
-// WithLLDPDiscovery sets the LLDPDiscovery field in the declarative configuration to the given value
+// WithDiscoveryType sets the DiscoveryType field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the LLDPDiscovery field is set to the value of the last call.
-func (b *EpgApplyConfiguration) WithLLDPDiscovery(value bool) *EpgApplyConfiguration {
-	b.LLDPDiscovery = &value
+// If called multiple times, the DiscoveryType field is set to the value of the last call.
+func (b *EpgApplyConfiguration) WithDiscoveryType(value acifabricattachmentv1.StaticPathMgmtType) *EpgApplyConfiguration {
+	b.DiscoveryType = &value
 	return b
 }

--- a/pkg/hostagent/testdata/aci.fabricattachment_networkfabricconfigurations.yaml
+++ b/pkg/hostagent/testdata/aci.fabricattachment_networkfabricconfigurations.yaml
@@ -90,9 +90,8 @@ spec:
                                 type: string
                               type: array
                           type: object
-                        lldpDiscovery:
-                          default: true
-                          type: boolean
+                        discoveryType:
+                          type: string
                         name:
                           type: string
                         tenant:


### PR DESCRIPTION
When the same AEP is shared by multiple vlans in NFC CR, delete the physdom association based on last staticpath delete on a vlan.
Because of the way this feature is currently being used, change the defaults on the CR to have both LLDP and AEP attachments allowed by default