### PR TITLE
Retain pod IP in service file during termination

### DIFF
--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -877,12 +877,12 @@ func (seps *serviceEndpointSlice) SetOpflexService(ofas *opflexService, as *v1.S
 							nodeZone = zone
 							if !external && zoneOk && hintsEnabled && e.Hints != nil {
 								for _, hintZone := range e.Hints.ForZones {
-									if nodeZone == hintZone.Name && *e.Conditions.Ready {
+									if nodeZone == hintZone.Name && (*e.Conditions.Ready || (e.Conditions.Terminating != nil && *e.Conditions.Terminating)) {
 										nexthops["topologyawarehints"] =
 											append(nexthops["topologyawarehints"], a)
 									}
 								}
-							} else if *e.Conditions.Ready {
+							} else if *e.Conditions.Ready || (e.Conditions.Terminating != nil && *e.Conditions.Terminating) {
 								nexthops["any"] = append(nexthops["any"], a)
 							}
 						}


### PR DESCRIPTION
Previously, the endpoint IP was removed from service file when the endpoint was in terminating state, which led to dropped return traffic due to OVS flow removal breaking existing connections before applications could shut down cleanly.

This fix retains the endpoint IP in the service file during the termination grace period, allowing ongoing connections to complete and enabling graceful shutdown of applications as per terminationGracePeriodSeconds.