### PR TITLE
Handled network policies with CIDR for hpp direct

### DIFF
--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -4238,13 +4238,21 @@ func TestBuildLocalNetPolSubjRule(t *testing.T) {
 			},
 			remoteSubnets: []string{"10.0.0.0/24", "192.168.0.0/16"},
 			expectedRule: hppv1.HostprotRule{
-				ConnTrack:                "reflexive",
-				Direction:                "egress",
-				Ethertype:                "ipv4",
-				Protocol:                 "tcp",
-				FromPort:                 "unspecified",
-				ToPort:                   "80",
-				Name:                     "rule1",
+				ConnTrack: "reflexive",
+				Direction: "egress",
+				Ethertype: "ipv4",
+				Protocol:  "tcp",
+				FromPort:  "unspecified",
+				ToPort:    "80",
+				Name:      "rule1",
+				HostprotRemoteIp: []hppv1.HostprotRemoteIp{
+					{
+						Addr: "10.0.0.0/24",
+					},
+					{
+						Addr: "192.168.0.0/16",
+					},
+				},
 				HostprotServiceRemoteIps: []string{"10.0.0.0/24", "192.168.0.0/16"},
 				RsRemoteIpContainer:      []string{"namespace1", "namespace2"},
 				HostprotFilterContainer: hppv1.HostprotFilterContainer{

--- a/pkg/hostagent/hpp.go
+++ b/pkg/hostagent/hpp.go
@@ -258,6 +258,15 @@ func (agent *HostAgent) updateLocalHpp(obj interface{}) {
 						hpRule.Children = append(hpRule.Children, map[string]HpSubjGrandchild{"hostprotRemoteIp": *hpSubnet})
 					}
 				}
+
+				for _, hostprotRemoteIp := range rule.HostprotRemoteIp {
+					hpSubnet := &HpSubjGrandchild{
+						Attributes: map[string]string{
+							"addr": hostprotRemoteIp.Addr,
+						},
+					}
+					hpRule.Children = append(hpRule.Children, map[string]HpSubjGrandchild{"hostprotRemoteIp": *hpSubnet})
+				}
 			}
 
 			hpSubj.Children = append(hpSubj.Children, map[string]HpSubjChild{"hostprotRule": *hpRule})

--- a/pkg/hpp/apis/aci.hpp/v1/types.go
+++ b/pkg/hpp/apis/aci.hpp/v1/types.go
@@ -28,6 +28,7 @@ type HostprotRule struct {
 	FromPort                 string                  `json:"fromPort,omitempty"`
 	RsRemoteIpContainer      []string                `json:"rsRemoteIpContainer,omitempty"`
 	HostprotFilterContainer  HostprotFilterContainer `json:"hostprotFilterContainer,omitempty"`
+	HostprotRemoteIp         []HostprotRemoteIp      `json:"hostprotRemoteIp,omitempty"`
 	HostprotServiceRemoteIps []string                `json:"hostprotServiceRemoteIps,omitempty"`
 }
 


### PR DESCRIPTION
When enable_hpp_direct was enabled, network policies with CIDR were not working as expected as the CIDR was not added to the hostprotpol CR and thus not added to the netpol file provided by host-agent container to the opflex-agent.
Added code to handle it.

(cherry picked from commit b681da881d1acbe3dec66158888e871e244fd2cb)