### PR TITLE
Delete stale snatlocalinfo CRs

### DIFF
--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -52,6 +52,7 @@ type testAciController struct {
 	fakeErspanPolicySource    *framework.FakeControllerSource
 	fakeNodePodIFSource       *framework.FakeControllerSource
 	fakeNodeInfoSource        *framework.FakeControllerSource
+	fakeSnatLocalInfoSource   *framework.FakeControllerSource
 	fakeIstioSource           *framework.FakeControllerSource
 	fakeSnatCfgSource         *framework.FakeControllerSource
 	fakeCRDSource             *framework.FakeControllerSource
@@ -175,6 +176,13 @@ func (cont *testAciController) InitController() {
 		&cache.ListWatch{
 			ListFunc:  cont.fakeNodeInfoSource.List,
 			WatchFunc: cont.fakeNodeInfoSource.Watch,
+		})
+
+	cont.fakeSnatLocalInfoSource = framework.NewFakeControllerSource()
+	cont.initSnatLocalInfoInformerBase(
+		&cache.ListWatch{
+			ListFunc:  cont.fakeSnatLocalInfoSource.List,
+			WatchFunc: cont.fakeSnatLocalInfoSource.Watch,
 		})
 
 	cont.fakeIstioSource = framework.NewFakeControllerSource()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -106,6 +106,7 @@ type AciController struct {
 	snatInformer                         cache.Controller
 	snatNodeInfoIndexer                  cache.Indexer
 	snatNodeInformer                     cache.Controller
+	snatLocalInfoInformer                cache.Controller
 	crdInformer                          cache.Controller
 	rdConfigInformer                     cache.Controller
 	rdConfigIndexer                      cache.Indexer

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -206,6 +206,7 @@ func (env *K8sEnvironment) Init(cont *AciController) error {
 		cont.initCRDInformer()
 		cont.initSnatInformerFromClient(snatClient)
 		cont.initSnatNodeInformerFromClient(env.nodeInfoClient)
+		cont.initSnatLocalInfoInformerFromClient(env.snatLocalInfoClient)
 		cont.initRdConfigInformerFromClient(env.rdConfigClient)
 		cont.initSnatCfgFromClient(kubeClient)
 		if cont.config.InstallIstio {
@@ -303,6 +304,9 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 		go cont.snatNodeInformer.Run(stopCh)
 		cont.log.Debug("Waiting for snat nodeinfo cache sync")
 		cache.WaitForCacheSync(stopCh, cont.snatNodeInformer.HasSynced)
+		go cont.snatLocalInfoInformer.Run(stopCh)
+		cont.log.Debug("Waiting for snatlocalinfo cache sync")
+		cache.WaitForCacheSync(stopCh, cont.snatLocalInfoInformer.HasSynced)
 		cont.createGlobalInfoCache(cont.unitTestMode)
 		cont.snatFullSync()
 		cont.log.Info("Snat cache sync successful")

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -433,16 +433,11 @@ func (cont *AciController) nodeDeleted(obj interface{}) {
 	cont.updateServicesForNode(node.ObjectMeta.Name)
 	cont.snatFullSync()
 	if _, ok := cont.snatNodeInfoCache[node.ObjectMeta.Name]; ok {
-		env := cont.env.(*K8sEnvironment)
-		nodeinfocl := env.nodeInfoClient
-		//TODO Add reconcile here on failure
-		if nodeinfocl != nil {
-			err := util.DeleteNodeInfoCR(*nodeinfocl, node.ObjectMeta.Name)
-			if err != nil {
-				cont.log.Error("Could not delete the NodeInfo", node.ObjectMeta.Name)
-				return
-			}
-			cont.log.Debug("Successfully Deleted NodeInfoCR for node: ", node.ObjectMeta.Name)
+		cont.log.Info("Deleting stale snat resources of node: ", node.ObjectMeta.Name)
+		err := cont.deleteStaleSnatResources(node.ObjectMeta.Name, true, true)
+		if err != nil {
+			cont.log.Error("Failed to delete stale snat resources for node: ", node.ObjectMeta.Name)
+			return
 		}
 		nodeinfo := cont.snatNodeInfoCache[node.ObjectMeta.Name]
 		delete(cont.snatNodeInfoCache, node.ObjectMeta.Name)


### PR DESCRIPTION
When a node with applied snatpolicies is removed from the OCP cluster, only the nodeinfo CR was deleted, while the snatlocalinfo CR remained.

This commit modifies the code to ensure that snatlocalinfo CRs are also deleted when the corresponding node is removed. Additionally, the code is updated to remove all snatlocalinfo CRs in the cluster for nodes and nodeinfos that have already been deleted.