### PR TITLE
Added fix to support CNI version 1.0.0 from OCP 4.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,13 +164,13 @@ dist/opflex-agent-cni: ${AGENTCNI_DEPS}
 	${BUILD_CMD} -o $@ ${BASE}/cmd/opflexagentcni
 
 dist/netop-cni: ${AGENTCNI_DEPS}
-	${BUILD_CMD} -o $@ ${BASE}/cmd/opflexagentcni
+	${BUILD_CMD} -tags netopcni -o $@ ${BASE}/cmd/opflexagentcni
 
 dist-static/opflex-agent-cni: ${AGENTCNI_DEPS}
 	${STATIC_BUILD_CMD} -o $@ ${BASE}/cmd/opflexagentcni
 
 dist-static/netop-cni: ${AGENTCNI_DEPS}
-	${STATIC_BUILD_CMD} -o $@ ${BASE}/cmd/opflexagentcni
+	${STATIC_BUILD_CMD} -tags netopcni -o $@ ${BASE}/cmd/opflexagentcni
 
 dist/aci-containers-host-agent: ${HOSTAGENT_DEPS}
 	${BUILD_CMD} -o $@ ${BASE}/cmd/hostagent

--- a/cmd/opflexagentcni/main.go
+++ b/cmd/opflexagentcni/main.go
@@ -426,8 +426,7 @@ func cmdCheck(args *skel.CmdArgs) error {
 }
 
 func main() {
-	skel.PluginMain(cmdAdd, cmdCheck, cmdDel,
-		version.PluginSupports("0.3.0", "0.3.1", "0.4.0"), "cni")
+	pluginMain()
 
 	if logFile != "" {
 		logFd.Close()

--- a/cmd/opflexagentcni/netop_plugin.go
+++ b/cmd/opflexagentcni/netop_plugin.go
@@ -1,0 +1,29 @@
+// Copyright 2014 CNI authors
+// Copyright 2016 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build netopcni
+// +build netopcni
+
+package main
+
+import (
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+func pluginMain() {
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel,
+		version.PluginSupports("0.3.0", "0.3.1", "0.4.0", "1.0.0"), "cni")
+}

--- a/cmd/opflexagentcni/opeflexagent_plugin.go
+++ b/cmd/opflexagentcni/opeflexagent_plugin.go
@@ -1,0 +1,29 @@
+// Copyright 2014 CNI authors
+// Copyright 2016 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !netopcni
+// +build !netopcni
+
+package main
+
+import (
+	"github.com/containernetworking/cni/pkg/skel"
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+func pluginMain() {
+	skel.PluginMain(cmdAdd, cmdCheck, cmdDel,
+		version.PluginSupports("0.3.0", "0.3.1", "0.4.0"), "cni")
+}

--- a/docker/launch-hostagent.sh
+++ b/docker/launch-hostagent.sh
@@ -34,7 +34,7 @@ if [ -z != $CHAINED_MODE ] && [ "$CHAINED_MODE" == "true" ] && [ -z != $PRIMARY_
     if [ "$PATCH_PRIMARY" == "true" ]; then
     CHAINEDACICNI=$(echo "\
 {\
-  \"supportedVersions\": [ \"0.3.0\", \"0.3.1\", \"0.4.0\" ],\
+  \"supportedVersions\": [ \"0.3.0\", \"0.3.1\", \"0.4.0\", \"1.0.0\" ],\
   \"type\": \"netop-cni\",\
   \"chaining-mode\": true,\
   \"log-file\": \"/var/log/netopcni.log\"\

--- a/pkg/hostagent/netattachdef_test.go
+++ b/pkg/hostagent/netattachdef_test.go
@@ -192,7 +192,7 @@ func TestNADSRIOVCRUD(t *testing.T) {
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	assert.Nil(t, err, "clientset create")
 
-	configJsondata := `{ "cniVersion":"0.3.1", "name":"sriov-net-1","plugins":[{"name":"sriov-net-1","cniVersion":"0.3.1","type":"sriov","vlan":0,"trust":"on","vlanQoS":0,"capabilities":{"ips":true},"link_state":"auto", "ipam": {"type": "whereabouts","range": "192.168.64.0/24", "exclude": ["192.168.64.0/32", "192.168.64.1/32", "192.168.64.254/32"]}}, {"supportedVersions": [ "0.3.0", "0.3.1", "0.4.0" ], "type": "netop-cni", "chaining-mode": true }]}`
+	configJsondata := `{ "cniVersion":"0.3.1", "name":"sriov-net-1","plugins":[{"name":"sriov-net-1","cniVersion":"0.3.1","type":"sriov","vlan":0,"trust":"on","vlanQoS":0,"capabilities":{"ips":true},"link_state":"auto", "ipam": {"type": "whereabouts","range": "192.168.64.0/24", "exclude": ["192.168.64.0/32", "192.168.64.1/32", "192.168.64.254/32"]}}, {"supportedVersions": [ "0.3.0", "0.3.1", "0.4.0", "1.0.0" ], "type": "netop-cni", "chaining-mode": true }]}`
 
 	resourceAnnot := make(map[string]string)
 	resourceAnnot["k8s.v1.cni.cncf.io/resourceName"] = "openshift.io/enp216s0f0"
@@ -262,9 +262,9 @@ func TestNADMacVlanCRUD(t *testing.T) {
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	assert.Nil(t, err, "clientset create")
 
-	configJsondata := `{"cniVersion": "0.3.1", "name": "macvlan-net2", "plugins":[{"cniVersion": "0.3.1", "name": "macvlan-net2", "type": "macvlan", "mode": "private", "master": "bond1", "ipam": {"type": "whereabouts", "range": "192.168.100.0/24", "exclude": ["192.168.100.0/32", "192.168.100.1/32", "192.168.100.254/32"]}},{ "supportedVersions": [ "0.3.0", "0.3.1", "0.4.0" ], "type": "opflex-agent-cni", "chaining-mode": true, "log-level": "debug", "log-file": "/var/log/opflexagentcni.log" }]}`
+	configJsondata := `{"cniVersion": "0.3.1", "name": "macvlan-net2", "plugins":[{"cniVersion": "0.3.1", "name": "macvlan-net2", "type": "macvlan", "mode": "private", "master": "bond1", "ipam": {"type": "whereabouts", "range": "192.168.100.0/24", "exclude": ["192.168.100.0/32", "192.168.100.1/32", "192.168.100.254/32"]}},{ "supportedVersions": [ "0.3.0", "0.3.1", "0.4.0", "1.0.0" ], "type": "opflex-agent-cni", "chaining-mode": true, "log-level": "debug", "log-file": "/var/log/opflexagentcni.log" }]}`
 
-	configJsondata2 := `{"cniVersion": "0.3.1", "name": "macvlan-net2", "plugins":[{"cniVersion": "0.3.1", "name": "macvlan-net2", "type": "macvlan", "mode": "private", "master": "bond1.101", "ipam": {"type": "whereabouts", "range": "192.168.100.0/24", "exclude": ["192.168.100.0/32", "192.168.100.1/32", "192.168.100.254/32"]}},{ "supportedVersions": [ "0.3.0", "0.3.1", "0.4.0" ], "type": "opflex-agent-cni", "chaining-mode": true, "log-level": "debug", "log-file": "/var/log/opflexagentcni.log" }]}`
+	configJsondata2 := `{"cniVersion": "0.3.1", "name": "macvlan-net2", "plugins":[{"cniVersion": "0.3.1", "name": "macvlan-net2", "type": "macvlan", "mode": "private", "master": "bond1.101", "ipam": {"type": "whereabouts", "range": "192.168.100.0/24", "exclude": ["192.168.100.0/32", "192.168.100.1/32", "192.168.100.254/32"]}},{ "supportedVersions": [ "0.3.0", "0.3.1", "0.4.0", "1.0.0" ], "type": "opflex-agent-cni", "chaining-mode": true, "log-level": "debug", "log-file": "/var/log/opflexagentcni.log" }]}`
 	resourceAnnot := make(map[string]string)
 	agent := testAgentEnvtest(getChainedModeConfig(nodename), kubeClient, cfg)
 	kubeClient.CoreV1().Namespaces().Create(context.Background(), mkNamespace("aci-containers-system", "", "", ""), metav1.CreateOptions{})
@@ -341,7 +341,7 @@ func TestNADVlanMatch(t *testing.T) {
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	assert.Nil(t, err, "clientset create")
 
-	configJsondata := `{"cniVersion": "0.3.1", "name": "pc-mm-net1", "plugins":[{"cniVersion": "0.3.1", "name": "pc-mm-net1", "type": "macvlan", "mode": "private", "master": "bond1", "ipam": {"type": "whereabouts", "range": "192.168.100.0/24", "exclude": ["192.168.100.0/32", "192.168.100.1/32", "192.168.100.254/32"]}},{ "supportedVersions": [ "0.3.0", "0.3.1", "0.4.0" ], "type": "opflex-agent-cni", "chaining-mode": true, "log-level": "debug", "log-file": "/var/log/opflexagentcni.log" }]}`
+	configJsondata := `{"cniVersion": "0.3.1", "name": "pc-mm-net1", "plugins":[{"cniVersion": "0.3.1", "name": "pc-mm-net1", "type": "macvlan", "mode": "private", "master": "bond1", "ipam": {"type": "whereabouts", "range": "192.168.100.0/24", "exclude": ["192.168.100.0/32", "192.168.100.1/32", "192.168.100.254/32"]}},{ "supportedVersions": [ "0.3.0", "0.3.1", "0.4.0", "1.0.0" ], "type": "opflex-agent-cni", "chaining-mode": true, "log-level": "debug", "log-file": "/var/log/opflexagentcni.log" }]}`
 	nadVlanMap := &fabattv1.NadVlanMap{
 		ObjectMeta: metav1.ObjectMeta{Name: "nad-vlan-map",
 			Namespace: "aci-containers-system",

--- a/pkg/webhook/networkattachmentdefinition/handlers.go
+++ b/pkg/webhook/networkattachmentdefinition/handlers.go
@@ -112,7 +112,7 @@ func addNetopToNAD(ctx context.Context, req AdmissionRequest) AdmissionResponse 
 		}
 	}
 	netopPlugin := Plugin{
-		SupportedVersions: []string{"0.3.0", "0.3.1", "0.4.0"},
+		SupportedVersions: []string{"0.3.0", "0.3.1", "0.4.0, 1.0.0"},
 		Type:              "netop-cni",
 		ChainingMode:      true,
 		LogLevel:          "info",


### PR DESCRIPTION
Issue description:
Pod creation on NAD with cniVersion 1.0.0 was failing because netop-cni was not supporting cniVersion 1.0.0.

Fix:
Added cniVersion 1.0.0 in supported CNI versions list.

Tests:
- Verified by running all chained mode test cases on ocpbm3 setup.
- Verified by running fix on k8s-akhila1 setup and running smoke tests on same setup