### PR TITLE
Donot remove networkpolicy key from hppcache if spec is same

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -1412,7 +1412,9 @@ func (cont *AciController) networkPolicyChanged(oldobj interface{},
 	}
 
 	if cont.config.HppOptimization {
-		cont.removeFromHppCache(oldnp, npkey)
+		if !reflect.DeepEqual(oldnp.Spec, newnp.Spec) {
+			cont.removeFromHppCache(oldnp, npkey)
+		}
 	}
 
 	cont.writeApicNP(npkey, newnp)


### PR DESCRIPTION
Donot remove networkpolicy key from hppcache when a networkpolicy change is detected and if the spec if the new networkpolicy is same as the new one. The networkpolicy key is added back to the cache for networkpolicy change only when there is change in spec

(cherry picked from commit fab28b4417cde8b64b92f24ea6ef3659f36eb6e4)