### PR TITLE
Fixes for NFC status CRD

### DIFF
--- a/pkg/controller/networkfabricconfigurations.go
+++ b/pkg/controller/networkfabricconfigurations.go
@@ -100,11 +100,11 @@ func (cont *AciController) initFabNetConfigInformerFromClient(fabAttClient *faba
 	cont.initFabNetConfigInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return fabAttClient.AciV1().NetworkFabricConfigurations(metav1.NamespaceAll).List(context.TODO(), options)
+				return fabAttClient.AciV1().NetworkFabricConfigurations().List(context.TODO(), options)
 			},
 
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return fabAttClient.AciV1().NetworkFabricConfigurations(metav1.NamespaceAll).Watch(context.TODO(), options)
+				return fabAttClient.AciV1().NetworkFabricConfigurations().Watch(context.TODO(), options)
 			},
 		})
 }

--- a/pkg/controller/networkfabricl3configurations.go
+++ b/pkg/controller/networkfabricl3configurations.go
@@ -81,11 +81,11 @@ func (cont *AciController) initNetworkFabricL3ConfigurationInformerFromClient(fa
 	cont.initNetworkFabricL3ConfigurationInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return fabAttClient.AciV1().NetworkFabricL3Configurations(metav1.NamespaceAll).List(context.TODO(), options)
+				return fabAttClient.AciV1().NetworkFabricL3Configurations().List(context.TODO(), options)
 			},
 
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return fabAttClient.AciV1().NetworkFabricL3Configurations(metav1.NamespaceAll).Watch(context.TODO(), options)
+				return fabAttClient.AciV1().NetworkFabricL3Configurations().Watch(context.TODO(), options)
 			},
 		})
 }
@@ -1081,10 +1081,10 @@ func (cont *AciController) updateNetworkFabricL3ConfigurationStatus() {
 	if cont.unitTestMode {
 		return
 	}
-	fabl3Config, err := cont.fabNetAttClient.AciV1().NetworkFabricL3Configurations(metav1.NamespaceAll).Get(context.TODO(), "networkfabricl3configuration", metav1.GetOptions{})
+	fabl3Config, err := cont.fabNetAttClient.AciV1().NetworkFabricL3Configurations().Get(context.TODO(), "networkfabricl3configuration", metav1.GetOptions{})
 	if err == nil {
 		fabl3Config.Status = *cont.computeNetworkFabricL3ConfigurationStatus()
-		_, err = cont.fabNetAttClient.AciV1().NetworkFabricL3Configurations(metav1.NamespaceAll).UpdateStatus(context.TODO(), fabl3Config, metav1.UpdateOptions{})
+		_, err = cont.fabNetAttClient.AciV1().NetworkFabricL3Configurations().UpdateStatus(context.TODO(), fabl3Config, metav1.UpdateOptions{})
 		if err != nil {
 			cont.log.Errorf("Failed to update NetworkFabricL3ConfigurationStatus: %v", err)
 		}

--- a/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricconfiguration_types.go
+++ b/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricconfiguration_types.go
@@ -62,6 +62,7 @@ type NetworkFabricConfigurationSpec struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status

--- a/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricl3configurations_types.go
+++ b/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricl3configurations_types.go
@@ -59,7 +59,7 @@ type FabricL3OutRtrNode struct {
 type FabricL3OutNode struct {
 	NodeRef            FabricNodeRef `json:"nodeRef"`
 	PrimaryAddress     string        `json:"primaryAddress"`
-	SecondaryAddresses []string      `json:"secondaryAddresses"`
+	SecondaryAddresses []string      `json:"secondaryAddresses,omitempty"`
 }
 
 type FabricL3Subnet struct {
@@ -135,6 +135,7 @@ type NetworkFabricL3ConfigStatus struct {
 }
 
 // +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status

--- a/pkg/fabricattachment/applyconfiguration/aci.fabricattachment/v1/networkfabricconfiguration.go
+++ b/pkg/fabricattachment/applyconfiguration/aci.fabricattachment/v1/networkfabricconfiguration.go
@@ -34,10 +34,9 @@ type NetworkFabricConfigurationApplyConfiguration struct {
 
 // NetworkFabricConfiguration constructs an declarative configuration of the NetworkFabricConfiguration type for use with
 // apply.
-func NetworkFabricConfiguration(name, namespace string) *NetworkFabricConfigurationApplyConfiguration {
+func NetworkFabricConfiguration(name string) *NetworkFabricConfigurationApplyConfiguration {
 	b := &NetworkFabricConfigurationApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("NetworkFabricConfiguration")
 	b.WithAPIVersion("aci.fabricattachment/v1")
 	return b

--- a/pkg/fabricattachment/applyconfiguration/aci.fabricattachment/v1/networkfabricl3configuration.go
+++ b/pkg/fabricattachment/applyconfiguration/aci.fabricattachment/v1/networkfabricl3configuration.go
@@ -34,10 +34,9 @@ type NetworkFabricL3ConfigurationApplyConfiguration struct {
 
 // NetworkFabricL3Configuration constructs an declarative configuration of the NetworkFabricL3Configuration type for use with
 // apply.
-func NetworkFabricL3Configuration(name, namespace string) *NetworkFabricL3ConfigurationApplyConfiguration {
+func NetworkFabricL3Configuration(name string) *NetworkFabricL3ConfigurationApplyConfiguration {
 	b := &NetworkFabricL3ConfigurationApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("NetworkFabricL3Configuration")
 	b.WithAPIVersion("aci.fabricattachment/v1")
 	return b

--- a/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/aci.fabricattachment_client.go
+++ b/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/aci.fabricattachment_client.go
@@ -47,12 +47,12 @@ func (c *AciV1Client) NadVlanMaps(namespace string) NadVlanMapInterface {
 	return newNadVlanMaps(c, namespace)
 }
 
-func (c *AciV1Client) NetworkFabricConfigurations(namespace string) NetworkFabricConfigurationInterface {
-	return newNetworkFabricConfigurations(c, namespace)
+func (c *AciV1Client) NetworkFabricConfigurations() NetworkFabricConfigurationInterface {
+	return newNetworkFabricConfigurations(c)
 }
 
-func (c *AciV1Client) NetworkFabricL3Configurations(namespace string) NetworkFabricL3ConfigurationInterface {
-	return newNetworkFabricL3Configurations(c, namespace)
+func (c *AciV1Client) NetworkFabricL3Configurations() NetworkFabricL3ConfigurationInterface {
+	return newNetworkFabricL3Configurations(c)
 }
 
 func (c *AciV1Client) NodeFabricNetworkAttachments(namespace string) NodeFabricNetworkAttachmentInterface {

--- a/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/fake/fake_aci.fabricattachment_client.go
+++ b/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/fake/fake_aci.fabricattachment_client.go
@@ -35,12 +35,12 @@ func (c *FakeAciV1) NadVlanMaps(namespace string) v1.NadVlanMapInterface {
 	return &FakeNadVlanMaps{c, namespace}
 }
 
-func (c *FakeAciV1) NetworkFabricConfigurations(namespace string) v1.NetworkFabricConfigurationInterface {
-	return &FakeNetworkFabricConfigurations{c, namespace}
+func (c *FakeAciV1) NetworkFabricConfigurations() v1.NetworkFabricConfigurationInterface {
+	return &FakeNetworkFabricConfigurations{c}
 }
 
-func (c *FakeAciV1) NetworkFabricL3Configurations(namespace string) v1.NetworkFabricL3ConfigurationInterface {
-	return &FakeNetworkFabricL3Configurations{c, namespace}
+func (c *FakeAciV1) NetworkFabricL3Configurations() v1.NetworkFabricL3ConfigurationInterface {
+	return &FakeNetworkFabricL3Configurations{c}
 }
 
 func (c *FakeAciV1) NodeFabricNetworkAttachments(namespace string) v1.NodeFabricNetworkAttachmentInterface {

--- a/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/fake/fake_networkfabricconfiguration.go
+++ b/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/fake/fake_networkfabricconfiguration.go
@@ -34,7 +34,6 @@ import (
 // FakeNetworkFabricConfigurations implements NetworkFabricConfigurationInterface
 type FakeNetworkFabricConfigurations struct {
 	Fake *FakeAciV1
-	ns   string
 }
 
 var networkfabricconfigurationsResource = v1.SchemeGroupVersion.WithResource("networkfabricconfigurations")
@@ -44,8 +43,7 @@ var networkfabricconfigurationsKind = v1.SchemeGroupVersion.WithKind("NetworkFab
 // Get takes name of the networkFabricConfiguration, and returns the corresponding networkFabricConfiguration object, and an error if there is any.
 func (c *FakeNetworkFabricConfigurations) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.NetworkFabricConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(networkfabricconfigurationsResource, c.ns, name), &v1.NetworkFabricConfiguration{})
-
+		Invokes(testing.NewRootGetAction(networkfabricconfigurationsResource, name), &v1.NetworkFabricConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -55,8 +53,7 @@ func (c *FakeNetworkFabricConfigurations) Get(ctx context.Context, name string, 
 // List takes label and field selectors, and returns the list of NetworkFabricConfigurations that match those selectors.
 func (c *FakeNetworkFabricConfigurations) List(ctx context.Context, opts metav1.ListOptions) (result *v1.NetworkFabricConfigurationList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(networkfabricconfigurationsResource, networkfabricconfigurationsKind, c.ns, opts), &v1.NetworkFabricConfigurationList{})
-
+		Invokes(testing.NewRootListAction(networkfabricconfigurationsResource, networkfabricconfigurationsKind, opts), &v1.NetworkFabricConfigurationList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -77,15 +74,13 @@ func (c *FakeNetworkFabricConfigurations) List(ctx context.Context, opts metav1.
 // Watch returns a watch.Interface that watches the requested networkFabricConfigurations.
 func (c *FakeNetworkFabricConfigurations) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(networkfabricconfigurationsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(networkfabricconfigurationsResource, opts))
 }
 
 // Create takes the representation of a networkFabricConfiguration and creates it.  Returns the server's representation of the networkFabricConfiguration, and an error, if there is any.
 func (c *FakeNetworkFabricConfigurations) Create(ctx context.Context, networkFabricConfiguration *v1.NetworkFabricConfiguration, opts metav1.CreateOptions) (result *v1.NetworkFabricConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(networkfabricconfigurationsResource, c.ns, networkFabricConfiguration), &v1.NetworkFabricConfiguration{})
-
+		Invokes(testing.NewRootCreateAction(networkfabricconfigurationsResource, networkFabricConfiguration), &v1.NetworkFabricConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +90,7 @@ func (c *FakeNetworkFabricConfigurations) Create(ctx context.Context, networkFab
 // Update takes the representation of a networkFabricConfiguration and updates it. Returns the server's representation of the networkFabricConfiguration, and an error, if there is any.
 func (c *FakeNetworkFabricConfigurations) Update(ctx context.Context, networkFabricConfiguration *v1.NetworkFabricConfiguration, opts metav1.UpdateOptions) (result *v1.NetworkFabricConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(networkfabricconfigurationsResource, c.ns, networkFabricConfiguration), &v1.NetworkFabricConfiguration{})
-
+		Invokes(testing.NewRootUpdateAction(networkfabricconfigurationsResource, networkFabricConfiguration), &v1.NetworkFabricConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -107,8 +101,7 @@ func (c *FakeNetworkFabricConfigurations) Update(ctx context.Context, networkFab
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeNetworkFabricConfigurations) UpdateStatus(ctx context.Context, networkFabricConfiguration *v1.NetworkFabricConfiguration, opts metav1.UpdateOptions) (*v1.NetworkFabricConfiguration, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(networkfabricconfigurationsResource, "status", c.ns, networkFabricConfiguration), &v1.NetworkFabricConfiguration{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(networkfabricconfigurationsResource, "status", networkFabricConfiguration), &v1.NetworkFabricConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -118,14 +111,13 @@ func (c *FakeNetworkFabricConfigurations) UpdateStatus(ctx context.Context, netw
 // Delete takes name of the networkFabricConfiguration and deletes it. Returns an error if one occurs.
 func (c *FakeNetworkFabricConfigurations) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(networkfabricconfigurationsResource, c.ns, name, opts), &v1.NetworkFabricConfiguration{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(networkfabricconfigurationsResource, name, opts), &v1.NetworkFabricConfiguration{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeNetworkFabricConfigurations) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(networkfabricconfigurationsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(networkfabricconfigurationsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1.NetworkFabricConfigurationList{})
 	return err
@@ -134,8 +126,7 @@ func (c *FakeNetworkFabricConfigurations) DeleteCollection(ctx context.Context, 
 // Patch applies the patch and returns the patched networkFabricConfiguration.
 func (c *FakeNetworkFabricConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.NetworkFabricConfiguration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(networkfabricconfigurationsResource, c.ns, name, pt, data, subresources...), &v1.NetworkFabricConfiguration{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(networkfabricconfigurationsResource, name, pt, data, subresources...), &v1.NetworkFabricConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -156,8 +147,7 @@ func (c *FakeNetworkFabricConfigurations) Apply(ctx context.Context, networkFabr
 		return nil, fmt.Errorf("networkFabricConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(networkfabricconfigurationsResource, c.ns, *name, types.ApplyPatchType, data), &v1.NetworkFabricConfiguration{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(networkfabricconfigurationsResource, *name, types.ApplyPatchType, data), &v1.NetworkFabricConfiguration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -179,8 +169,7 @@ func (c *FakeNetworkFabricConfigurations) ApplyStatus(ctx context.Context, netwo
 		return nil, fmt.Errorf("networkFabricConfiguration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(networkfabricconfigurationsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.NetworkFabricConfiguration{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(networkfabricconfigurationsResource, *name, types.ApplyPatchType, data, "status"), &v1.NetworkFabricConfiguration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/fake/fake_networkfabricl3configuration.go
+++ b/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/fake/fake_networkfabricl3configuration.go
@@ -34,7 +34,6 @@ import (
 // FakeNetworkFabricL3Configurations implements NetworkFabricL3ConfigurationInterface
 type FakeNetworkFabricL3Configurations struct {
 	Fake *FakeAciV1
-	ns   string
 }
 
 var networkfabricl3configurationsResource = v1.SchemeGroupVersion.WithResource("networkfabricl3configurations")
@@ -44,8 +43,7 @@ var networkfabricl3configurationsKind = v1.SchemeGroupVersion.WithKind("NetworkF
 // Get takes name of the networkFabricL3Configuration, and returns the corresponding networkFabricL3Configuration object, and an error if there is any.
 func (c *FakeNetworkFabricL3Configurations) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.NetworkFabricL3Configuration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(networkfabricl3configurationsResource, c.ns, name), &v1.NetworkFabricL3Configuration{})
-
+		Invokes(testing.NewRootGetAction(networkfabricl3configurationsResource, name), &v1.NetworkFabricL3Configuration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -55,8 +53,7 @@ func (c *FakeNetworkFabricL3Configurations) Get(ctx context.Context, name string
 // List takes label and field selectors, and returns the list of NetworkFabricL3Configurations that match those selectors.
 func (c *FakeNetworkFabricL3Configurations) List(ctx context.Context, opts metav1.ListOptions) (result *v1.NetworkFabricL3ConfigurationList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(networkfabricl3configurationsResource, networkfabricl3configurationsKind, c.ns, opts), &v1.NetworkFabricL3ConfigurationList{})
-
+		Invokes(testing.NewRootListAction(networkfabricl3configurationsResource, networkfabricl3configurationsKind, opts), &v1.NetworkFabricL3ConfigurationList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -77,15 +74,13 @@ func (c *FakeNetworkFabricL3Configurations) List(ctx context.Context, opts metav
 // Watch returns a watch.Interface that watches the requested networkFabricL3Configurations.
 func (c *FakeNetworkFabricL3Configurations) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(networkfabricl3configurationsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(networkfabricl3configurationsResource, opts))
 }
 
 // Create takes the representation of a networkFabricL3Configuration and creates it.  Returns the server's representation of the networkFabricL3Configuration, and an error, if there is any.
 func (c *FakeNetworkFabricL3Configurations) Create(ctx context.Context, networkFabricL3Configuration *v1.NetworkFabricL3Configuration, opts metav1.CreateOptions) (result *v1.NetworkFabricL3Configuration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(networkfabricl3configurationsResource, c.ns, networkFabricL3Configuration), &v1.NetworkFabricL3Configuration{})
-
+		Invokes(testing.NewRootCreateAction(networkfabricl3configurationsResource, networkFabricL3Configuration), &v1.NetworkFabricL3Configuration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +90,7 @@ func (c *FakeNetworkFabricL3Configurations) Create(ctx context.Context, networkF
 // Update takes the representation of a networkFabricL3Configuration and updates it. Returns the server's representation of the networkFabricL3Configuration, and an error, if there is any.
 func (c *FakeNetworkFabricL3Configurations) Update(ctx context.Context, networkFabricL3Configuration *v1.NetworkFabricL3Configuration, opts metav1.UpdateOptions) (result *v1.NetworkFabricL3Configuration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(networkfabricl3configurationsResource, c.ns, networkFabricL3Configuration), &v1.NetworkFabricL3Configuration{})
-
+		Invokes(testing.NewRootUpdateAction(networkfabricl3configurationsResource, networkFabricL3Configuration), &v1.NetworkFabricL3Configuration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -107,8 +101,7 @@ func (c *FakeNetworkFabricL3Configurations) Update(ctx context.Context, networkF
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeNetworkFabricL3Configurations) UpdateStatus(ctx context.Context, networkFabricL3Configuration *v1.NetworkFabricL3Configuration, opts metav1.UpdateOptions) (*v1.NetworkFabricL3Configuration, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(networkfabricl3configurationsResource, "status", c.ns, networkFabricL3Configuration), &v1.NetworkFabricL3Configuration{})
-
+		Invokes(testing.NewRootUpdateSubresourceAction(networkfabricl3configurationsResource, "status", networkFabricL3Configuration), &v1.NetworkFabricL3Configuration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -118,14 +111,13 @@ func (c *FakeNetworkFabricL3Configurations) UpdateStatus(ctx context.Context, ne
 // Delete takes name of the networkFabricL3Configuration and deletes it. Returns an error if one occurs.
 func (c *FakeNetworkFabricL3Configurations) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(networkfabricl3configurationsResource, c.ns, name, opts), &v1.NetworkFabricL3Configuration{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(networkfabricl3configurationsResource, name, opts), &v1.NetworkFabricL3Configuration{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeNetworkFabricL3Configurations) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(networkfabricl3configurationsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(networkfabricl3configurationsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1.NetworkFabricL3ConfigurationList{})
 	return err
@@ -134,8 +126,7 @@ func (c *FakeNetworkFabricL3Configurations) DeleteCollection(ctx context.Context
 // Patch applies the patch and returns the patched networkFabricL3Configuration.
 func (c *FakeNetworkFabricL3Configurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.NetworkFabricL3Configuration, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(networkfabricl3configurationsResource, c.ns, name, pt, data, subresources...), &v1.NetworkFabricL3Configuration{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(networkfabricl3configurationsResource, name, pt, data, subresources...), &v1.NetworkFabricL3Configuration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -156,8 +147,7 @@ func (c *FakeNetworkFabricL3Configurations) Apply(ctx context.Context, networkFa
 		return nil, fmt.Errorf("networkFabricL3Configuration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(networkfabricl3configurationsResource, c.ns, *name, types.ApplyPatchType, data), &v1.NetworkFabricL3Configuration{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(networkfabricl3configurationsResource, *name, types.ApplyPatchType, data), &v1.NetworkFabricL3Configuration{})
 	if obj == nil {
 		return nil, err
 	}
@@ -179,8 +169,7 @@ func (c *FakeNetworkFabricL3Configurations) ApplyStatus(ctx context.Context, net
 		return nil, fmt.Errorf("networkFabricL3Configuration.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(networkfabricl3configurationsResource, c.ns, *name, types.ApplyPatchType, data, "status"), &v1.NetworkFabricL3Configuration{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(networkfabricl3configurationsResource, *name, types.ApplyPatchType, data, "status"), &v1.NetworkFabricL3Configuration{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/networkfabricconfiguration.go
+++ b/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/networkfabricconfiguration.go
@@ -35,7 +35,7 @@ import (
 // NetworkFabricConfigurationsGetter has a method to return a NetworkFabricConfigurationInterface.
 // A group's client should implement this interface.
 type NetworkFabricConfigurationsGetter interface {
-	NetworkFabricConfigurations(namespace string) NetworkFabricConfigurationInterface
+	NetworkFabricConfigurations() NetworkFabricConfigurationInterface
 }
 
 // NetworkFabricConfigurationInterface has methods to work with NetworkFabricConfiguration resources.
@@ -57,14 +57,12 @@ type NetworkFabricConfigurationInterface interface {
 // networkFabricConfigurations implements NetworkFabricConfigurationInterface
 type networkFabricConfigurations struct {
 	client rest.Interface
-	ns     string
 }
 
 // newNetworkFabricConfigurations returns a NetworkFabricConfigurations
-func newNetworkFabricConfigurations(c *AciV1Client, namespace string) *networkFabricConfigurations {
+func newNetworkFabricConfigurations(c *AciV1Client) *networkFabricConfigurations {
 	return &networkFabricConfigurations{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -72,7 +70,6 @@ func newNetworkFabricConfigurations(c *AciV1Client, namespace string) *networkFa
 func (c *networkFabricConfigurations) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.NetworkFabricConfiguration, err error) {
 	result = &v1.NetworkFabricConfiguration{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,7 +86,6 @@ func (c *networkFabricConfigurations) List(ctx context.Context, opts metav1.List
 	}
 	result = &v1.NetworkFabricConfigurationList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,7 +102,6 @@ func (c *networkFabricConfigurations) Watch(ctx context.Context, opts metav1.Lis
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,7 +112,6 @@ func (c *networkFabricConfigurations) Watch(ctx context.Context, opts metav1.Lis
 func (c *networkFabricConfigurations) Create(ctx context.Context, networkFabricConfiguration *v1.NetworkFabricConfiguration, opts metav1.CreateOptions) (result *v1.NetworkFabricConfiguration, err error) {
 	result = &v1.NetworkFabricConfiguration{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(networkFabricConfiguration).
@@ -130,7 +124,6 @@ func (c *networkFabricConfigurations) Create(ctx context.Context, networkFabricC
 func (c *networkFabricConfigurations) Update(ctx context.Context, networkFabricConfiguration *v1.NetworkFabricConfiguration, opts metav1.UpdateOptions) (result *v1.NetworkFabricConfiguration, err error) {
 	result = &v1.NetworkFabricConfiguration{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		Name(networkFabricConfiguration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -145,7 +138,6 @@ func (c *networkFabricConfigurations) Update(ctx context.Context, networkFabricC
 func (c *networkFabricConfigurations) UpdateStatus(ctx context.Context, networkFabricConfiguration *v1.NetworkFabricConfiguration, opts metav1.UpdateOptions) (result *v1.NetworkFabricConfiguration, err error) {
 	result = &v1.NetworkFabricConfiguration{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		Name(networkFabricConfiguration.Name).
 		SubResource("status").
@@ -159,7 +151,6 @@ func (c *networkFabricConfigurations) UpdateStatus(ctx context.Context, networkF
 // Delete takes name of the networkFabricConfiguration and deletes it. Returns an error if one occurs.
 func (c *networkFabricConfigurations) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		Name(name).
 		Body(&opts).
@@ -174,7 +165,6 @@ func (c *networkFabricConfigurations) DeleteCollection(ctx context.Context, opts
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -187,7 +177,6 @@ func (c *networkFabricConfigurations) DeleteCollection(ctx context.Context, opts
 func (c *networkFabricConfigurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.NetworkFabricConfiguration, err error) {
 	result = &v1.NetworkFabricConfiguration{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		Name(name).
 		SubResource(subresources...).
@@ -214,7 +203,6 @@ func (c *networkFabricConfigurations) Apply(ctx context.Context, networkFabricCo
 	}
 	result = &v1.NetworkFabricConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -243,7 +231,6 @@ func (c *networkFabricConfigurations) ApplyStatus(ctx context.Context, networkFa
 
 	result = &v1.NetworkFabricConfiguration{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("networkfabricconfigurations").
 		Name(*name).
 		SubResource("status").

--- a/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/networkfabricl3configuration.go
+++ b/pkg/fabricattachment/clientset/versioned/typed/aci.fabricattachment/v1/networkfabricl3configuration.go
@@ -35,7 +35,7 @@ import (
 // NetworkFabricL3ConfigurationsGetter has a method to return a NetworkFabricL3ConfigurationInterface.
 // A group's client should implement this interface.
 type NetworkFabricL3ConfigurationsGetter interface {
-	NetworkFabricL3Configurations(namespace string) NetworkFabricL3ConfigurationInterface
+	NetworkFabricL3Configurations() NetworkFabricL3ConfigurationInterface
 }
 
 // NetworkFabricL3ConfigurationInterface has methods to work with NetworkFabricL3Configuration resources.
@@ -57,14 +57,12 @@ type NetworkFabricL3ConfigurationInterface interface {
 // networkFabricL3Configurations implements NetworkFabricL3ConfigurationInterface
 type networkFabricL3Configurations struct {
 	client rest.Interface
-	ns     string
 }
 
 // newNetworkFabricL3Configurations returns a NetworkFabricL3Configurations
-func newNetworkFabricL3Configurations(c *AciV1Client, namespace string) *networkFabricL3Configurations {
+func newNetworkFabricL3Configurations(c *AciV1Client) *networkFabricL3Configurations {
 	return &networkFabricL3Configurations{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -72,7 +70,6 @@ func newNetworkFabricL3Configurations(c *AciV1Client, namespace string) *network
 func (c *networkFabricL3Configurations) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.NetworkFabricL3Configuration, err error) {
 	result = &v1.NetworkFabricL3Configuration{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -89,7 +86,6 @@ func (c *networkFabricL3Configurations) List(ctx context.Context, opts metav1.Li
 	}
 	result = &v1.NetworkFabricL3ConfigurationList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -106,7 +102,6 @@ func (c *networkFabricL3Configurations) Watch(ctx context.Context, opts metav1.L
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -117,7 +112,6 @@ func (c *networkFabricL3Configurations) Watch(ctx context.Context, opts metav1.L
 func (c *networkFabricL3Configurations) Create(ctx context.Context, networkFabricL3Configuration *v1.NetworkFabricL3Configuration, opts metav1.CreateOptions) (result *v1.NetworkFabricL3Configuration, err error) {
 	result = &v1.NetworkFabricL3Configuration{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(networkFabricL3Configuration).
@@ -130,7 +124,6 @@ func (c *networkFabricL3Configurations) Create(ctx context.Context, networkFabri
 func (c *networkFabricL3Configurations) Update(ctx context.Context, networkFabricL3Configuration *v1.NetworkFabricL3Configuration, opts metav1.UpdateOptions) (result *v1.NetworkFabricL3Configuration, err error) {
 	result = &v1.NetworkFabricL3Configuration{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		Name(networkFabricL3Configuration.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -145,7 +138,6 @@ func (c *networkFabricL3Configurations) Update(ctx context.Context, networkFabri
 func (c *networkFabricL3Configurations) UpdateStatus(ctx context.Context, networkFabricL3Configuration *v1.NetworkFabricL3Configuration, opts metav1.UpdateOptions) (result *v1.NetworkFabricL3Configuration, err error) {
 	result = &v1.NetworkFabricL3Configuration{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		Name(networkFabricL3Configuration.Name).
 		SubResource("status").
@@ -159,7 +151,6 @@ func (c *networkFabricL3Configurations) UpdateStatus(ctx context.Context, networ
 // Delete takes name of the networkFabricL3Configuration and deletes it. Returns an error if one occurs.
 func (c *networkFabricL3Configurations) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		Name(name).
 		Body(&opts).
@@ -174,7 +165,6 @@ func (c *networkFabricL3Configurations) DeleteCollection(ctx context.Context, op
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -187,7 +177,6 @@ func (c *networkFabricL3Configurations) DeleteCollection(ctx context.Context, op
 func (c *networkFabricL3Configurations) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.NetworkFabricL3Configuration, err error) {
 	result = &v1.NetworkFabricL3Configuration{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		Name(name).
 		SubResource(subresources...).
@@ -214,7 +203,6 @@ func (c *networkFabricL3Configurations) Apply(ctx context.Context, networkFabric
 	}
 	result = &v1.NetworkFabricL3Configuration{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).
@@ -243,7 +231,6 @@ func (c *networkFabricL3Configurations) ApplyStatus(ctx context.Context, network
 
 	result = &v1.NetworkFabricL3Configuration{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("networkfabricl3configurations").
 		Name(*name).
 		SubResource("status").

--- a/pkg/fabricattachment/informers/externalversions/aci.fabricattachment/v1/interface.go
+++ b/pkg/fabricattachment/informers/externalversions/aci.fabricattachment/v1/interface.go
@@ -58,12 +58,12 @@ func (v *version) NadVlanMaps() NadVlanMapInformer {
 
 // NetworkFabricConfigurations returns a NetworkFabricConfigurationInformer.
 func (v *version) NetworkFabricConfigurations() NetworkFabricConfigurationInformer {
-	return &networkFabricConfigurationInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &networkFabricConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // NetworkFabricL3Configurations returns a NetworkFabricL3ConfigurationInformer.
 func (v *version) NetworkFabricL3Configurations() NetworkFabricL3ConfigurationInformer {
-	return &networkFabricL3ConfigurationInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &networkFabricL3ConfigurationInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }
 
 // NodeFabricNetworkAttachments returns a NodeFabricNetworkAttachmentInformer.

--- a/pkg/fabricattachment/informers/externalversions/aci.fabricattachment/v1/networkfabricconfiguration.go
+++ b/pkg/fabricattachment/informers/externalversions/aci.fabricattachment/v1/networkfabricconfiguration.go
@@ -41,33 +41,32 @@ type NetworkFabricConfigurationInformer interface {
 type networkFabricConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewNetworkFabricConfigurationInformer constructs a new informer for NetworkFabricConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewNetworkFabricConfigurationInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredNetworkFabricConfigurationInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewNetworkFabricConfigurationInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredNetworkFabricConfigurationInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredNetworkFabricConfigurationInformer constructs a new informer for NetworkFabricConfiguration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredNetworkFabricConfigurationInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredNetworkFabricConfigurationInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AciV1().NetworkFabricConfigurations(namespace).List(context.TODO(), options)
+				return client.AciV1().NetworkFabricConfigurations().List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AciV1().NetworkFabricConfigurations(namespace).Watch(context.TODO(), options)
+				return client.AciV1().NetworkFabricConfigurations().Watch(context.TODO(), options)
 			},
 		},
 		&acifabricattachmentv1.NetworkFabricConfiguration{},
@@ -77,7 +76,7 @@ func NewFilteredNetworkFabricConfigurationInformer(client versioned.Interface, n
 }
 
 func (f *networkFabricConfigurationInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredNetworkFabricConfigurationInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredNetworkFabricConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *networkFabricConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/fabricattachment/informers/externalversions/aci.fabricattachment/v1/networkfabricl3configuration.go
+++ b/pkg/fabricattachment/informers/externalversions/aci.fabricattachment/v1/networkfabricl3configuration.go
@@ -41,33 +41,32 @@ type NetworkFabricL3ConfigurationInformer interface {
 type networkFabricL3ConfigurationInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewNetworkFabricL3ConfigurationInformer constructs a new informer for NetworkFabricL3Configuration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewNetworkFabricL3ConfigurationInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredNetworkFabricL3ConfigurationInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewNetworkFabricL3ConfigurationInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredNetworkFabricL3ConfigurationInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredNetworkFabricL3ConfigurationInformer constructs a new informer for NetworkFabricL3Configuration type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredNetworkFabricL3ConfigurationInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredNetworkFabricL3ConfigurationInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AciV1().NetworkFabricL3Configurations(namespace).List(context.TODO(), options)
+				return client.AciV1().NetworkFabricL3Configurations().List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AciV1().NetworkFabricL3Configurations(namespace).Watch(context.TODO(), options)
+				return client.AciV1().NetworkFabricL3Configurations().Watch(context.TODO(), options)
 			},
 		},
 		&acifabricattachmentv1.NetworkFabricL3Configuration{},
@@ -77,7 +76,7 @@ func NewFilteredNetworkFabricL3ConfigurationInformer(client versioned.Interface,
 }
 
 func (f *networkFabricL3ConfigurationInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredNetworkFabricL3ConfigurationInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredNetworkFabricL3ConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *networkFabricL3ConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/fabricattachment/listers/aci.fabricattachment/v1/expansion_generated.go
+++ b/pkg/fabricattachment/listers/aci.fabricattachment/v1/expansion_generated.go
@@ -37,17 +37,9 @@ type NadVlanMapNamespaceListerExpansion interface{}
 // NetworkFabricConfigurationLister.
 type NetworkFabricConfigurationListerExpansion interface{}
 
-// NetworkFabricConfigurationNamespaceListerExpansion allows custom methods to be added to
-// NetworkFabricConfigurationNamespaceLister.
-type NetworkFabricConfigurationNamespaceListerExpansion interface{}
-
 // NetworkFabricL3ConfigurationListerExpansion allows custom methods to be added to
 // NetworkFabricL3ConfigurationLister.
 type NetworkFabricL3ConfigurationListerExpansion interface{}
-
-// NetworkFabricL3ConfigurationNamespaceListerExpansion allows custom methods to be added to
-// NetworkFabricL3ConfigurationNamespaceLister.
-type NetworkFabricL3ConfigurationNamespaceListerExpansion interface{}
 
 // NodeFabricNetworkAttachmentListerExpansion allows custom methods to be added to
 // NodeFabricNetworkAttachmentLister.

--- a/pkg/fabricattachment/listers/aci.fabricattachment/v1/networkfabricconfiguration.go
+++ b/pkg/fabricattachment/listers/aci.fabricattachment/v1/networkfabricconfiguration.go
@@ -30,8 +30,9 @@ type NetworkFabricConfigurationLister interface {
 	// List lists all NetworkFabricConfigurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.NetworkFabricConfiguration, err error)
-	// NetworkFabricConfigurations returns an object that can list and get NetworkFabricConfigurations.
-	NetworkFabricConfigurations(namespace string) NetworkFabricConfigurationNamespaceLister
+	// Get retrieves the NetworkFabricConfiguration from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1.NetworkFabricConfiguration, error)
 	NetworkFabricConfigurationListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *networkFabricConfigurationLister) List(selector labels.Selector) (ret [
 	return ret, err
 }
 
-// NetworkFabricConfigurations returns an object that can list and get NetworkFabricConfigurations.
-func (s *networkFabricConfigurationLister) NetworkFabricConfigurations(namespace string) NetworkFabricConfigurationNamespaceLister {
-	return networkFabricConfigurationNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// NetworkFabricConfigurationNamespaceLister helps list and get NetworkFabricConfigurations.
-// All objects returned here must be treated as read-only.
-type NetworkFabricConfigurationNamespaceLister interface {
-	// List lists all NetworkFabricConfigurations in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.NetworkFabricConfiguration, err error)
-	// Get retrieves the NetworkFabricConfiguration from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.NetworkFabricConfiguration, error)
-	NetworkFabricConfigurationNamespaceListerExpansion
-}
-
-// networkFabricConfigurationNamespaceLister implements the NetworkFabricConfigurationNamespaceLister
-// interface.
-type networkFabricConfigurationNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all NetworkFabricConfigurations in the indexer for a given namespace.
-func (s networkFabricConfigurationNamespaceLister) List(selector labels.Selector) (ret []*v1.NetworkFabricConfiguration, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1.NetworkFabricConfiguration))
-	})
-	return ret, err
-}
-
-// Get retrieves the NetworkFabricConfiguration from the indexer for a given namespace and name.
-func (s networkFabricConfigurationNamespaceLister) Get(name string) (*v1.NetworkFabricConfiguration, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the NetworkFabricConfiguration from the index for a given name.
+func (s *networkFabricConfigurationLister) Get(name string) (*v1.NetworkFabricConfiguration, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fabricattachment/listers/aci.fabricattachment/v1/networkfabricl3configuration.go
+++ b/pkg/fabricattachment/listers/aci.fabricattachment/v1/networkfabricl3configuration.go
@@ -30,8 +30,9 @@ type NetworkFabricL3ConfigurationLister interface {
 	// List lists all NetworkFabricL3Configurations in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.NetworkFabricL3Configuration, err error)
-	// NetworkFabricL3Configurations returns an object that can list and get NetworkFabricL3Configurations.
-	NetworkFabricL3Configurations(namespace string) NetworkFabricL3ConfigurationNamespaceLister
+	// Get retrieves the NetworkFabricL3Configuration from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1.NetworkFabricL3Configuration, error)
 	NetworkFabricL3ConfigurationListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *networkFabricL3ConfigurationLister) List(selector labels.Selector) (ret
 	return ret, err
 }
 
-// NetworkFabricL3Configurations returns an object that can list and get NetworkFabricL3Configurations.
-func (s *networkFabricL3ConfigurationLister) NetworkFabricL3Configurations(namespace string) NetworkFabricL3ConfigurationNamespaceLister {
-	return networkFabricL3ConfigurationNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// NetworkFabricL3ConfigurationNamespaceLister helps list and get NetworkFabricL3Configurations.
-// All objects returned here must be treated as read-only.
-type NetworkFabricL3ConfigurationNamespaceLister interface {
-	// List lists all NetworkFabricL3Configurations in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.NetworkFabricL3Configuration, err error)
-	// Get retrieves the NetworkFabricL3Configuration from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.NetworkFabricL3Configuration, error)
-	NetworkFabricL3ConfigurationNamespaceListerExpansion
-}
-
-// networkFabricL3ConfigurationNamespaceLister implements the NetworkFabricL3ConfigurationNamespaceLister
-// interface.
-type networkFabricL3ConfigurationNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all NetworkFabricL3Configurations in the indexer for a given namespace.
-func (s networkFabricL3ConfigurationNamespaceLister) List(selector labels.Selector) (ret []*v1.NetworkFabricL3Configuration, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1.NetworkFabricL3Configuration))
-	})
-	return ret, err
-}
-
-// Get retrieves the NetworkFabricL3Configuration from the indexer for a given namespace and name.
-func (s networkFabricL3ConfigurationNamespaceLister) Get(name string) (*v1.NetworkFabricL3Configuration, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the NetworkFabricL3Configuration from the index for a given name.
+func (s *networkFabricL3ConfigurationLister) Get(name string) (*v1.NetworkFabricL3Configuration, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/hostagent/testdata/aci.fabricattachment_networkfabricl3configurations.yaml
+++ b/pkg/hostagent/testdata/aci.fabricattachment_networkfabricl3configurations.yaml
@@ -103,7 +103,6 @@ spec:
                               required:
                               - nodeRef
                               - primaryAddress
-                              - secondaryAddresses
                               type: object
                             type: array
                           primarySubnet:
@@ -330,7 +329,6 @@ spec:
                               required:
                               - nodeRef
                               - primaryAddress
-                              - secondaryAddresses
                               type: object
                             type: array
                           primarySubnet:


### PR DESCRIPTION
client-gen flags need to be explicitly marked nonnamespaced. Other fixes for Status CRD.