### PR TITLE
acikubectl - collect opflex-agent connection status

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -477,6 +477,13 @@ func clusterReport(cmd *cobra.Command, args []string) {
 			args:     []string{"-urq", "DmtreeRoot"},
 		},
 		{
+			path:     "cluster-report/cmds/node-%s/opflex-agent-conn-status.log",
+			cont:     "opflex-agent",
+			selector: opflexAgentSelector,
+			argFunc:  otherNodeArgs,
+			args:     []string{"sh", "-c", "netstat -antp | grep 8009"},
+		},
+		{
 			path:     "cluster-report/cmds/node-%s/ovs-ofctl-show-int.log",
 			cont:     "aci-containers-openvswitch",
 			selector: openvswitchSelector,


### PR DESCRIPTION
Include the opflex agent connection status using netstat in the cluster report

(cherry picked from commit c70f3c0f9a0a32420056787c77cc9918104e26b1)
(cherry picked from commit 265c7a159e635dd17463c29368282b57b30d9ae2)