### PR TITLE
update SnatGlobalInfo CR when uplink MAC address changes

### DIFF
--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -439,6 +439,10 @@ func (agent *HostAgent) discoverHostConfig() (conf *HostAgentNodeConfig) {
 		intf, err := net.InterfaceByName(conf.UplinkIface)
 		if err == nil {
 			conf.UplinkMacAdress = intf.HardwareAddr.String()
+			if conf.UplinkMacAdress != agent.config.UplinkMacAdress {
+				agent.log.Info("UplinkMacAdress updated from ", agent.config.UplinkMacAdress, " to ", conf.UplinkMacAdress)
+				agent.scheduleSyncNodeInfo()
+			}
 			return
 		}
 	}

--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -507,17 +507,18 @@ func (agent *HostAgent) syncSnatNodeInfo() bool {
 			snatPolicyNames[key] = true
 		}
 	}
+	uplinkMacAddress := agent.config.UplinkMacAdress
 	agent.indexMutex.Unlock()
 	env := agent.env.(*K8sEnvironment)
 	if env == nil {
 		return false
 	}
 	// send nodeupdate for the policy names
-	if !agent.InformNodeInfo(env.nodeInfo, snatPolicyNames) {
-		agent.log.Debug("Failed to update retry: ", snatPolicyNames)
+	if !agent.InformNodeInfo(env.nodeInfo, snatPolicyNames, uplinkMacAddress) {
+		agent.log.Debug("Failed to update retry: ", snatPolicyNames, " macAddress:", uplinkMacAddress)
 		return true
 	}
-	agent.log.Debug("Updated Node Info: ", snatPolicyNames)
+	agent.log.Debug("Updated Node Info: ", snatPolicyNames, " macAddress:", uplinkMacAddress)
 	return false
 }
 


### PR DESCRIPTION
When uplink MAC address changes, the SnatGlobalInfo was not getting updated which was causing disruption in SNAT traffic