### PR TITLE
Optimize local hpp MO sync

### DIFF
--- a/pkg/hostagent/group_assign.go
+++ b/pkg/hostagent/group_assign.go
@@ -146,7 +146,9 @@ func (agent *HostAgent) mergeNetPolSg(podkey string, pod *v1.Pod,
 		return sgval, nil
 	}
 
-	agent.scheduleSyncHppMo()
+	if agent.config.EnableHppDirect {
+		agent.scheduleSyncLocalHppMo()
+	}
 
 	return g, nil
 }

--- a/pkg/hostagent/hpp.go
+++ b/pkg/hostagent/hpp.go
@@ -295,10 +295,10 @@ func (agent *HostAgent) updateLocalHpp(obj interface{}) {
 		agent.updateNetpolFile(*modb, labelKey)
 	}
 
-	agent.scheduleSyncHppMo()
+	agent.scheduleSyncLocalHppMo()
 }
 
-func (agent *HostAgent) syncHppMo() bool {
+func (agent *HostAgent) syncLocalHppMo() bool {
 	agent.indexMutex.Lock()
 	defer agent.indexMutex.Unlock()
 


### PR DESCRIPTION
Start local hpp MO sync only if HPP Direct is enabled

Issue:
hppLocalMoSyncQueue is called even when the local hpp is not enabled, causing syncHppMo to be called continuously.