### PR TITLE
Enable Resilient Hashing in LoadBalancer PBR

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -635,8 +635,9 @@ var metadata = map[string]*apicMeta{
 	},
 	"vnsSvcRedirectPol": {
 		attributes: map[string]interface{}{
-			"name":                "",
-			"thresholdDownAction": "permit",
+			"name":                 "",
+			"thresholdDownAction":  "permit",
+			"resilientHashEnabled": "yes",
 		},
 		children: []string{
 			"vnsRedirectDest",

--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -832,6 +832,7 @@ func NewVnsSvcRedirectPol(tenantName, name string) ApicObject {
 	ret["vnsSvcRedirectPol"].Attributes["name"] = name
 	ret["vnsSvcRedirectPol"].Attributes["dn"] =
 		fmt.Sprintf("uni/tn-%s/svcCont/svcRedirectPol-%s", tenantName, name)
+	ret["vnsSvcRedirectPol"].Attributes["resilientHashEnabled"] = "yes"
 	return ret
 }
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -139,6 +139,10 @@ type ControllerConfig struct {
 	// is enabled for snat
 	AciPbrTrackingNonSnat bool `json:"aci-pbr-tracking-non-snat,omitempty"`
 
+	// By default, the Resilient Hashing Enabled field of vnsSvcRedirectPol is
+	// set to "yes". If DisableResilientHashing is true, it will be set to "no"
+	DisableResilientHashing bool `json:"disable-resilient-hashing,omitempty"`
+
 	// The tenants related to AciVrf where BDs/EPGs/Subnets could exist.
 	// Usually AciVrfTenant and AciPolicyTenant
 	AciVrfRelatedTenants []string `json:"aci-vrf-related-tenants,omitempty"`

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -661,6 +661,9 @@ func (cont *AciController) apicRedirectPol(name string, tenantName string, nodes
 	monPolDn string, enablePbrTracking bool) (apicapi.ApicObject, string) {
 	rp := apicapi.NewVnsSvcRedirectPol(tenantName, name)
 	rp.SetAttr("thresholdDownAction", "deny")
+	if cont.config.DisableResilientHashing {
+		rp.SetAttr("resilientHashEnabled", "no")
+	}
 	rpDn := rp.GetDn()
 	for _, node := range nodes {
 		cont.indexMutex.Lock()


### PR DESCRIPTION
Add change to enable Resilient Hashing in L4-L7 Redirection Policy by default, when exposing a service as type LoadBalancer. When this option is enabled, ACI fabric wont re-hashing existing flows when a L3 Destination will be deleted or added.