### PR TITLE
Pre-provision Service VLAN on ESXi Hosts

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -289,6 +289,7 @@ type ControllerConfig struct {
 	// Labels to filter nodes from SNAT redirect policy
 	NodeSnatRedirectExclude []NodeSnatRedirectExclude `json:"node-snat-redirect-exclude,omitempty"`
 
+	AEP string `json:"aep,omitempty"`
 	// Application Profile
 	AppProfile string `json:"app-profile,omitempty"`
 


### PR DESCRIPTION
Add pre-provisioning of service VLAN on ESXi hosts to prevent traffic disruption in case of delayed VLAN programming on the nodes after migration.

(cherry picked from commit 3b587709b2956a1f356ed7155aeeeac45176e227)