### PR TITLE
Fix for NetworkPolicy with both egress and ingress

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -747,7 +747,17 @@ func (cont *AciController) peerMatchesPod(npNs string,
 		if err != nil {
 			cont.log.Error("Could not parse namespace selector: ", err)
 		} else {
-			return selector.Matches(labels.Set(podNs.ObjectMeta.Labels))
+			match := selector.Matches(labels.Set(podNs.ObjectMeta.Labels))
+			if match && peer.PodSelector != nil {
+				podSelector, err :=
+					metav1.LabelSelectorAsSelector(peer.PodSelector)
+				if err != nil {
+					cont.log.Error("Could not parse pod selector: ", err)
+				} else {
+					return podSelector.Matches(labels.Set(pod.ObjectMeta.Labels))
+				}
+			}
+			return match
 		}
 	}
 	return false


### PR DESCRIPTION
When a network policy with both egress and ingress is created, where ingress and egress have same namespaceSelector and different podSelector, traffic to and from both ingress pods and egress pods were working.Traffic to ingress pods and fraffic from egress pods should be blocked.

When namespaceSelector is present in network policy, podSelector was not handled. So, both ingress pod ips and egress pod ips were added to both ingress and egress rules. Modified code to consider podSelector also