### PR TITLE
Donot remove networkpolicy key from hppcache if spec is same

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -2293,7 +2293,9 @@ func (cont *AciController) networkPolicyChanged(oldobj interface{},
 	}
 
 	if cont.config.HppOptimization || cont.config.EnableHppDirect {
-		cont.removeFromHppCache(oldnp, npkey)
+		if !reflect.DeepEqual(oldnp.Spec, newnp.Spec) {
+			cont.removeFromHppCache(oldnp, npkey)
+		}
 	}
 
 	cont.indexMutex.Lock()


### PR DESCRIPTION
Donot remove networkpolicy key from hppcache when a networkpolicy change is detected and if the spec if the new networkpolicy is same as the new one. The networkpolicy key is added back to the cache for networkpolicy change only when there is change in spec