### PR TITLE
Typo fix in unknown-mac-unicast-action

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -268,7 +268,7 @@ type ControllerConfig struct {
 
 	// Configure unkMacUcastAct attribute of service BD
 	// The forwarding method for unknown layer 2 destinations
-	UnknownMacUnicastAction string `json:"unkown-mac-unicast-action,omitempty"`
+	UnknownMacUnicastAction string `json:"unknown-mac-unicast-action,omitempty"`
 
 	// PhysDom for additional networks in chained mode
 	AciPhysDom string `json:"aci-phys-dom,omitempty"`


### PR DESCRIPTION
(cherry picked from commit 05382632c196af94ea113a1aa1a683f0925cc766)