### PR TITLE
Skip opflexODev delete from controller

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -1104,6 +1104,9 @@ func (conn *ApicConnection) Delete(dn string) bool {
 			obj := NewDeleteHostprotRemoteIp(addr)
 			conn.log.Debug("Posting delete of dn ", dn)
 			return conn.postDn(dn, obj)
+		} else if iSlice[0] == "odev" {
+			conn.log.Debug("Skipping delete of opflexODev : ", dn)
+			return false
 		}
 	}
 	return conn.DeleteDn(dn)


### PR DESCRIPTION
When there are mutiple opflexODev update requests at same time, controller was sending opflexODev delete request to APIC. Modified code to avoid opflexODev delete API calls from controller