### PR TITLE
Skip vlan pool delete

### DIFF
--- a/pkg/controller/networkfabricconfigurations_test.go
+++ b/pkg/controller/networkfabricconfigurations_test.go
@@ -200,9 +200,9 @@ func NFCCRUDCase(t *testing.T, additionalVlans string, explicitAp bool, discover
 	assert.Equal(t, expectedApicSlice3, delProgMap[labelKey], "nfna update global epg vlan 101")
 	delProgMap = cont.deleteNodeFabNetAttObj("master1.cluster.local_" + nfna1.Spec.NetworkRef.Namespace + "/" + nfna1.Spec.NetworkRef.Name)
 
-	lenEpgObjs = 2
+	lenEpgObjs = 1
 	if discoveryType == fabattv1.StaticPathMgmtTypeAEP {
-		lenEpgObjs = 3
+		lenEpgObjs = 2
 	}
 	assert.Equal(t, lenEpgObjs, len(delProgMap), "nfna delete epg count")
 }

--- a/pkg/controller/networkfabricl3configurations_test.go
+++ b/pkg/controller/networkfabricl3configurations_test.go
@@ -353,7 +353,7 @@ func NFCL3CRUDCase(t *testing.T, additionalVlans string, aciPrefix string, preex
 	nfcObjCount = 1
 	assert.Equal(t, nfcObjCount, len(delProgMap), "nfna update epg count")
 	delProgMap = cont.deleteNodeFabNetAttObj("master1.cluster.local_" + nfna1.Spec.NetworkRef.Namespace + "/" + nfna1.Spec.NetworkRef.Name)
-	assert.Equal(t, 2, len(delProgMap), "nfna delete epg count")
+	assert.Equal(t, 1, len(delProgMap), "nfna delete epg count")
 }
 
 func TestNFCL3CRUD(t *testing.T) {

--- a/pkg/controller/nodefabricnetworkattachments.go
+++ b/pkg/controller/nodefabricnetworkattachments.go
@@ -1036,10 +1036,12 @@ func (cont *AciController) deleteNodeFabNetAttObj(key string) (progMap map[strin
 				cont.deleteNodeFabNetAttGlobalEncapVlanLocked(encap, nodeName, nodeFabNetAttKey, progMap)
 			}
 			cont.clearLLDPIf(nodeFabNetAttKey)
+			/* Avoid deleting vlan pool as the deletes can be reordered on APIC
 			if len(cont.additionalNetworkCache) == 0 {
 				cont.clearGlobalScopeVlanConfig(progMap)
 				return progMap
 			}
+			*/
 			return progMap
 		}
 	}

--- a/pkg/controller/nodefabricnetworkattachments_test.go
+++ b/pkg/controller/nodefabricnetworkattachments_test.go
@@ -347,7 +347,7 @@ func NFNACRUDCase(t *testing.T, globalScopeVlan bool, additionalVlans string, ac
 
 	if globalScopeVlan {
 		cont.log.Debugf("%v", progMap)
-		assert.Equal(t, 3, len(progMap), "nfna delete apicKey count")
+		assert.Equal(t, 2, len(progMap), "nfna delete apicKey count")
 
 	} else {
 		assert.Equal(t, 1, len(progMap), "nfna create apicKey count")

--- a/pkg/controller/nodefabricnetworkl3peers_test.go
+++ b/pkg/controller/nodefabricnetworkl3peers_test.go
@@ -135,7 +135,7 @@ func NodeFabricNetworkL3PeerCRUDCase(t *testing.T, additionalVlans string, aciPr
 	l3peers = cont.computeNodeFabricNetworkL3PeerStatus(false)
 	assert.Equal(t, expectedL3Peers, l3peers, "nfna nodefabricl3peers status ond delete")
 	delProgMap = cont.deleteNodeFabNetAttObj("master1.cluster.local_" + nfna1.Spec.NetworkRef.Namespace + "/" + nfna1.Spec.NetworkRef.Name)
-	assert.Equal(t, 2, len(delProgMap), "nfna delete epg count")
+	assert.Equal(t, 1, len(delProgMap), "nfna delete epg count")
 }
 
 func TestNodeFabricL3PeersCRUD(t *testing.T) {


### PR DESCRIPTION
On deleting the last NAD, avoid deleting vlan pool as deletes can be processed out of order and
vlan pool delete may not go through.

Signed-off-by: Kiran Shastri <shastrinator@gmail.com>
(cherry picked from commit 9d14f8b1dfb65829ec582d52a9be026ab9b42b95)