### PR TITLE
Backport ProactiveConf changes to mmr-6.1.1

### DIFF
--- a/pkg/controller/epgcache.go
+++ b/pkg/controller/epgcache.go
@@ -144,7 +144,7 @@ func (cont *AciController) handleEpgDnCacheUpdate(epgDnCacheUpdated bool) bool {
 			cont.log.Error("proactiveConfClient not found")
 			return false
 		}
-		ProactiveConfList, err := pccl.AciV1().ProactiveConfs(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+		ProactiveConfList, err := pccl.AciV1().ProactiveConfs().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			cont.log.Errorf("Failed to get ProactiveConfs: %v", err)
 			return false

--- a/pkg/controller/proactiveconf.go
+++ b/pkg/controller/proactiveconf.go
@@ -55,10 +55,10 @@ func (cont *AciController) initProactiveConfInformerFromClient(
 	cont.initProactiveConfInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return proactiveConfClient.AciV1().ProactiveConfs(metav1.NamespaceAll).List(context.TODO(), options)
+				return proactiveConfClient.AciV1().ProactiveConfs().List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return proactiveConfClient.AciV1().ProactiveConfs(metav1.NamespaceAll).Watch(context.TODO(), options)
+				return proactiveConfClient.AciV1().ProactiveConfs().Watch(context.TODO(), options)
 			},
 		})
 }
@@ -169,12 +169,12 @@ func (cont *AciController) postfvRsDomAtt(fvRsDomAttSlice []apicapi.ApicObject) 
 	}
 }
 
-func (cont *AciController) updateFvRsDomAttInstrImedcy(fvRsDomAttSlice []apicapi.ApicObject, immediacy string) {
+func (cont *AciController) updateFvRsDomAttImmediacy(fvRsDomAttSlice []apicapi.ApicObject, instrImedcy, resImedcy string) {
 	for _, fvRsDomAtt := range fvRsDomAttSlice {
 		dn := fvRsDomAtt.GetAttr("dn").(string)
 		fvRsDomAttNew := apicapi.EmptyApicObject("fvRsDomAtt", dn)
-		fvRsDomAttNew.SetAttr("instrImedcy", immediacy)
-		fvRsDomAttNew.SetAttr("resImedcy", immediacy)
+		fvRsDomAttNew.SetAttr("instrImedcy", instrImedcy)
+		fvRsDomAttNew.SetAttr("resImedcy", resImedcy)
 		cont.postfvRsDomAtt([]apicapi.ApicObject{fvRsDomAttNew})
 	}
 }
@@ -186,12 +186,12 @@ func (cont *AciController) updateProactiveConf(policy *pcv1.ProactiveConf) {
 	fvRsDomAttSlice := cont.getfvRsDomAtt()
 
 	if vmmEpgDeploymentImmediacy == pcv1.VmmEpgDeploymentImmediacyTypeImmediate {
-		cont.updateFvRsDomAttInstrImedcy(fvRsDomAttSlice, "immediate")
+		cont.updateFvRsDomAttImmediacy(fvRsDomAttSlice, "immediate", "pre-provision")
 	} else {
 		cont.deleteProactiveConf(fvRsDomAttSlice)
 	}
 }
 
 func (cont *AciController) deleteProactiveConf(fvRsDomAttSlice []apicapi.ApicObject) {
-	cont.updateFvRsDomAttInstrImedcy(fvRsDomAttSlice, "lazy")
+	cont.updateFvRsDomAttImmediacy(fvRsDomAttSlice, "lazy", "lazy")
 }

--- a/pkg/hostagent/proactiveconf.go
+++ b/pkg/hostagent/proactiveconf.go
@@ -37,10 +37,10 @@ func (agent *HostAgent) initProactiveConfInformerFromClient(
 	agent.initProactiveConfInformerBase(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				return proactiveConfClient.AciV1().ProactiveConfs(metav1.NamespaceAll).List(context.TODO(), options)
+				return proactiveConfClient.AciV1().ProactiveConfs().List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				return proactiveConfClient.AciV1().ProactiveConfs(metav1.NamespaceAll).Watch(context.TODO(), options)
+				return proactiveConfClient.AciV1().ProactiveConfs().Watch(context.TODO(), options)
 			},
 		})
 }

--- a/pkg/proactiveconf/apis/aci.pc/v1/types.go
+++ b/pkg/proactiveconf/apis/aci.pc/v1/types.go
@@ -19,8 +19,10 @@ type ProactiveConfSpec struct {
 
 // +genclient
 // +genclient:noStatus
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Cluster
+// +kubebuilder:validation:XValidation:rule="self.metadata.name == 'proactiveconf'",message="Only one instance allowed with name proactiveconf"
 // ProactiveConf is the Schema for the proactiveconfs API
 type ProactiveConf struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/proactiveconf/applyconfiguration/aci.pc/v1/proactiveconf.go
+++ b/pkg/proactiveconf/applyconfiguration/aci.pc/v1/proactiveconf.go
@@ -33,10 +33,9 @@ type ProactiveConfApplyConfiguration struct {
 
 // ProactiveConf constructs an declarative configuration of the ProactiveConf type for use with
 // apply.
-func ProactiveConf(name, namespace string) *ProactiveConfApplyConfiguration {
+func ProactiveConf(name string) *ProactiveConfApplyConfiguration {
 	b := &ProactiveConfApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("ProactiveConf")
 	b.WithAPIVersion("aci.pc/v1")
 	return b

--- a/pkg/proactiveconf/clientset/versioned/typed/aci.pc/v1/aci.pc_client.go
+++ b/pkg/proactiveconf/clientset/versioned/typed/aci.pc/v1/aci.pc_client.go
@@ -35,8 +35,8 @@ type AciV1Client struct {
 	restClient rest.Interface
 }
 
-func (c *AciV1Client) ProactiveConfs(namespace string) ProactiveConfInterface {
-	return newProactiveConfs(c, namespace)
+func (c *AciV1Client) ProactiveConfs() ProactiveConfInterface {
+	return newProactiveConfs(c)
 }
 
 // NewForConfig creates a new AciV1Client for the given config.

--- a/pkg/proactiveconf/clientset/versioned/typed/aci.pc/v1/fake/fake_aci.pc_client.go
+++ b/pkg/proactiveconf/clientset/versioned/typed/aci.pc/v1/fake/fake_aci.pc_client.go
@@ -27,8 +27,8 @@ type FakeAciV1 struct {
 	*testing.Fake
 }
 
-func (c *FakeAciV1) ProactiveConfs(namespace string) v1.ProactiveConfInterface {
-	return &FakeProactiveConfs{c, namespace}
+func (c *FakeAciV1) ProactiveConfs() v1.ProactiveConfInterface {
+	return &FakeProactiveConfs{c}
 }
 
 // RESTClient returns a RESTClient that is used to communicate

--- a/pkg/proactiveconf/clientset/versioned/typed/aci.pc/v1/fake/fake_proactiveconf.go
+++ b/pkg/proactiveconf/clientset/versioned/typed/aci.pc/v1/fake/fake_proactiveconf.go
@@ -34,7 +34,6 @@ import (
 // FakeProactiveConfs implements ProactiveConfInterface
 type FakeProactiveConfs struct {
 	Fake *FakeAciV1
-	ns   string
 }
 
 var proactiveconfsResource = v1.SchemeGroupVersion.WithResource("proactiveconfs")
@@ -44,8 +43,7 @@ var proactiveconfsKind = v1.SchemeGroupVersion.WithKind("ProactiveConf")
 // Get takes name of the proactiveConf, and returns the corresponding proactiveConf object, and an error if there is any.
 func (c *FakeProactiveConfs) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ProactiveConf, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(proactiveconfsResource, c.ns, name), &v1.ProactiveConf{})
-
+		Invokes(testing.NewRootGetAction(proactiveconfsResource, name), &v1.ProactiveConf{})
 	if obj == nil {
 		return nil, err
 	}
@@ -55,8 +53,7 @@ func (c *FakeProactiveConfs) Get(ctx context.Context, name string, options metav
 // List takes label and field selectors, and returns the list of ProactiveConfs that match those selectors.
 func (c *FakeProactiveConfs) List(ctx context.Context, opts metav1.ListOptions) (result *v1.ProactiveConfList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewListAction(proactiveconfsResource, proactiveconfsKind, c.ns, opts), &v1.ProactiveConfList{})
-
+		Invokes(testing.NewRootListAction(proactiveconfsResource, proactiveconfsKind, opts), &v1.ProactiveConfList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -77,15 +74,13 @@ func (c *FakeProactiveConfs) List(ctx context.Context, opts metav1.ListOptions) 
 // Watch returns a watch.Interface that watches the requested proactiveConfs.
 func (c *FakeProactiveConfs) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(proactiveconfsResource, c.ns, opts))
-
+		InvokesWatch(testing.NewRootWatchAction(proactiveconfsResource, opts))
 }
 
 // Create takes the representation of a proactiveConf and creates it.  Returns the server's representation of the proactiveConf, and an error, if there is any.
 func (c *FakeProactiveConfs) Create(ctx context.Context, proactiveConf *v1.ProactiveConf, opts metav1.CreateOptions) (result *v1.ProactiveConf, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(proactiveconfsResource, c.ns, proactiveConf), &v1.ProactiveConf{})
-
+		Invokes(testing.NewRootCreateAction(proactiveconfsResource, proactiveConf), &v1.ProactiveConf{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +90,7 @@ func (c *FakeProactiveConfs) Create(ctx context.Context, proactiveConf *v1.Proac
 // Update takes the representation of a proactiveConf and updates it. Returns the server's representation of the proactiveConf, and an error, if there is any.
 func (c *FakeProactiveConfs) Update(ctx context.Context, proactiveConf *v1.ProactiveConf, opts metav1.UpdateOptions) (result *v1.ProactiveConf, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(proactiveconfsResource, c.ns, proactiveConf), &v1.ProactiveConf{})
-
+		Invokes(testing.NewRootUpdateAction(proactiveconfsResource, proactiveConf), &v1.ProactiveConf{})
 	if obj == nil {
 		return nil, err
 	}
@@ -106,14 +100,13 @@ func (c *FakeProactiveConfs) Update(ctx context.Context, proactiveConf *v1.Proac
 // Delete takes name of the proactiveConf and deletes it. Returns an error if one occurs.
 func (c *FakeProactiveConfs) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	_, err := c.Fake.
-		Invokes(testing.NewDeleteActionWithOptions(proactiveconfsResource, c.ns, name, opts), &v1.ProactiveConf{})
-
+		Invokes(testing.NewRootDeleteActionWithOptions(proactiveconfsResource, name, opts), &v1.ProactiveConf{})
 	return err
 }
 
 // DeleteCollection deletes a collection of objects.
 func (c *FakeProactiveConfs) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOpts metav1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(proactiveconfsResource, c.ns, listOpts)
+	action := testing.NewRootDeleteCollectionAction(proactiveconfsResource, listOpts)
 
 	_, err := c.Fake.Invokes(action, &v1.ProactiveConfList{})
 	return err
@@ -122,8 +115,7 @@ func (c *FakeProactiveConfs) DeleteCollection(ctx context.Context, opts metav1.D
 // Patch applies the patch and returns the patched proactiveConf.
 func (c *FakeProactiveConfs) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ProactiveConf, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(proactiveconfsResource, c.ns, name, pt, data, subresources...), &v1.ProactiveConf{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(proactiveconfsResource, name, pt, data, subresources...), &v1.ProactiveConf{})
 	if obj == nil {
 		return nil, err
 	}
@@ -144,8 +136,7 @@ func (c *FakeProactiveConfs) Apply(ctx context.Context, proactiveConf *acipcv1.P
 		return nil, fmt.Errorf("proactiveConf.Name must be provided to Apply")
 	}
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(proactiveconfsResource, c.ns, *name, types.ApplyPatchType, data), &v1.ProactiveConf{})
-
+		Invokes(testing.NewRootPatchSubresourceAction(proactiveconfsResource, *name, types.ApplyPatchType, data), &v1.ProactiveConf{})
 	if obj == nil {
 		return nil, err
 	}

--- a/pkg/proactiveconf/clientset/versioned/typed/aci.pc/v1/proactiveconf.go
+++ b/pkg/proactiveconf/clientset/versioned/typed/aci.pc/v1/proactiveconf.go
@@ -35,7 +35,7 @@ import (
 // ProactiveConfsGetter has a method to return a ProactiveConfInterface.
 // A group's client should implement this interface.
 type ProactiveConfsGetter interface {
-	ProactiveConfs(namespace string) ProactiveConfInterface
+	ProactiveConfs() ProactiveConfInterface
 }
 
 // ProactiveConfInterface has methods to work with ProactiveConf resources.
@@ -55,14 +55,12 @@ type ProactiveConfInterface interface {
 // proactiveConfs implements ProactiveConfInterface
 type proactiveConfs struct {
 	client rest.Interface
-	ns     string
 }
 
 // newProactiveConfs returns a ProactiveConfs
-func newProactiveConfs(c *AciV1Client, namespace string) *proactiveConfs {
+func newProactiveConfs(c *AciV1Client) *proactiveConfs {
 	return &proactiveConfs{
 		client: c.RESTClient(),
-		ns:     namespace,
 	}
 }
 
@@ -70,7 +68,6 @@ func newProactiveConfs(c *AciV1Client, namespace string) *proactiveConfs {
 func (c *proactiveConfs) Get(ctx context.Context, name string, options metav1.GetOptions) (result *v1.ProactiveConf, err error) {
 	result = &v1.ProactiveConf{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("proactiveconfs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
@@ -87,7 +84,6 @@ func (c *proactiveConfs) List(ctx context.Context, opts metav1.ListOptions) (res
 	}
 	result = &v1.ProactiveConfList{}
 	err = c.client.Get().
-		Namespace(c.ns).
 		Resource("proactiveconfs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -104,7 +100,6 @@ func (c *proactiveConfs) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 	}
 	opts.Watch = true
 	return c.client.Get().
-		Namespace(c.ns).
 		Resource("proactiveconfs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -115,7 +110,6 @@ func (c *proactiveConfs) Watch(ctx context.Context, opts metav1.ListOptions) (wa
 func (c *proactiveConfs) Create(ctx context.Context, proactiveConf *v1.ProactiveConf, opts metav1.CreateOptions) (result *v1.ProactiveConf, err error) {
 	result = &v1.ProactiveConf{}
 	err = c.client.Post().
-		Namespace(c.ns).
 		Resource("proactiveconfs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(proactiveConf).
@@ -128,7 +122,6 @@ func (c *proactiveConfs) Create(ctx context.Context, proactiveConf *v1.Proactive
 func (c *proactiveConfs) Update(ctx context.Context, proactiveConf *v1.ProactiveConf, opts metav1.UpdateOptions) (result *v1.ProactiveConf, err error) {
 	result = &v1.ProactiveConf{}
 	err = c.client.Put().
-		Namespace(c.ns).
 		Resource("proactiveconfs").
 		Name(proactiveConf.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
@@ -141,7 +134,6 @@ func (c *proactiveConfs) Update(ctx context.Context, proactiveConf *v1.Proactive
 // Delete takes name of the proactiveConf and deletes it. Returns an error if one occurs.
 func (c *proactiveConfs) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("proactiveconfs").
 		Name(name).
 		Body(&opts).
@@ -156,7 +148,6 @@ func (c *proactiveConfs) DeleteCollection(ctx context.Context, opts metav1.Delet
 		timeout = time.Duration(*listOpts.TimeoutSeconds) * time.Second
 	}
 	return c.client.Delete().
-		Namespace(c.ns).
 		Resource("proactiveconfs").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
@@ -169,7 +160,6 @@ func (c *proactiveConfs) DeleteCollection(ctx context.Context, opts metav1.Delet
 func (c *proactiveConfs) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ProactiveConf, err error) {
 	result = &v1.ProactiveConf{}
 	err = c.client.Patch(pt).
-		Namespace(c.ns).
 		Resource("proactiveconfs").
 		Name(name).
 		SubResource(subresources...).
@@ -196,7 +186,6 @@ func (c *proactiveConfs) Apply(ctx context.Context, proactiveConf *acipcv1.Proac
 	}
 	result = &v1.ProactiveConf{}
 	err = c.client.Patch(types.ApplyPatchType).
-		Namespace(c.ns).
 		Resource("proactiveconfs").
 		Name(*name).
 		VersionedParams(&patchOpts, scheme.ParameterCodec).

--- a/pkg/proactiveconf/informers/externalversions/aci.pc/v1/interface.go
+++ b/pkg/proactiveconf/informers/externalversions/aci.pc/v1/interface.go
@@ -40,5 +40,5 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 
 // ProactiveConfs returns a ProactiveConfInformer.
 func (v *version) ProactiveConfs() ProactiveConfInformer {
-	return &proactiveConfInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+	return &proactiveConfInformer{factory: v.factory, tweakListOptions: v.tweakListOptions}
 }

--- a/pkg/proactiveconf/informers/externalversions/aci.pc/v1/proactiveconf.go
+++ b/pkg/proactiveconf/informers/externalversions/aci.pc/v1/proactiveconf.go
@@ -41,33 +41,32 @@ type ProactiveConfInformer interface {
 type proactiveConfInformer struct {
 	factory          internalinterfaces.SharedInformerFactory
 	tweakListOptions internalinterfaces.TweakListOptionsFunc
-	namespace        string
 }
 
 // NewProactiveConfInformer constructs a new informer for ProactiveConf type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewProactiveConfInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
-	return NewFilteredProactiveConfInformer(client, namespace, resyncPeriod, indexers, nil)
+func NewProactiveConfInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return NewFilteredProactiveConfInformer(client, resyncPeriod, indexers, nil)
 }
 
 // NewFilteredProactiveConfInformer constructs a new informer for ProactiveConf type.
 // Always prefer using an informer factory to get a shared informer instead of getting an independent
 // one. This reduces memory footprint and number of connections to the server.
-func NewFilteredProactiveConfInformer(client versioned.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
+func NewFilteredProactiveConfInformer(client versioned.Interface, resyncPeriod time.Duration, indexers cache.Indexers, tweakListOptions internalinterfaces.TweakListOptionsFunc) cache.SharedIndexInformer {
 	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AciV1().ProactiveConfs(namespace).List(context.TODO(), options)
+				return client.AciV1().ProactiveConfs().List(context.TODO(), options)
 			},
 			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 				if tweakListOptions != nil {
 					tweakListOptions(&options)
 				}
-				return client.AciV1().ProactiveConfs(namespace).Watch(context.TODO(), options)
+				return client.AciV1().ProactiveConfs().Watch(context.TODO(), options)
 			},
 		},
 		&acipcv1.ProactiveConf{},
@@ -77,7 +76,7 @@ func NewFilteredProactiveConfInformer(client versioned.Interface, namespace stri
 }
 
 func (f *proactiveConfInformer) defaultInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFilteredProactiveConfInformer(client, f.namespace, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
+	return NewFilteredProactiveConfInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc}, f.tweakListOptions)
 }
 
 func (f *proactiveConfInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/proactiveconf/listers/aci.pc/v1/expansion_generated.go
+++ b/pkg/proactiveconf/listers/aci.pc/v1/expansion_generated.go
@@ -20,7 +20,3 @@ package v1
 // ProactiveConfListerExpansion allows custom methods to be added to
 // ProactiveConfLister.
 type ProactiveConfListerExpansion interface{}
-
-// ProactiveConfNamespaceListerExpansion allows custom methods to be added to
-// ProactiveConfNamespaceLister.
-type ProactiveConfNamespaceListerExpansion interface{}

--- a/pkg/proactiveconf/listers/aci.pc/v1/proactiveconf.go
+++ b/pkg/proactiveconf/listers/aci.pc/v1/proactiveconf.go
@@ -30,8 +30,9 @@ type ProactiveConfLister interface {
 	// List lists all ProactiveConfs in the indexer.
 	// Objects returned here must be treated as read-only.
 	List(selector labels.Selector) (ret []*v1.ProactiveConf, err error)
-	// ProactiveConfs returns an object that can list and get ProactiveConfs.
-	ProactiveConfs(namespace string) ProactiveConfNamespaceLister
+	// Get retrieves the ProactiveConf from the index for a given name.
+	// Objects returned here must be treated as read-only.
+	Get(name string) (*v1.ProactiveConf, error)
 	ProactiveConfListerExpansion
 }
 
@@ -53,41 +54,9 @@ func (s *proactiveConfLister) List(selector labels.Selector) (ret []*v1.Proactiv
 	return ret, err
 }
 
-// ProactiveConfs returns an object that can list and get ProactiveConfs.
-func (s *proactiveConfLister) ProactiveConfs(namespace string) ProactiveConfNamespaceLister {
-	return proactiveConfNamespaceLister{indexer: s.indexer, namespace: namespace}
-}
-
-// ProactiveConfNamespaceLister helps list and get ProactiveConfs.
-// All objects returned here must be treated as read-only.
-type ProactiveConfNamespaceLister interface {
-	// List lists all ProactiveConfs in the indexer for a given namespace.
-	// Objects returned here must be treated as read-only.
-	List(selector labels.Selector) (ret []*v1.ProactiveConf, err error)
-	// Get retrieves the ProactiveConf from the indexer for a given namespace and name.
-	// Objects returned here must be treated as read-only.
-	Get(name string) (*v1.ProactiveConf, error)
-	ProactiveConfNamespaceListerExpansion
-}
-
-// proactiveConfNamespaceLister implements the ProactiveConfNamespaceLister
-// interface.
-type proactiveConfNamespaceLister struct {
-	indexer   cache.Indexer
-	namespace string
-}
-
-// List lists all ProactiveConfs in the indexer for a given namespace.
-func (s proactiveConfNamespaceLister) List(selector labels.Selector) (ret []*v1.ProactiveConf, err error) {
-	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
-		ret = append(ret, m.(*v1.ProactiveConf))
-	})
-	return ret, err
-}
-
-// Get retrieves the ProactiveConf from the indexer for a given namespace and name.
-func (s proactiveConfNamespaceLister) Get(name string) (*v1.ProactiveConf, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+// Get retrieves the ProactiveConf from the index for a given name.
+func (s *proactiveConfLister) Get(name string) (*v1.ProactiveConf, error) {
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Do not use cachedEpgDns to filter out fvRsDomAtt
    
```
As cachedEpgDns are updated only for APIC version >=5.2, to allow
for compatiability with previous versions removed the logic to use
cachedEpgDns to filter out the EPGs for which the fvRsDomAtt needs
to be updated on ProactiveConf update. As the vmmDomPDn is used to
filter checking for Dns in cachedEpgDns was redundant.

(cherry picked from commit c8926ac9f6e7709ff86d7c47eb51700055a3b529)
```
    
Change to set VMM domain association resolution immediacy
    
```
When the VmmEpgDeploymentImmediacy is Immediate in ProactiveConf
CR the resolution immediacy of fvRsDomAtt is set to 'pre-provision'

(cherry picked from commit 5953693726d4e49a97f2173c79f1029917e22a61)
```