### PR TITLE
Preserve range to address brownfield cases

### DIFF
--- a/pkg/controller/fabricvlanpools.go
+++ b/pkg/controller/fabricvlanpools.go
@@ -135,7 +135,7 @@ func (cont *AciController) updateFabricVlanPool(obj interface{}) map[string]apic
 	if !ok {
 		nsVlanPoolMap = make(map[string]string)
 	}
-	_, _, vlanStr, err := util.ParseVlanList(fabricVlanPoolObj.Spec.Vlans)
+	_, _, vlanStr, err := util.ParseVlanListWithRangePreserved(fabricVlanPoolObj.Spec.Vlans)
 	if err != nil {
 		cont.log.Error(err)
 	}

--- a/pkg/controller/nodefabricnetworkattachments.go
+++ b/pkg/controller/nodefabricnetworkattachments.go
@@ -48,7 +48,7 @@ func (cont *AciController) updateGlobalConfig(encapStr string, progMap map[strin
 		cont.log.Errorf("Cannot set globalscope objects in per-port vlan mode")
 		return
 	}
-	_, encapBlks, _, err := util.ParseVlanList([]string{encapStr})
+	_, encapBlks, _, err := util.ParseVlanListWithRangePreserved([]string{encapStr})
 	if err != nil {
 		cont.log.Errorf("Error updating GlobalScopeVlanConfig: %v", err)
 		return

--- a/pkg/controller/nodefabricnetworkattachments_test.go
+++ b/pkg/controller/nodefabricnetworkattachments_test.go
@@ -18,6 +18,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/noironetworks/aci-containers/pkg/apicapi"
@@ -70,13 +71,21 @@ func CreateNFNADom(nfna *fabattv1.NodeFabricNetworkAttachment, encapStr string, 
 		networkName = "secondary"
 	}
 	fvnsVlanInstP := apicapi.NewFvnsVlanInstP("kubernetes", networkName)
-	var fvnsEncapBlk apicapi.ApicObject
+	var fvnsEncapBlk1, fvnsEncapBlk2 apicapi.ApicObject
 	if cont.config.AciUseGlobalScopeVlan {
-		fvnsEncapBlk = apicapi.NewFvnsEncapBlk(fvnsVlanInstP.GetDn(), "100", "101")
+		if strings.Contains(encapStr, ",") {
+			fvnsEncapBlk1 = apicapi.NewFvnsEncapBlk(fvnsVlanInstP.GetDn(), "100", "100")
+			fvnsEncapBlk2 = apicapi.NewFvnsEncapBlk(fvnsVlanInstP.GetDn(), "101", "101")
+			fvnsVlanInstP.AddChild(fvnsEncapBlk1)
+			fvnsVlanInstP.AddChild(fvnsEncapBlk2)
+		} else {
+			fvnsEncapBlk1 = apicapi.NewFvnsEncapBlk(fvnsVlanInstP.GetDn(), "100", "101")
+			fvnsVlanInstP.AddChild(fvnsEncapBlk1)
+		}
 	} else {
-		fvnsEncapBlk = apicapi.NewFvnsEncapBlk(fvnsVlanInstP.GetDn(), "5", "6")
+		fvnsEncapBlk1 = apicapi.NewFvnsEncapBlk(fvnsVlanInstP.GetDn(), "5", "6")
+		fvnsVlanInstP.AddChild(fvnsEncapBlk1)
 	}
-	fvnsVlanInstP.AddChild(fvnsEncapBlk)
 	apicSlice = append(apicSlice, fvnsVlanInstP)
 	physDom := apicapi.NewPhysDomP("kubernetes-" + networkName)
 	infraRsVlanNs := apicapi.NewInfraRsVlanNs(physDom.GetDn(), fvnsVlanInstP.GetDn())


### PR DESCRIPTION
vlan ranges will be preserved if added as a separate item to the vlan list in fabricvlanpool CRs.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit 0dda9fa25376d82bde27c45cda81ab78acf090de)