### PR TITLE
Retry APIC Requests on Service Unavailable

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -103,6 +103,9 @@ type ApicConnection struct {
 	CachedVersion       string
 	ReconnectInterval   time.Duration
 	ReconnectRetryLimit int
+	RequestRetryDelay   int
+	EnableRequestRetry  bool
+
 	RefreshInterval     time.Duration
 	RefreshTickerAdjust time.Duration
 	SubscriptionDelay   time.Duration

--- a/pkg/apicapi/apicapi_test.go
+++ b/pkg/apicapi/apicapi_test.go
@@ -1114,6 +1114,8 @@ func TestAddSubscriptionTree(t *testing.T) {
 	}
 }
 
+/*
+// commented out - DeleteDnInline function no longer in use
 func TestDeleteDnInline(t *testing.T) {
 	server := newTestServer()
 	defer server.server.Close()
@@ -1128,6 +1130,7 @@ func TestDeleteDnInline(t *testing.T) {
 	// No HTTPS server running, so we expect an error
 	assert.Error(t, err, "Could not delete dn")
 }
+*/
 
 func TestGetVersion(t *testing.T) {
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -299,6 +299,12 @@ type ControllerConfig struct {
 	// Number of times the connection to APIC should be retried before switching to another APIC
 	ApicConnectionRetryLimit int `json:"apic-connection-retry-limit,omitempty"`
 
+	// Timeout in minutes to wait in between retries before sending request to APIC
+	ApicRequestRetryDelay int `json:"apic-request-retry-delay,omitempty"`
+
+	// Enable retying request to APIC when a 503 error is encountered
+	EnableApicRequestRetry bool `json:"enable-apic-request-retry-delay,omitempty"`
+
 	// Disable hpp rendering if set to true
 	DisableHppRendering bool `json:"disable-hpp-rendering,omitempty"`
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -854,6 +854,8 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	}
 
 	cont.apicConn.ReconnectRetryLimit = cont.config.ApicConnectionRetryLimit
+	cont.apicConn.RequestRetryDelay = cont.config.ApicRequestRetryDelay
+	cont.apicConn.EnableRequestRetry = cont.config.EnableApicRequestRetry
 
 	if len(cont.config.ApicHosts) != 0 {
 	APIC_SWITCH:


### PR DESCRIPTION
Previously, the connection to APIC was restarted immediately upon receiving a 503 Service Unavailable response. Now the request is retried up to 5 times when a 503 Service Unavailable response is received. The wait time between retries is controlled by the apic_request_retry_delay parameter, which defaults to 2 minutes.

(cherry picked from commit 37551e96b5952afb765a2dc080aa8fde3c962108)