### PR TITLE
Fixed AAEP creation issue if used underscore in NFC CR

### DIFF
--- a/pkg/controller/networkfabricconfigurations.go
+++ b/pkg/controller/networkfabricconfigurations.go
@@ -147,7 +147,7 @@ func (cont *AciController) updateNfcVlanMap(sfna *fabattv1.NetworkFabricConfigur
 			if vlanRef.Epg.ApplicationProfile != "" {
 				appProfile := vlanRef.Epg.ApplicationProfile
 				tenantName := cont.getNodeFabNetAttTenant(vlanRef.Epg.Tenant)
-				appProfKey := "tenant_" + tenantName + "_" + appProfile
+				appProfKey := "tenant/" + tenantName + "/" + appProfile
 				currAppProfs[appProfKey] = true
 			}
 			for _, aep := range vlanRef.Aeps {
@@ -162,7 +162,7 @@ func (cont *AciController) updateNfcVlanMap(sfna *fabattv1.NetworkFabricConfigur
 		}
 		cont.sharedEncapNfcAppProfileMap[appProfile] = true
 		labelKey := cont.aciNameForKey("ap", appProfile)
-		parts := strings.Split(appProfile, "_")
+		parts := strings.Split(appProfile, "/")
 		ap := cont.createNodeFabNetAttAp(parts[1], parts[2])
 		apicSlice = append(apicSlice, ap)
 		progMap[labelKey] = apicSlice


### PR DESCRIPTION
Fixed the issue in which if application profile name provided contains '_' was causing wrong application profile creation.

Verified by using following steps:
1. Created NFC CR with application profile name 'con-vms_1'
2. Create NAD
3. Create 2 pods
4. Verified ICMP traffic.