### PR TITLE
Preprovision svi

### DIFF
--- a/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricl3configurations_types.go
+++ b/pkg/fabricattachment/apis/aci.fabricattachment/v1/networkfabricl3configurations_types.go
@@ -69,14 +69,15 @@ type FabricL3Subnet struct {
 }
 
 type PrimaryNetwork struct {
-	L3OutName           string        `json:"l3OutName"`
-	L3OutOnCommonTenant bool          `json:"l3OutOnCommonTenant,omitempty"`
-	UseExistingL3Out    bool          `json:"useExistingL3Out,omitempty"`
-	MaxNodes            int           `json:"maxNodes,omitempty"`
-	Encap               int           `json:"encap"`
-	SviType             FabricSviType `json:"sviType,omitempty"`
-	PrimarySubnet       string        `json:"primarySubnet"`
-	BGPPeerPolicy       BGPPeerPolicy `json:"bgpPeerPolicy,omitempty"`
+	L3OutName             string        `json:"l3OutName"`
+	L3OutOnCommonTenant   bool          `json:"l3OutOnCommonTenant,omitempty"`
+	UseExistingL3Out      bool          `json:"useExistingL3Out,omitempty"`
+	MaxNodes              int           `json:"maxNodes,omitempty"`
+	Encap                 int           `json:"encap"`
+	SviType               FabricSviType `json:"sviType,omitempty"`
+	RequirePodToProvision bool          `json:"requirePodToProvision,omitempty"`
+	PrimarySubnet         string        `json:"primarySubnet"`
+	BGPPeerPolicy         BGPPeerPolicy `json:"bgpPeerPolicy,omitempty"`
 }
 
 type FabricL3Network struct {

--- a/pkg/hostagent/testdata/aci.fabricattachment_networkfabricl3configurations.yaml
+++ b/pkg/hostagent/testdata/aci.fabricattachment_networkfabricl3configurations.yaml
@@ -107,6 +107,8 @@ spec:
                             type: array
                           primarySubnet:
                             type: string
+                          requirePodToProvision:
+                            type: boolean
                           subnets:
                             items:
                               properties:
@@ -333,6 +335,8 @@ spec:
                             type: array
                           primarySubnet:
                             type: string
+                          requirePodToProvision:
+                            type: boolean
                           status:
                             type: string
                           subnets:


### PR DESCRIPTION
To avoid race conditions with first pod,
have a knob at the svi level, defaulting to false, on whether we wait for the first pod to bring up svi. 
Additional fixes for custom node address, routerId.