### PR TITLE
Fix PodSelectors for hpp_direct

### DIFF
--- a/crd-code-generation/hack/update-codegen-hpp.sh
+++ b/crd-code-generation/hack/update-codegen-hpp.sh
@@ -6,7 +6,23 @@ set -o pipefail
 
 SCRIPT_ROOT=$(dirname ${PWD})
 
-vendor/k8s.io/code-generator/kube_codegen.sh all \
-  github.com/noironetworks/aci-containers/pkg/hpp github.com/noironetworks/aci-containers/pkg/hpp/apis \
-  aci.hpp:v1 \
-  --go-header-file ${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt
+source vendor/k8s.io/code-generator/kube_codegen.sh
+
+PKG_NAME="hpp"
+OUTPUT_PKG="github.com/noironetworks/aci-containers/pkg/${PKG_NAME}"
+GROUP="aci.hpp"
+VERSION="v1"
+
+# Generate deepcopy
+kube::codegen::gen_helpers \
+    --boilerplate "${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt" \
+    "${SCRIPT_ROOT}/aci-containers/pkg/${PKG_NAME}/apis/${GROUP}/${VERSION}"
+
+# Generate the clientset, listers, and informers
+kube::codegen::gen_client \
+    --with-applyconfig \
+    --with-watch \
+    "${SCRIPT_ROOT}/aci-containers/pkg/${PKG_NAME}/apis" \
+    --output-dir "${SCRIPT_ROOT}/aci-containers/pkg/${PKG_NAME}" \
+    --output-pkg "${OUTPUT_PKG}" \
+    --boilerplate "${SCRIPT_ROOT}/aci-containers/crd-code-generation/hack/custom-boilerplate.go.txt"

--- a/pkg/hpp/apis/aci.hpp/v1/types.go
+++ b/pkg/hpp/apis/aci.hpp/v1/types.go
@@ -19,17 +19,17 @@ type HostprotSubj struct {
 }
 
 type HostprotRule struct {
-	Name                     string                  `json:"name,omitempty"`
-	Direction                string                  `json:"direction,omitempty"`
-	Ethertype                string                  `json:"ethertype,omitempty"`
-	ConnTrack                string                  `json:"connTrack,omitempty"`
-	Protocol                 string                  `json:"protocol,omitempty"`
-	ToPort                   string                  `json:"toPort,omitempty"`
-	FromPort                 string                  `json:"fromPort,omitempty"`
-	RsRemoteIpContainer      []string                `json:"rsRemoteIpContainer,omitempty"`
-	HostprotFilterContainer  HostprotFilterContainer `json:"hostprotFilterContainer,omitempty"`
-	HostprotRemoteIp         []HostprotRemoteIp      `json:"hostprotRemoteIp,omitempty"`
-	HostprotServiceRemoteIps []string                `json:"hostprotServiceRemoteIps,omitempty"`
+	Name                     string                    `json:"name,omitempty"`
+	Direction                string                    `json:"direction,omitempty"`
+	Ethertype                string                    `json:"ethertype,omitempty"`
+	ConnTrack                string                    `json:"connTrack,omitempty"`
+	Protocol                 string                    `json:"protocol,omitempty"`
+	ToPort                   string                    `json:"toPort,omitempty"`
+	FromPort                 string                    `json:"fromPort,omitempty"`
+	RsRemoteIpContainer      []string                  `json:"rsRemoteIpContainer,omitempty"`
+	HostprotFilterContainer  []HostprotFilterContainer `json:"hostprotFilterContainer,omitempty"`
+	HostprotRemoteIp         []HostprotRemoteIp        `json:"hostprotRemoteIp,omitempty"`
+	HostprotServiceRemoteIps []string                  `json:"hostprotServiceRemoteIps,omitempty"`
 }
 
 type HostprotFilterContainer struct {

--- a/pkg/hpp/apis/aci.hpp/v1/zz_generated.deepcopy.go
+++ b/pkg/hpp/apis/aci.hpp/v1/zz_generated.deepcopy.go
@@ -268,7 +268,20 @@ func (in *HostprotRule) DeepCopyInto(out *HostprotRule) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	in.HostprotFilterContainer.DeepCopyInto(&out.HostprotFilterContainer)
+	if in.HostprotFilterContainer != nil {
+		in, out := &in.HostprotFilterContainer, &out.HostprotFilterContainer
+		*out = make([]HostprotFilterContainer, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.HostprotRemoteIp != nil {
+		in, out := &in.HostprotRemoteIp, &out.HostprotRemoteIp
+		*out = make([]HostprotRemoteIp, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.HostprotServiceRemoteIps != nil {
 		in, out := &in.HostprotServiceRemoteIps, &out.HostprotServiceRemoteIps
 		*out = make([]string, len(*in))

--- a/pkg/hpp/applyconfiguration/aci.hpp/v1/hostprotrule.go
+++ b/pkg/hpp/applyconfiguration/aci.hpp/v1/hostprotrule.go
@@ -20,16 +20,17 @@ package v1
 // HostprotRuleApplyConfiguration represents an declarative configuration of the HostprotRule type for use
 // with apply.
 type HostprotRuleApplyConfiguration struct {
-	Name                     *string                                    `json:"name,omitempty"`
-	Direction                *string                                    `json:"direction,omitempty"`
-	Ethertype                *string                                    `json:"ethertype,omitempty"`
-	ConnTrack                *string                                    `json:"connTrack,omitempty"`
-	Protocol                 *string                                    `json:"protocol,omitempty"`
-	ToPort                   *string                                    `json:"toPort,omitempty"`
-	FromPort                 *string                                    `json:"fromPort,omitempty"`
-	RsRemoteIpContainer      []string                                   `json:"rsRemoteIpContainer,omitempty"`
-	HostprotFilterContainer  *HostprotFilterContainerApplyConfiguration `json:"hostprotFilterContainer,omitempty"`
-	HostprotServiceRemoteIps []string                                   `json:"hostprotServiceRemoteIps,omitempty"`
+	Name                     *string                                     `json:"name,omitempty"`
+	Direction                *string                                     `json:"direction,omitempty"`
+	Ethertype                *string                                     `json:"ethertype,omitempty"`
+	ConnTrack                *string                                     `json:"connTrack,omitempty"`
+	Protocol                 *string                                     `json:"protocol,omitempty"`
+	ToPort                   *string                                     `json:"toPort,omitempty"`
+	FromPort                 *string                                     `json:"fromPort,omitempty"`
+	RsRemoteIpContainer      []string                                    `json:"rsRemoteIpContainer,omitempty"`
+	HostprotFilterContainer  []HostprotFilterContainerApplyConfiguration `json:"hostprotFilterContainer,omitempty"`
+	HostprotRemoteIp         []HostprotRemoteIpApplyConfiguration        `json:"hostprotRemoteIp,omitempty"`
+	HostprotServiceRemoteIps []string                                    `json:"hostprotServiceRemoteIps,omitempty"`
 }
 
 // HostprotRuleApplyConfiguration constructs an declarative configuration of the HostprotRule type for use with
@@ -104,11 +105,29 @@ func (b *HostprotRuleApplyConfiguration) WithRsRemoteIpContainer(values ...strin
 	return b
 }
 
-// WithHostprotFilterContainer sets the HostprotFilterContainer field in the declarative configuration to the given value
-// and returns the receiver, so that objects can be built by chaining "With" function invocations.
-// If called multiple times, the HostprotFilterContainer field is set to the value of the last call.
-func (b *HostprotRuleApplyConfiguration) WithHostprotFilterContainer(value *HostprotFilterContainerApplyConfiguration) *HostprotRuleApplyConfiguration {
-	b.HostprotFilterContainer = value
+// WithHostprotFilterContainer adds the given value to the HostprotFilterContainer field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the HostprotFilterContainer field.
+func (b *HostprotRuleApplyConfiguration) WithHostprotFilterContainer(values ...*HostprotFilterContainerApplyConfiguration) *HostprotRuleApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithHostprotFilterContainer")
+		}
+		b.HostprotFilterContainer = append(b.HostprotFilterContainer, *values[i])
+	}
+	return b
+}
+
+// WithHostprotRemoteIp adds the given value to the HostprotRemoteIp field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the HostprotRemoteIp field.
+func (b *HostprotRuleApplyConfiguration) WithHostprotRemoteIp(values ...*HostprotRemoteIpApplyConfiguration) *HostprotRuleApplyConfiguration {
+	for i := range values {
+		if values[i] == nil {
+			panic("nil value passed to WithHostprotRemoteIp")
+		}
+		b.HostprotRemoteIp = append(b.HostprotRemoteIp, *values[i])
+	}
 	return b
 }
 


### PR DESCRIPTION
- Implemented support for handling multiple PodSelectors in Ingress-From and Egress-To when hpp_direct is enabled.
- Fixed handling of NetworkPolicy with multiple labels in PodSelector for hpp_direct.
- Corrected unit tests related to hpp_direct functionality.