### PR TITLE
Skip service VLAN pre-provisioning for single leaf 

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1064,6 +1064,9 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 				infraRtAttEntPFilter := fmt.Sprintf("and(wcard(infraRtAttEntP.dn,\"/attentp-%s/\"))", cont.config.AEP)
 				cont.apicConn.AddSubscriptionClass("infraRtAttEntP",
 					[]string{"infraRtAttEntP"}, infraRtAttEntPFilter)
+
+				// For bare metal, the infraRtAttEntP associated with an AEP will be empty.
+				// We should not receive any updates for such cases.
 				cont.apicConn.SetSubscriptionHooks("infraRtAttEntP",
 					func(obj apicapi.ApicObject) bool {
 						cont.infraRtAttEntPChanged(obj)

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -1474,7 +1474,7 @@ func (cont *AciController) infraRtAttEntPChanged(obj apicapi.ApicObject) {
 
 		// Ignore processing of single leaf
 		if !strings.Contains(tdn, "/accbundle-") {
-			cont.log.Info("Skipping processing of infraRtAttEntP update, not applicable for VPC configuration: ", tdn)
+			cont.log.Info("Skipping processing of infraRtAttEntP update, not applicable for non-VPC configuration: ", tdn)
 			return
 		}
 


### PR DESCRIPTION
Add changes not to support service VLAN pre-provisioning
on ESX hosts in single leaf setups. infraRtAttEntP update
processing is skipped for non-VPC case.