### PR TITLE
Fix AAEP association delete on full sync

### DIFF
--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -1246,12 +1246,6 @@ func computeRespClasses(targetClasses []string) []string {
 	visited := make(map[string]bool)
 	doComputeRespClasses(targetClasses, visited)
 
-	// Don't include targetclasses in rsp-subtree
-	// because they are implicitly included
-	for i := range targetClasses {
-		delete(visited, targetClasses[i])
-	}
-
 	var respClasses []string
 	for class := range visited {
 		respClasses = append(respClasses, class)

--- a/pkg/controller/networkfabricconfigurations_test.go
+++ b/pkg/controller/networkfabricconfigurations_test.go
@@ -85,7 +85,6 @@ func CreateAepEpgAttachment(vlan int, aep string, discoveryType fabattv1.StaticP
 		infraGeneric := apicapi.NewInfraGeneric(aep)
 		encap := fmt.Sprintf("%d", vlan)
 		infraRsFuncToEpg := apicapi.NewInfraRsFuncToEpg(infraGeneric.GetDn(), epg.GetDn(), encap, "regular")
-		apicSlice = append(apicSlice, infraGeneric)
 		apicSlice = append(apicSlice, infraRsFuncToEpg)
 	}
 	return apicSlice
@@ -150,7 +149,7 @@ func NFCCRUDCase(t *testing.T, additionalVlans string, explicitAp bool, discover
 	assert.Equal(t, 1, len(progMapPool), "dom count")
 	lenEpgObjs := 1
 	if discoveryType == fabattv1.StaticPathMgmtTypeAEP {
-		lenEpgObjs = 2
+		lenEpgObjs = 3
 	}
 	assert.Equal(t, lenEpgObjs, len(progMap), "nfna epg count")
 	expectedApicSlice1 = CreateNFNADom(nfna1, additionalVlans, cont)

--- a/pkg/controller/nodefabricnetworkattachments.go
+++ b/pkg/controller/nodefabricnetworkattachments.go
@@ -404,7 +404,12 @@ func (cont *AciController) createNodeFabNetAttEpgStaticAttachments(vlan int, aep
 		cont.sharedEncapCache[vlan].Aeps[aep] = true
 		progMap[labelKey] = apicSlice2
 		if _, ok := cont.sharedEncapAepCache[aep]; !ok {
+			var apicSlice3 apicapi.ApicSlice
+			labelKey2 := cont.aciNameForKey("aepInfraGeneric", aep)
 			cont.sharedEncapAepCache[aep] = make(map[int]bool)
+			infraGeneric := apicapi.NewInfraGeneric(aep)
+			apicSlice3 = append(apicSlice3, infraGeneric)
+			progMap[labelKey2] = apicSlice3
 		}
 		cont.sharedEncapAepCache[aep][vlan] = true
 	} else {
@@ -412,6 +417,8 @@ func (cont *AciController) createNodeFabNetAttEpgStaticAttachments(vlan int, aep
 		if _, ok := cont.sharedEncapAepCache[aep]; ok {
 			delete(cont.sharedEncapAepCache[aep], vlan)
 			if len(cont.sharedEncapAepCache[aep]) == 0 {
+				labelKey2 := cont.aciNameForKey("aepInfraGeneric", aep)
+				progMap[labelKey2] = nil
 				delete(cont.sharedEncapAepCache, aep)
 				progMap[labelKey] = nil
 				cont.log.Infof("Remove physdom association for AEP %s", aep)
@@ -426,7 +433,6 @@ func (cont *AciController) createNodeFabNetAttEpgStaticAttachments(vlan int, aep
 		infraGeneric := apicapi.NewInfraGeneric(aep)
 		encap := fmt.Sprintf("%d", vlan)
 		infraRsFuncToEpg := apicapi.NewInfraRsFuncToEpg(infraGeneric.GetDn(), epg.GetDn(), encap, "regular")
-		apicSlice = append(apicSlice, infraGeneric)
 		apicSlice = append(apicSlice, infraRsFuncToEpg)
 	}
 	return apicSlice


### PR DESCRIPTION
Push infraGeneric, based on reference instead
of using implicit delete. Include targetclasses
always to prevent subscription errors.