### PR TITLE
Provide option to disable service vlan preprovisioning

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -270,6 +270,10 @@ type ControllerConfig struct {
 	// The forwarding method for unknown layer 2 destinations
 	UnknownMacUnicastAction string `json:"unknown-mac-unicast-action,omitempty"`
 
+	// To disable service vlan preprovisioning on OpenShift on OpenStack Clusters
+	// By default the feature will be enabled
+	DisableServiceVlanPreprovisioning bool `json:"disable-service-vlan-preprovisioning"`
+
 	// PhysDom for additional networks in chained mode
 	AciPhysDom string `json:"aci-phys-dom,omitempty"`
 

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1411,7 +1411,7 @@ func (cont *AciController) opflexDeviceChanged(obj apicapi.ApicObject) {
 	domName := obj.GetAttrStr("domName")
 	ctrlrName := obj.GetAttrStr("ctrlrName")
 
-	if strings.Contains(cont.config.Flavor, "openstack") {
+	if !cont.config.DisableServiceVlanPreprovisioning && strings.Contains(cont.config.Flavor, "openstack") {
 		if cont.openStackOpflexOdevUpdate(obj) {
 			cont.log.Info("OpenStack opflexODev for ", obj.GetAttrStr("hostName"), " is added")
 			cont.updateDeviceCluster()


### PR DESCRIPTION
If disable-service-vlan-preprovisioning parameter is set as True in controller configmap, then service vlan programming will not be done on openstack compute hosts

(cherry picked from commit 52c826ba935456a378e3de1eba96cf8e965d4070)