### PR TITLE
LLDPIf Cache updates

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -832,6 +832,11 @@ var metadata = map[string]*apicMeta{
 			"l3extRsDynPathAtt",
 		},
 	},
+	// lldpIf is read-only
+	"lldpIf": {
+		attributes: map[string]interface{}{},
+		children:   []string{},
+	},
 	"l3extIp": {
 		attributes: map[string]interface{}{
 			"addr": "",

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -281,10 +281,14 @@ func testChainedController(aciPrefix string, aciUseGlobalScopeVlan bool, additio
 	}
 	cont.InitController()
 	// Hardcode lldpIfMOs
-	cont.lldpIfCache["topology/pod-1/node-101/pathep-[eth1/34]"] = "topology/pod-1/protpaths-101-102/pathep-[test-bond1]"
-	cont.lldpIfCache["topology/pod-1/node-102/pathep-[eth1/34]"] = "topology/pod-1/protpaths-101-102/pathep-[test-bond1]"
-	cont.lldpIfCache["topology/pod-1/node-101/pathep-[eth1/31]"] = "topology/pod-1/protpaths-101-102/pathep-[test-bond2]"
-	cont.lldpIfCache["topology/pod-1/node-102/pathep-[eth1/31]"] = "topology/pod-1/protpaths-101-102/pathep-[test-bond2]"
+	cont.lldpIfCache["topology/pod-1/node-101/pathep-[eth1/34]"] = &NfLLDPIfData{LLDPIf: "topology/pod-1/protpaths-101-102/pathep-[test-bond1]",
+		Refs: map[string]bool{"default-test-nad": true}}
+	cont.lldpIfCache["topology/pod-1/node-102/pathep-[eth1/34]"] = &NfLLDPIfData{LLDPIf: "topology/pod-1/protpaths-101-102/pathep-[test-bond1]",
+		Refs: map[string]bool{"default-test-nad": true}}
+	cont.lldpIfCache["topology/pod-1/node-101/pathep-[eth1/31]"] = &NfLLDPIfData{LLDPIf: "topology/pod-1/protpaths-101-102/pathep-[test-bond2]",
+		Refs: map[string]bool{"default-test-nad": true}}
+	cont.lldpIfCache["topology/pod-1/node-102/pathep-[eth1/31]"] = &NfLLDPIfData{LLDPIf: "topology/pod-1/protpaths-101-102/pathep-[test-bond2]",
+		Refs: map[string]bool{"default-test-nad": true}}
 	return cont
 }
 

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -392,6 +392,11 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 		go cont.syncOpflexDevices(stopCh, 60)
 		go cont.syncDelayedEpSlices(stopCh, 1)
 		go cont.syncNodeAciPods(stopCh, 1)
+	} else {
+		go cont.processLLDPIfQueue(cont.lldpIfQueue,
+			func(obj interface{}) bool {
+				return cont.handleLLDPIfUpdate(obj.(string))
+			}, stopCh)
 	}
 	return nil
 }


### PR DESCRIPTION
Remove checks around allowing multiple disagg. Ifs for NADs. Subscribe to individual LLDPIfs to avoid scale issues and handle cache updates.