### PR TITLE
Use ubi9-minimal latest to address vulnerabilities

### DIFF
--- a/docker/travis/Dockerfile-host
+++ b/docker/travis/Dockerfile-host
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3 as base
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest as base
 # Required OpenShift Labels
 LABEL name="ACI CNI Host-Agent" \
 vendor="Cisco" \
@@ -13,6 +13,8 @@ RUN microdnf install -y yum yum-utils \
 
 RUN yum update --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os -y --nogpgcheck && rm -rf /var/cache/yum
 RUN yum install --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os dhcp-client curl iptables-nft jq nmstate tar -y --allowerasing --nogpgcheck && rm -rf /var/cache/yum
+
+RUN yum update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y && rm -rf /var/cache/yum
 
 COPY dist-static/iptables-libs.tar.gz dist-static/iptables-bin.tar.gz dist-static/iptables-wrapper-installer.sh /tmp/
 RUN tar -zxf /tmp/iptables-bin.tar.gz -C /usr/sbin \

--- a/docker/travis/Dockerfile-openvswitch
+++ b/docker/travis/Dockerfile-openvswitch
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN microdnf install -y yum yum-utils
 RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
 RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \

--- a/docker/travis/Dockerfile-openvswitch-base
+++ b/docker/travis/Dockerfile-openvswitch-base
@@ -1,19 +1,29 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.3
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os
+
 RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
-RUN yum --nogpgcheck --disablerepo=\*ubi\* install -y \
+
+RUN yum --nogpgcheck --disablerepo=* install --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os -y \
   libtool pkgconfig autoconf automake make file python3-six \
-  openssl-devel git gcc gcc-c++ diffutils python3-devel \
+  git gcc gcc-c++ diffutils python3-devel \
   expat-devel wget which curl-devel libcap-devel \
   logrotate conntrack-tools tcpdump strace ltrace iptables net-tools \
   hostname vi iproute \
  && yum clean all
+
+RUN yum update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y && rm -rf /var/cache/yum
+
+RUN yum --nogpgcheck --disablerepo=* install --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y \
+  openssl-devel \
+ && yum clean all
+
 RUN wget https://nlnetlabs.nl/downloads/unbound/unbound-1.17.1.tar.gz \
  && tar zxvf unbound-1.17.1.tar.gz \
  && cd unbound-1.17.1 \
  && ./configure && make && make install
+
 RUN git clone https://github.com/openvswitch/ovs.git \
  && cd ovs \
  && git checkout remotes/origin/branch-3.1 \


### PR DESCRIPTION
The issue lies with the openvswitch-base image, specifically related to the openssl-devel package. When this package is installed from the CentOS repository, it causes a downgrade of the openssl-libs package. To ensure the correct version of openssl-libs is installed and remains free from vulnerabilities, openssl-devel is sourced from the UBI 9 repository instead of CentOS.