### PR TITLE
Fix to delete stale NodeInfo CR

### DIFF
--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -28,6 +28,7 @@ import (
 	rdConfig "github.com/noironetworks/aci-containers/pkg/rdconfig/apis/aci.snat/v1"
 	rdconfigclientset "github.com/noironetworks/aci-containers/pkg/rdconfig/clientset/versioned"
 	snatglobalclset "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/clientset/versioned"
+	snatlocalinfoclset "github.com/noironetworks/aci-containers/pkg/snatlocalinfo/clientset/versioned"
 	snatpolicy "github.com/noironetworks/aci-containers/pkg/snatpolicy/apis/aci.snat/v1"
 	snatclientset "github.com/noironetworks/aci-containers/pkg/snatpolicy/clientset/versioned"
 	"github.com/sirupsen/logrus"
@@ -62,6 +63,7 @@ type K8sEnvironment struct {
 	kubeClient          *kubernetes.Clientset
 	snatClient          *snatclientset.Clientset
 	snatGlobalClient    *snatglobalclset.Clientset
+	snatLocalInfoClient *snatlocalinfoclset.Clientset
 	nodeInfoClient      *nodeinfoclientset.Clientset
 	rdConfigClient      *rdconfigclientset.Clientset
 	istioClient         *istioclientset.Clientset
@@ -115,6 +117,11 @@ func NewK8sEnvironment(config *ControllerConfig, log *logrus.Logger) (*K8sEnviro
 		log.Debug("Failed to intialize node info client")
 		return nil, err
 	}
+	snatLocalInfoClient, err := snatlocalinfoclset.NewForConfig(restconfig)
+	if err != nil {
+		log.Debug("Failed to intialize snat local info client")
+		return nil, err
+	}
 	rdConfigClient, err := rdconfigclientset.NewForConfig(restconfig)
 	if err != nil {
 		log.Debug("Failed to intialize rdconfig client")
@@ -137,7 +144,7 @@ func NewK8sEnvironment(config *ControllerConfig, log *logrus.Logger) (*K8sEnviro
 	}
 	return &K8sEnvironment{restConfig: restconfig, kubeClient: kubeClient,
 		snatClient: snatClient, snatGlobalClient: snatGlobalClient,
-		nodeInfoClient: nodeInfoClient, rdConfigClient: rdConfigClient,
+		nodeInfoClient: nodeInfoClient, snatLocalInfoClient: snatLocalInfoClient, rdConfigClient: rdConfigClient,
 		istioClient: istioClient, hppClient: hppClient, proactiveConfClient: proactiveConfClient}, nil
 }
 

--- a/pkg/controller/snatglobalinfo_test.go
+++ b/pkg/controller/snatglobalinfo_test.go
@@ -182,6 +182,10 @@ func snatWaitForIpUpdated(t *testing.T, desc, snatIp string, actual map[string]m
 
 func TestSnatnodeInfo(t *testing.T) {
 	cont := testController()
+
+	cont.fakeNodeSource.Add(node("node-1"))
+	cont.fakeNodeSource.Add(node("node-2"))
+
 	for _, pt := range snatTests {
 		snatObj := snatpolicydata(pt.name, pt.namespace, pt.snatip, pt.labels)
 		cont.fakeSnatPolicySource.Add(snatObj)
@@ -290,6 +294,10 @@ func TestSnatnodeInfo(t *testing.T) {
 
 func TestPeriodicSnatGlobalCacheCachesync(t *testing.T) {
 	cont := testController()
+
+	cont.fakeNodeSource.Add(node("node-1"))
+	cont.fakeNodeSource.Add(node("node-2"))
+
 	for _, pt := range snatTests {
 		snatObj := snatpolicydata(pt.name, pt.namespace, pt.snatip, pt.labels)
 		cont.fakeSnatPolicySource.Add(snatObj)
@@ -353,6 +361,9 @@ func TestPeriodicSnatGlobalCacheCachesync(t *testing.T) {
 
 func TestSnatCfgChangeTest(t *testing.T) {
 	cont := testController()
+
+	cont.fakeNodeSource.Add(node("node-1"))
+
 	for _, pt := range snatTests {
 		snatObj := snatpolicydata(pt.name, pt.namespace, pt.snatip, pt.labels)
 		cont.fakeSnatPolicySource.Add(snatObj)

--- a/pkg/hostagent/nodeinfo.go
+++ b/pkg/hostagent/nodeinfo.go
@@ -31,6 +31,12 @@ func (agent *HostAgent) InformNodeInfo(nodeInfoClient *nodeInfoclientset.Clients
 		agent.log.Debug("nodeInfo or Kube clients are not intialized")
 		return true
 	}
+
+	if !agent.isNodeExists(agent.config.NodeName) {
+		agent.log.Error("Node not present in cluster : ", agent.config.NodeName, ", skipping NodeInfoCR creation/updation")
+		return true
+	}
+
 	nodeInfo, err := nodeInfoClient.AciV1().NodeInfos(agent.config.AciSnatNamespace).Get(context.TODO(), agent.config.NodeName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/hostagent/nodes.go
+++ b/pkg/hostagent/nodes.go
@@ -239,3 +239,11 @@ func (agent *HostAgent) routeInit() {
 		agent.log.Infof("VtepIP: %s, subnet: %+v, interface: %s", agent.vtepIP, nc.Subnet, hostVethName)
 	}
 }
+
+func (agent *HostAgent) isNodeExists(name string) bool {
+	_, exists, err := agent.nodeInformer.GetStore().GetByKey(name)
+	if err == nil && exists {
+		return true
+	}
+	return false
+}

--- a/pkg/hostagent/snatlocalinfo.go
+++ b/pkg/hostagent/snatlocalinfo.go
@@ -119,6 +119,12 @@ func (agent *HostAgent) UpdateLocalInfoCr() bool {
 		}
 	}
 	agent.indexMutex.Unlock()
+
+	if !agent.isNodeExists(agent.config.NodeName) {
+		agent.log.Error("Node not presnt in cluster : ", agent.config.NodeName, ", skipping SnatLocalInfoCR Creation/Updation")
+		return true
+	}
+
 	snatLocalInfoCr, err := snatLocalInfoClient.AciV1().SnatLocalInfos(agent.config.AciSnatNamespace).Get(context.TODO(), agent.config.NodeName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {

--- a/pkg/util/snat.go
+++ b/pkg/util/snat.go
@@ -26,6 +26,7 @@ import (
 	nodeinfoclset "github.com/noironetworks/aci-containers/pkg/nodeinfo/clientset/versioned"
 	snatglobal "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/apis/aci.snat/v1"
 	snatglobalclset "github.com/noironetworks/aci-containers/pkg/snatglobalinfo/clientset/versioned"
+	snatlocalinfoclset "github.com/noironetworks/aci-containers/pkg/snatlocalinfo/clientset/versioned"
 	snatpolicy "github.com/noironetworks/aci-containers/pkg/snatpolicy/apis/aci.snat/v1"
 	snatpolicyclset "github.com/noironetworks/aci-containers/pkg/snatpolicy/clientset/versioned"
 )
@@ -105,6 +106,15 @@ func DeleteNodeInfoCR(c nodeinfoclset.Clientset, name string) error {
 		return err
 	}
 	return nil
+}
+
+func DeleteSnatLocalInfoCr(c snatlocalinfoclset.Clientset, name string) error {
+	ns := os.Getenv("ACI_SNAT_NAMESPACE")
+	_, err := c.AciV1().SnatLocalInfos(ns).Get(context.TODO(), name, metav1.GetOptions{})
+	if err == nil {
+		err = c.AciV1().SnatLocalInfos(ns).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	}
+	return err
 }
 
 func GetPortRangeFromConfigMap(c *kubernetes.Clientset) (snatglobal.PortRange, int) {


### PR DESCRIPTION
When a node is removed from a cluster for which NodeInfo CR was present with snatpolicies, controller was deleting the NodeInfo CR for the node, but hostagent pod for the deleted node was remaining in the cluster for sometime even after the node was removed and it was re-creating the NodeInfo CR and SnatLocalInfo CR which remained as stale resources because of which snatpolicies were in IpPortsExhausted state.

Added fix not to re-create NodeInfo or SnatLocalInfo Cr when node is not present in cluster and delete the stale CRs that are already present in the cluster.

(cherry picked from commit 7598f897a34053e89b7e8e4532d6b554996f89c8)