### PR TITLE
Fixes for NFCL3 Status

### DIFF
--- a/crd-code-generation/hack/update-codegen-accprovisioninput.sh
+++ b/crd-code-generation/hack/update-codegen-accprovisioninput.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/accprovisioninput github.com/noironetworks/aci-containers/pkg/accprovisioninput/apis \
   aci.ctrl:v1alpha1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-containersoperator.sh
+++ b/crd-code-generation/hack/update-codegen-containersoperator.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/acicontainersoperator github.com/noironetworks/aci-containers/pkg/acicontainersoperator/apis \
   aci.ctrl:v1alpha1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-erspan.sh
+++ b/crd-code-generation/hack/update-codegen-erspan.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT="$(dirname "${PWD}")"
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/erspanpolicy github.com/noironetworks/aci-containers/pkg/erspanpolicy/apis \
   aci.erspan:v1alpha \
   --go-header-file "${SCRIPT_ROOT}"/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-fabricattachment.sh
+++ b/crd-code-generation/hack/update-codegen-fabricattachment.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/fabricattachment github.com/noironetworks/aci-containers/pkg/fabricattachment/apis \
   aci.fabricattachment:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-hpp.sh
+++ b/crd-code-generation/hack/update-codegen-hpp.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/hpp github.com/noironetworks/aci-containers/pkg/hpp/apis \
   aci.hpp:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-istio.sh
+++ b/crd-code-generation/hack/update-codegen-istio.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/istiocrd github.com/noironetworks/aci-containers/pkg/istiocrd/apis \
   aci.istio:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-netflow.sh
+++ b/crd-code-generation/hack/update-codegen-netflow.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/netflowpolicy github.com/noironetworks/aci-containers/pkg/netflowpolicy/apis \
   aci.netflow:v1alpha \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-nodepodif.sh
+++ b/crd-code-generation/hack/update-codegen-nodepodif.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/nodepodif github.com/noironetworks/aci-containers/pkg/nodepodif/apis \
   acipolicy:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-rdconfig.sh
+++ b/crd-code-generation/hack/update-codegen-rdconfig.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/rdconfig github.com/noironetworks/aci-containers/pkg/rdconfig/apis \
   aci.snat:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-snat.sh
+++ b/crd-code-generation/hack/update-codegen-snat.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/snatpolicy github.com/noironetworks/aci-containers/pkg/snatpolicy/apis \
   aci.snat:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-snatglobalinfo.sh
+++ b/crd-code-generation/hack/update-codegen-snatglobalinfo.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/snatglobalinfo github.com/noironetworks/aci-containers/pkg/snatglobalinfo/apis \
   aci.snat:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-snatlocalinfo.sh
+++ b/crd-code-generation/hack/update-codegen-snatlocalinfo.sh
@@ -7,7 +7,7 @@ set -o nounset
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/snatlocalinfo github.com/noironetworks/aci-containers/pkg/snatlocalinfo/apis \
   aci.snat:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen-snatnodeinfo.sh
+++ b/crd-code-generation/hack/update-codegen-snatnodeinfo.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh all \
+vendor/k8s.io/code-generator/kube_codegen.sh all \
   github.com/noironetworks/aci-containers/pkg/nodeinfo github.com/noironetworks/aci-containers/pkg/nodeinfo/apis \
   aci.snat:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/crd-code-generation/hack/update-codegen.sh
+++ b/crd-code-generation/hack/update-codegen.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/generate-groups.sh client,deepcopy,informer,lister \
+vendor/k8s.io/code-generator/kube_codegen.sh client,deepcopy,informer,lister \
   github.com/noironetworks/aci-containers/pkg/gbpcrd github.com/noironetworks/aci-containers/pkg/gbpcrd/apis \
   acipolicy:v1 \
   --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt

--- a/pkg/controller/networkfabricl3configurations_test.go
+++ b/pkg/controller/networkfabricl3configurations_test.go
@@ -328,7 +328,7 @@ func NFCL3CRUDCase(t *testing.T, additionalVlans string, aciPrefix string, preex
 	labelKey = cont.aciNameForKey("nfna", epgName)
 	expectedApicSlice1 = CreateNFNASVIObjs(cont, 101, preexisting_l3out, use_regular_svi)
 	assert.Equal(t, expectedApicSlice1, progMap[labelKey], "nfna create floating svi")
-	status := cont.computeNetworkFabricL3ConfigurationStatus()
+	status := cont.computeNetworkFabricL3ConfigurationStatus(false)
 	expectedStatus := GetNFCL3Status(101, sviType, preexisting_l3out)
 	assert.Equal(t, expectedStatus.Vrfs[0].DirectlyConnectedNetworks[0].FabricL3Network, status.Vrfs[0].DirectlyConnectedNetworks[0].FabricL3Network, "nfcl3status svi")
 	if expectedStatus.Vrfs[0].DirectlyConnectedNetworks[0].Nodes[0].NodeRef != status.Vrfs[0].DirectlyConnectedNetworks[0].Nodes[0].NodeRef {
@@ -378,7 +378,7 @@ func NFCL3RestoreCase(t *testing.T, additionalVlans string, aciPrefix string, pr
 	cont.updateNodeFabNetAttObj(nfna1)
 	nfcL3Obj = CreateNFCL3(101, sviType, preexisting_l3out)
 	cont.updateNetworkFabricL3ConfigObj(nfcL3Obj)
-	status := cont.computeNetworkFabricL3ConfigurationStatus()
+	status := cont.computeNetworkFabricL3ConfigurationStatus(false)
 	assert.Equal(t, expectedStatus.Vrfs[0].DirectlyConnectedNetworks[0].FabricL3Network, status.Vrfs[0].DirectlyConnectedNetworks[0].FabricL3Network, "nfcl3status svi")
 	if expectedStatus.Vrfs[0].DirectlyConnectedNetworks[0].Nodes[0].NodeRef != status.Vrfs[0].DirectlyConnectedNetworks[0].Nodes[0].NodeRef {
 		assert.Equal(t, expectedStatus.Vrfs[0].DirectlyConnectedNetworks[0].Nodes[0], status.Vrfs[0].DirectlyConnectedNetworks[0].Nodes[1], "nfcl3status svi ipam")

--- a/pkg/controller/nodefabricnetworkattachments.go
+++ b/pkg/controller/nodefabricnetworkattachments.go
@@ -291,7 +291,7 @@ func (cont *AciController) populateNodeFabNetAttPaths(epg apicapi.ApicObject, en
 		}
 	}
 	if ctxt.present {
-		cont.updateNetworkFabricL3ConfigurationStatus()
+		cont.updateNetworkFabricL3ConfigurationStatus(true)
 	}
 }
 
@@ -572,6 +572,7 @@ func (cont *AciController) deleteNodeFabNetAttGlobalEncapVlanLocked(vlan int, no
 			delete(cont.sharedEncapNfcAppProfileMap[apKey], vlan)
 			if len(cont.sharedEncapNfcAppProfileMap[apKey]) == 0 {
 				progMap[apKey] = nil
+				delete(cont.sharedEncapNfcAppProfileMap, apKey)
 			}
 		}
 		return
@@ -589,7 +590,7 @@ func (cont *AciController) deleteNodeFabNetAttGlobalEncapVlanLocked(vlan int, no
 			if _, ok := cont.sharedEncapNfcAppProfileMap[apLabel]; !ok {
 				var apicSlice apicapi.ApicSlice
 				cont.sharedEncapNfcAppProfileMap[apLabel] = make(map[int]bool)
-				ap := apicapi.NewFvAP(nfcEpgTenant, nfcEpgAp)
+				ap := cont.createNodeFabNetAttAp(nfcEpgAp, nfcEpgTenant)
 				apicSlice = append(apicSlice, ap)
 				apKey := cont.aciNameForKey("ap", apLabel)
 				progMap[apKey] = apicSlice
@@ -692,7 +693,7 @@ func (cont *AciController) applyNodeFabNetAttObjLocked(vlans []int, addNet *Addi
 				apLabel := "tenant_" + tenantName + "_" + nfcEpgAp
 				if _, ok := cont.sharedEncapNfcAppProfileMap[apLabel]; !ok {
 					cont.sharedEncapNfcAppProfileMap[apLabel] = make(map[int]bool)
-					ap := apicapi.NewFvAP(nfcEpgTenant, nfcEpgAp)
+					ap := cont.createNodeFabNetAttAp(nfcEpgAp, nfcEpgTenant)
 					apicSlice = append(apicSlice, ap)
 					apKey := cont.aciNameForKey("ap", apLabel)
 					progMap[apKey] = apicSlice
@@ -757,7 +758,7 @@ func (cont *AciController) applyNodeFabNetAttObjLocked(vlans []int, addNet *Addi
 				apLabel := "tenant_" + tenantName + "_" + nfcEpgAp
 				if _, ok := cont.sharedEncapNfcAppProfileMap[apLabel]; !ok {
 					cont.sharedEncapNfcAppProfileMap[apLabel] = make(map[int]bool)
-					ap := apicapi.NewFvAP(nfcEpgTenant, nfcEpgAp)
+					ap := cont.createNodeFabNetAttAp(nfcEpgAp, nfcEpgTenant)
 					apicSlice = append(apicSlice, ap)
 					apKey := cont.aciNameForKey("ap", apLabel)
 					progMap[apKey] = apicSlice

--- a/pkg/controller/nodefabricnetworkl3peers_test.go
+++ b/pkg/controller/nodefabricnetworkl3peers_test.go
@@ -118,7 +118,7 @@ func NodeFabricNetworkL3PeerCRUDCase(t *testing.T, additionalVlans string, aciPr
 	expectedApicSlice1 = CreateNFNASVIObjs(cont, 101, preexisting_l3out, use_regular_svi)
 	assert.Equal(t, expectedApicSlice1, progMap[labelKey], "nfna create floating svi")
 	expectedL3Peers := GetNodeFabricNetworkL3PeerStatus(101)
-	l3peers := cont.computeNodeFabricNetworkL3PeerStatus()
+	l3peers := cont.computeNodeFabricNetworkL3PeerStatus(false)
 	for _, peerInfo := range l3peers.PeeringInfo {
 		sort.Sort(TestFabL3OutNodes(peerInfo.FabricNodes))
 	}
@@ -132,7 +132,7 @@ func NodeFabricNetworkL3PeerCRUDCase(t *testing.T, additionalVlans string, aciPr
 	nfcObjCount = 1
 	assert.Equal(t, nfcObjCount, len(delProgMap), "nfna update epg count")
 	expectedL3Peers = &fabattv1.NodeFabricNetworkL3PeerStatus{}
-	l3peers = cont.computeNodeFabricNetworkL3PeerStatus()
+	l3peers = cont.computeNodeFabricNetworkL3PeerStatus(false)
 	assert.Equal(t, expectedL3Peers, l3peers, "nfna nodefabricl3peers status ond delete")
 	delProgMap = cont.deleteNodeFabNetAttObj("master1.cluster.local_" + nfna1.Spec.NetworkRef.Namespace + "/" + nfna1.Spec.NetworkRef.Name)
 	assert.Equal(t, 2, len(delProgMap), "nfna delete epg count")

--- a/pkg/fabricattachment/apis/aci.fabricattachment/v1/nodefabricnetworkl3peer_types.go
+++ b/pkg/fabricattachment/apis/aci.fabricattachment/v1/nodefabricnetworkl3peer_types.go
@@ -28,8 +28,8 @@ type NADFabricL3Peer struct {
 }
 
 type NodeFabricNetworkL3PeerStatus struct {
-	NADRefs     []NADFabricL3Peer            `json:"nadRefs"`
-	PeeringInfo []NetworkFabricL3PeeringInfo `json:"peeringInfo"`
+	NADRefs     []NADFabricL3Peer            `json:"nadRefs,omitempty"`
+	PeeringInfo []NetworkFabricL3PeeringInfo `json:"peeringInfo,omitempty"`
 }
 
 // +genclient

--- a/pkg/hostagent/testdata/aci.fabricattachment_nodefabricnetworkl3peers.yaml
+++ b/pkg/hostagent/testdata/aci.fabricattachment_nodefabricnetworkl3peers.yaml
@@ -123,9 +123,6 @@ spec:
                   - encap
                   type: object
                 type: array
-            required:
-            - nadRefs
-            - peeringInfo
             type: object
         type: object
         x-kubernetes-validations:


### PR DESCRIPTION
fixes issues related to updating status for multiple l3 outs fixes application profile not getting created in some cases make some fields in nodefabricnetworkl3peer optional to handle empty NFCL3 CR. update codegen to use kube_codegen.sh as earlier script is now deprecated and not functional.