### PR TITLE
Fix opflexSnatLocalInfos cache deletion logic for pod

### DIFF
--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -566,6 +566,9 @@ func (agent *HostAgent) deleteSnatLocalInfo(poduid string, res ResourceType, plc
 				if len(localinfo.Snatpolicies[res]) == 0 {
 					delete(localinfo.Snatpolicies, res)
 				}
+				if len(localinfo.Snatpolicies) == 0 {
+					delete(agent.opflexSnatLocalInfos, poduid)
+				}
 				if v, ok := agent.snatPods[plcyname]; ok {
 					if _, ok := v[poduid]; ok {
 						agent.snatPods[plcyname][poduid] &= ^(res) // clear the bit
@@ -915,6 +918,7 @@ func (agent *HostAgent) updateEpFiles(poduids []string) {
 	for _, uid := range poduids {
 		localinfo, ok := agent.opflexSnatLocalInfos[uid]
 		if !ok {
+			syncEp = true
 			continue
 		}
 		var i uint = 1
@@ -958,9 +962,6 @@ func (agent *HostAgent) updateEpFiles(poduids []string) {
 			agent.log.Debug("Update EpFile: ", uids)
 			agent.opflexSnatLocalInfos[uid].Existing = false
 			agent.opflexSnatLocalInfos[uid].PlcyUuids = uids
-			if len(uids) == 0 {
-				delete(agent.opflexSnatLocalInfos, uid)
-			}
 			syncEp = true
 		}
 	}


### PR DESCRIPTION
Issue: When multiple SNAT policies are continuously created and deleted, the snatlocalinfos CRs sometimes fail to be created for few nodes.

Root Cause: The opflexSnatLocalInfos for a pod was being deleted within the updateEpFiles function if no SNAT policy was selected for the pod. This function is triggered by both snatpolicy and snatglobalinfos events. In some cases, when a SNAT policy is deleted and recreated, the sequence of create and delete events for snatpolicy and snatglobalinfos can become unordered. This results in the deletion event of the previous SNAT policy occurring after the updation event of the snatglobalinfos for current policy, causing the current cache entry to be deleted after it is created. Consequently, the opflexSnatLocalInfos is not created due to a mismatch between opflexSnatLocalInfos and opflexSnatGlobalInfos.

Fix: The deletion of opflexSnatLocalInfos for a pod has been moved to function deleteSnatLocalInfo, which is triggered only by snatpolicy events and not by snatglobalinfos events.

(cherry picked from commit b700899a8ad4094dff2dae796a2845c840a5f32e)