### PR TITLE
Set unkMacUcastAct of service BD as proxy

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -266,6 +266,10 @@ type ControllerConfig struct {
 	// Configure sleep time for global SNAT sync
 	SleepTimeSnatGlobalInfoSync int `json:"sleep-time-snat-global-info-sync,omitempty"`
 
+	// Configure unkMacUcastAct attribute of service BD
+	// The forwarding method for unknown layer 2 destinations
+	UnknownMacUnicastAction string `json:"unkown-mac-unicast-action,omitempty"`
+
 	// PhysDom for additional networks in chained mode
 	AciPhysDom string `json:"aci-phys-dom,omitempty"`
 
@@ -340,6 +344,7 @@ func InitFlags(config *ControllerConfig) {
 	flag.IntVar(&config.MaxCSRTunnels, "max-csr-tunnels", 16, "Number of CSR tunnels")
 	flag.IntVar(&config.CSRTunnelIDBase, "csr-tunnel-id-base", 4001, "CSR starting tunnel ID")
 	flag.BoolVar(&config.EnableVmmInjectedLabels, "enable-vmm-injected-labels", false, "Enable creation of VmmInjectedLabel")
+	flag.StringVar(&config.UnknownMacUnicastAction, "unkown-mac-unicast-action", "proxy", "Set the forwarding method for unknown mac for service BD")
 	flag.BoolVar(&config.ChainedMode, "chained-mode", false, "CNI is in chained mode")
 	flag.BoolVar(&config.ReconcileStaticObjects, "reconcile-static-objects", false, "controller will reconcile implicit static objects")
 	flag.BoolVar(&config.AciUseGlobalScopeVlan, "aci-use-global-scope-vlan", false, "Use global vlans for NADs in chained mode")

--- a/pkg/controller/config_test.go
+++ b/pkg/controller/config_test.go
@@ -87,6 +87,7 @@ func TestInitFlags(t *testing.T) {
 		EnableVmmInjectedLabels:           false,
 		OpflexDeviceDeleteTimeout:         0,
 		SleepTimeSnatGlobalInfoSync:       0,
+		UnknownMacUnicastAction:           "proxy",
 		AciPhysDom:                        "",
 		ChainedMode:                       false,
 		AciAdditionalAep:                  "",

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -240,7 +240,7 @@ func (cont *AciController) staticServiceObjs() apicapi.ApicSlice {
 	}
 	bd.SetAttr("arpFlood", "yes")
 	bd.SetAttr("ipLearning", "no")
-	bd.SetAttr("unkMacUcastAct", "flood")
+	bd.SetAttr("unkMacUcastAct", cont.config.UnknownMacUnicastAction)
 	bdToOut := apicapi.NewRsBdToOut(bd.GetDn(), cont.config.AciL3Out)
 	bd.AddChild(bdToOut)
 	bdToVrf := apicapi.NewRsCtx(bd.GetDn(), cont.config.AciVrf)


### PR DESCRIPTION
As fabric is already already aware of the MAC address, there is no need to learn MAC and the forwarding method for unknown MAC can be proxy instead of flood.

Added changes to set unkMacUcastAct of service BD as proxy instead of MAC. To change it to flood, unkown-mac-unicast-action field in controller configmap can be set to proxy

(cherry picked from commit 4b3ef4d0e5c23b8764dfeae309e392b4246c8386)