### PR TITLE
Multipod vm migration fixes

### DIFF
--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -436,6 +436,7 @@ func (cont *AciController) nodeChanged(obj interface{}) {
 			if cont.nodeSyncEnabled {
 				if aciPodAnn != nodeAciPod && nodeAciPod != "" {
 					node.ObjectMeta.Annotations[metadata.AciPodAnnotation] = nodeAciPod
+					logger.Info("ACI pod annotation for multipod on node ", node.ObjectMeta.Name, "changed from ", aciPodAnn, " to ", nodeAciPod)
 					nodeUpdated = true
 				}
 			}

--- a/pkg/hostagent/nodes.go
+++ b/pkg/hostagent/nodes.go
@@ -119,7 +119,7 @@ func (agent *HostAgent) nodeChanged(obj ...interface{}) {
 				if err != nil {
 					agent.log.Error("Failed to inform opflex-agent about opflexOdev disconnect ", err)
 				} else {
-					agent.log.Debug("Informed opflex-agent about opflexOdev disconnect")
+					agent.log.Info("Informed opflex-agent about opflexOdev disconnect")
 				}
 			}
 			agent.nodeAciPodAnnotation = nodeAciPod


### PR DESCRIPTION
* Stop retrying dhcp release and renew when the vlan interface gets an ip which is not from old pod subnet
* Retry dhcp release if the ip is not released in first try
* Add more info level logs

(cherry picked from commit 5ccc166cc7c587042f7c724935d504816da14dd0) (cherry picked from commit 6caeb37e6415e0daddba9cca95aa1a253244eef2)