### PR TITLE
Increase subscription refresh offset

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -510,7 +510,11 @@ func (conn *ApicConnection) AddImmediateSubscriptionDnLocked(dn string,
 	if deleteHook != nil {
 		conn.subscriptions.subs[dn].deleteHook = deleteHook
 	}
-	return conn.subscribe(dn, conn.subscriptions.subs[dn], true)
+	if conn.connection != nil {
+		return conn.subscribe(dn, conn.subscriptions.subs[dn], true)
+	} else {
+		return false
+	}
 }
 
 func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -757,7 +757,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 
 	// If RefreshTickerAdjustInterval is not defined, default to 150Sec.
 	if cont.config.ApicRefreshTickerAdjust == "" {
-		cont.config.ApicRefreshTickerAdjust = "150"
+		cont.config.ApicRefreshTickerAdjust = "210"
 	}
 	refreshTickerAdjust, err := strconv.Atoi(cont.config.ApicRefreshTickerAdjust)
 	if err != nil {

--- a/pkg/controller/nodefabricnetworkattachments.go
+++ b/pkg/controller/nodefabricnetworkattachments.go
@@ -206,6 +206,7 @@ func (cont *AciController) clearLLDPIf(addNetKey string) {
 		if _, ok := lldpIfData.Refs[addNetKey]; !ok {
 			continue
 		}
+		cont.log.Info("clear lldpIf: deleted mapping for ", fabricLink)
 		delete(cont.lldpIfCache[fabricLink].Refs, addNetKey)
 		if len(cont.lldpIfCache[fabricLink].Refs) == 0 {
 			dn := strings.Replace(fabricLink, "/pathep-", "/sys/lldp/inst/if-", 1)


### PR DESCRIPTION
Atleast with lldpIf MO, subscription expiry seems to happen atleast 190 secs earlier than expected, so
increasing the offset to 210 seconds.