### PR TITLE
OpflexODev subscription specific to VMMDomain

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1039,8 +1039,14 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 				cont.SubnetDeleted(dn)
 			})
 
+		var opflexODevFilter string
+		if strings.Contains(cont.config.Flavor, "openstack") {
+			opflexODevFilter = fmt.Sprintf("or(eq(opflexODev.domName,\"%s\"),wcard(opflexODev.compHvDn,\"prov-OpenStack\"))", cont.config.AciVmmDomain)
+		} else {
+			opflexODevFilter = fmt.Sprintf("eq(opflexODev.domName,\"%s\")", cont.config.AciVmmDomain)
+		}
 		cont.apicConn.AddSubscriptionClass("opflexODev",
-			[]string{"opflexODev"}, "")
+			[]string{"opflexODev"}, opflexODevFilter)
 
 		cont.apicConn.SetSubscriptionHooks("opflexODev",
 			func(obj apicapi.ApicObject) bool {


### PR DESCRIPTION
Previously, the opflexODev subscription included the entire class, resulting in retrieval of data of all clusters.
With this change, the subscription is scoped to the specific vmmDomain of the cluster, reducing unnecessary GET calls to APIC.