### PR TITLE
Handle suboptimal peers

### DIFF
--- a/pkg/webhook/types/webhook_types.go
+++ b/pkg/webhook/types/webhook_types.go
@@ -38,6 +38,7 @@ type RunTimeData struct {
 }
 
 type Config struct {
+	UnitTestMode         bool
 	RequireNADAnnotation bool
 	ContainerName        string
 	RunTimeData


### PR DESCRIPTION
In case of pods on non-anchor nodes,
return list of all anchor nodes as peers,
router pod can then decide which peers to choose.
Affinities along with peers can be published, this is TBD. In case of regular svi, there will always be optimal peers.