### PR TITLE
Skip service VLAN pre-provisioning for single leaf

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1064,6 +1064,9 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 				infraRtAttEntPFilter := fmt.Sprintf("and(wcard(infraRtAttEntP.dn,\"/attentp-%s/\"))", cont.config.AEP)
 				cont.apicConn.AddSubscriptionClass("infraRtAttEntP",
 					[]string{"infraRtAttEntP"}, infraRtAttEntPFilter)
+
+				// For bare metal, the infraRtAttEntP associated with an AEP will be empty.
+				// We should not receive any updates for such cases.
 				cont.apicConn.SetSubscriptionHooks("infraRtAttEntP",
 					func(obj apicapi.ApicObject) bool {
 						cont.infraRtAttEntPChanged(obj)


### PR DESCRIPTION
Add changes not to support service VLAN pre-provisioning on ESX hosts in single leaf setups. infraRtAttEntP update processing is skipped for non-VPC case.