### PR TITLE
Fix handling of HostNetwork pods in hpp_direct

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -194,8 +194,8 @@ type AciController struct {
 	nmPortNp map[string]bool
 	//maps network policy hash to hpp
 	hppRef map[string]hppReference
-	//map for ns to remoteIpCont
-	nsRemoteIpCont map[string]remoteIpCont
+	//map for ns to remoteIpConts
+	nsRemoteIpCont map[string]remoteIpConts
 	// cache to look for Epg DNs which are bound to Vmm domain
 	cachedEpgDns             []string
 	vmmClusterFaultSupported bool
@@ -261,6 +261,9 @@ type NfL3Data struct {
 	NetAddr     map[string]*RoutedNetworkData
 	Nodes       map[int]fabattv1.FabricL3OutNode
 }
+
+// maps pod name to remoteIpCont
+type remoteIpConts map[string]remoteIpCont
 
 // remoteIpCont maps ip to pod labels
 type remoteIpCont map[string]map[string]string
@@ -528,7 +531,7 @@ func NewController(config *ControllerConfig, env Environment, log *logrus.Logger
 		lldpIfCache:                 make(map[string]*NfLLDPIfData),
 		fabricVlanPoolMap:           make(map[string]map[string]string),
 		openStackFabricPathDnMap:    make(map[string]openstackOpflexOdevInfo),
-		nsRemoteIpCont:              make(map[string]remoteIpCont),
+		nsRemoteIpCont:              make(map[string]remoteIpConts),
 	}
 	cont.syncProcessors = map[string]func() bool{
 		"snatGlobalInfo": cont.syncSnatGlobalInfo,

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -4784,9 +4784,11 @@ func TestHandleRemIpContUpdate(t *testing.T) {
 	cont.run()
 	defer cont.stop()
 
-	cont.nsRemoteIpCont["test-namespace"] = map[string]map[string]string{
-		"192.168.10.5": {
-			"app": "db",
+	cont.nsRemoteIpCont["test-namespace"] = remoteIpConts{
+		"test-pod": {
+			"192.168.10.5": {
+				"app": "db",
+			},
 		},
 	}
 

--- a/pkg/hostagent/hpp.go
+++ b/pkg/hostagent/hpp.go
@@ -178,11 +178,11 @@ func (agent *HostAgent) matchesAllFilters(labels []hppv1.HppEpLabel, filterConta
 	return matchFound
 }
 
-func (agent *HostAgent) filterHostProtRemoteIps(remoteIps []hppv1.HostprotRemoteIp, filterContainers []hppv1.HostprotFilterContainer) []string {
-	var matchedAddrs []string
+func (agent *HostAgent) filterHostProtRemoteIps(remoteIps []hppv1.HostprotRemoteIp, filterContainers []hppv1.HostprotFilterContainer) map[string]struct{} {
+	matchedAddrs := make(map[string]struct{})
 	for _, remoteIp := range remoteIps {
 		if agent.matchesAllFilters(remoteIp.HppEpLabel, filterContainers) {
-			matchedAddrs = append(matchedAddrs, remoteIp.Addr)
+			matchedAddrs[remoteIp.Addr] = struct{}{}
 		}
 	}
 	return matchedAddrs
@@ -262,7 +262,7 @@ func (agent *HostAgent) updateLocalHpp(obj interface{}) {
 					}
 					hostprotRemoteIps := remoteIpCont.Spec.HostprotRemoteIp
 					matchedAddrs := agent.filterHostProtRemoteIps(hostprotRemoteIps, hostprotFilters)
-					for _, matchedAddr := range matchedAddrs {
+					for matchedAddr := range matchedAddrs {
 						hpSubnet := &HpSubjGrandchild{
 							Attributes: map[string]string{
 								"addr": matchedAddr,


### PR DESCRIPTION
When hpp_direct is enabled, the hostprotremoteipcontainer CR was previously storing a single entry for each IP address, which caused issues when multiple pods with the same IP but different labels existed in the same namespace. Deleting one pod would result in the IP being removed from the hostprotremoteipcontainer CR, even if other pods using the same IP remained.

This update modifies the code to add a separate entry for each pod in the hostprotremoteipcontainer CR, ensuring that IPs are only removed when all pods using the IP have been deleted.