### PR TITLE
[mmr-6.1.1] Fix deletion of hostprotpol CR on Network Policy change

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -2453,8 +2453,9 @@ func (cont *AciController) networkPolicyChanged(oldobj interface{},
 		cont.netPolEgressPods.UpdateSelectorObjNoCallback(newobj)
 		queue = true
 	}
-	if cont.config.EnableHppDirect {
+	if cont.config.EnableHppDirect && !reflect.DeepEqual(oldnp.Spec, newnp.Spec) {
 		cont.deleteHppCr(oldnp)
+		queue = true
 	}
 	if queue {
 		cont.queueNetPolUpdateByKey(npkey)


### PR DESCRIPTION
- Delete old hostprotpol and queue creation of new one on Network Policy spec change.
- For non spec changes hostprotpol remains the same.

(cherry picked from commit 2f5020bf2b5dc6cc424e35dffa9b9393e2524461)