### PR TITLE
Fixes related to cluster wide SNAT policy

### DIFF
--- a/pkg/hostagent/snatlocalinfo.go
+++ b/pkg/hostagent/snatlocalinfo.go
@@ -140,6 +140,9 @@ func (agent *HostAgent) UpdateLocalInfoCr() bool {
 		Spec := snatLocalInfov1.SnatLocalInfoSpec{
 			LocalInfos: localInfos,
 		}
+		if len(localInfos) == 0 {
+			return agent.deleteLocalInfoCr()
+		}
 		if !reflect.DeepEqual(snatLocalInfoCr.Spec, Spec) {
 			snatLocalInfoCr.Spec = Spec
 			_, err = snatLocalInfoClient.AciV1().SnatLocalInfos(agent.config.AciSnatNamespace).Update(context.TODO(), snatLocalInfoCr, metav1.UpdateOptions{})

--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -821,7 +821,7 @@ func (agent *HostAgent) syncSnat() bool {
 			}
 			seen[uuid] = true
 		} else {
-			logger.Info("Removing snat")
+			logger.Info("Removing snat ", snatfile)
 			os.Remove(snatfile)
 		}
 	}
@@ -1277,9 +1277,11 @@ func (agent *HostAgent) handleObjectDeleteForSnat(obj interface{}) {
 		agent.snatPolicyCacheMutex.RUnlock()
 		for _, uid := range poduids {
 			if getResourceType(obj) == SERVICE {
-				agent.log.Debug("Service deleted update the localInfo: ", name)
 				for _, res := range resources {
-					agent.deleteSnatLocalInfo(uid, res, name)
+					if res == SERVICE {
+						agent.deleteSnatLocalInfo(uid, res, name)
+						agent.log.Debug("Service deleted update the localInfo: ", name)
+					}
 				}
 			} else {
 				delete(agent.opflexSnatLocalInfos, uid)


### PR DESCRIPTION
1. When a cluster wide SNAT policy is present and service SNAT policy is created along with service, SNAT files was not getting deleted when service SNAT policy or the service is deleted.

   Root cause: When a SNAT policy name is deleted from the NodeInfo CR, that information was not updated in SnatGlobalInfo CR

   Fix: Added fix to remove the SNAT entries that are not present in the NodeInfo from SnatGlobalInfo cache and thereby from the SnatGlobalInfo CR

2. When a cluster wide SNAT policy is present and a service is deleted, the SNAT uuid of cluster wide SNAT policy was getting removed from EP file of the service endpoints.

   Root cause: When a service is deleted, all the SNAT policies applicable to the service endpoints were deleted from SnatLocalInfo

   Fix: When service is deleted, only service SNAT policy is removed from the SnatLocalInfo