### PR TITLE
Extract the policies using gbp_inspect into the file

### DIFF
--- a/cmd/acikubectl/cmd/policy.go
+++ b/cmd/acikubectl/cmd/policy.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"bytes"
+	kubecontext "context"
+	"fmt"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
+	"strings"
+)
+
+func processpolicy(cmd *cobra.Command, args []string) {
+	// Extract the arguments
+	req := args[0]
+
+	kubeClient := initClientPrintError()
+	if kubeClient == nil {
+		return
+	}
+	systemNamespace, err := findSystemNamespace(kubeClient)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Could not find aci-containers system namespace:", err)
+		return
+	}
+
+	systemNamespacePods, err1 := kubeClient.CoreV1().Pods(systemNamespace).List(kubecontext.TODO(), metav1.ListOptions{})
+	if err1 != nil {
+		fmt.Fprintln(os.Stderr, "Could not list pods:", err1)
+	}
+
+	// Check again in kube-system
+	if len(systemNamespacePods.Items) == 0 {
+		systemNamespace = "kube-system"
+		systemNamespacePods, err1 = kubeClient.CoreV1().Pods(systemNamespace).List(kubecontext.TODO(), metav1.ListOptions{})
+	}
+	if err1 != nil {
+		fmt.Fprintln(os.Stderr, "Could not list pods:", err1)
+	}
+
+	if req == "store" {
+		for pod := range systemNamespacePods.Items {
+			if strings.Contains(systemNamespacePods.Items[pod].Name, "aci-containers-host") {
+				buffer := new(bytes.Buffer)
+				path := "/usr/local/var/lib/opflex-agent-ovs/startup/pol.json"
+				execCmd := fmt.Sprintf("gbp_inspect -x -fprq DmtreeRoot -t dump > %s", path)
+				podName := systemNamespacePods.Items[pod].Name
+				cmd := []string{"exec", podName, "-n", systemNamespace, "-c", "opflex-agent", "--", "bash", "-c", execCmd}
+				fmt.Println("executing the command :", cmd)
+				execKubectl(cmd, buffer)
+				if buffer != nil {
+					trimString := strings.TrimSpace(buffer.String())
+					fmt.Println(trimString)
+				}
+			}
+		}
+	} else if req == "remove" {
+		for pod := range systemNamespacePods.Items {
+			if strings.Contains(systemNamespacePods.Items[pod].Name, "aci-containers-host") {
+				buffer := new(bytes.Buffer)
+				execCmd := "rm /usr/local/var/lib/opflex-agent-ovs/startup/pol.json"
+				podName := systemNamespacePods.Items[pod].Name
+				cmd := []string{"exec", podName, "-n", systemNamespace, "-c", "opflex-agent", "--", "bash", "-c", execCmd}
+				fmt.Println("executing the command :", cmd)
+				execKubectl(cmd, buffer)
+				if buffer != nil {
+					trimString := strings.TrimSpace(buffer.String())
+					fmt.Println(trimString)
+				}
+			}
+		}
+	} else {
+		fmt.Fprintln(os.Stderr, "Could not process the request: Invalid input")
+	}
+}
+
+var policyDumpCmd = &cobra.Command{
+	Use:     "policy store/remove",
+	Short:   "output the gbp_inspect policies into a file for all the host-agent pods",
+	Example: `acikubectl policy store/remove`,
+	Args:    cobra.ExactArgs(1),
+	Run:     processpolicy,
+}
+
+func init() {
+	RootCmd.AddCommand(policyDumpCmd)
+}


### PR DESCRIPTION
Opflex startup db feature:
https://github.com/noironetworks/opflex/pull/532/files
https://github.com/noironetworks/opflex/pull/532/files
https://github.com/noironetworks/aci-containers/pull/1313
https://github.com/noironetworks/acc-provision/commit/6a1169c61757d4976d5ea6dcb32e9e7e6a0f502b

documentation: https://github.com/noironetworks/acc-provision/blob/master/doc/features/opflex-agent-restart-policy-startupdb.md

The file system /usr/local/var/lib/opflex-agent-ovs/startup/ should exists prior to running this command

"acikubectl policy store" - will output the policies into the file across all the running host agent pods. This gets executed inside opflex-agent containers
"acikubectl policy remove" - this will remove the pol.json from opflex-agent file system /usr/local/var/lib/opflex-agent-ovs/startup/ across all the host-agent pods