### PR TITLE
Fix openvswitch-base dockerfile for openssl-lib & openssl-fips-provider

### DIFF
--- a/docker/travis/Dockerfile-openvswitch-base
+++ b/docker/travis/Dockerfile-openvswitch-base
@@ -1,8 +1,8 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
- && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
- && yum --nogpgcheck -y update
+ && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os
+RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
 RUN yum --nogpgcheck --disablerepo=\*ubi\* install -y \
   libtool pkgconfig autoconf automake make file python3-six \
   openssl-devel git gcc gcc-c++ diffutils python3-devel \


### PR DESCRIPTION
version mismatch error