### PR TITLE
Limit opflexODev processing to cluster vmmDomain

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -105,6 +105,9 @@ type ApicConnection struct {
 	ReconnectRetryLimit int
 	RequestRetryDelay   int
 	EnableRequestRetry  bool
+	VmmDomain           string
+	Flavor              string
+	FilterOpflexDevice  bool
 
 	RefreshInterval     time.Duration
 	RefreshTickerAdjust time.Duration
@@ -131,6 +134,7 @@ type ApicConnection struct {
 	SyncDone     bool
 	SyncMutex    sync.Mutex
 
+	cacheOpflexOdev    map[string]struct{}
 	desiredState       map[string]ApicSlice
 	desiredStateDn     map[string]ApicObject
 	keyHashes          map[string]string
@@ -186,6 +190,14 @@ func (o ApicObject) GetDn() string {
 		return o.GetHintDn()
 	}
 	return attrDn
+}
+
+func (o ApicObject) GetDomName() string {
+	return o.GetAttrStr("domName")
+}
+
+func (o ApicObject) GetCompHvDn() string {
+	return o.GetAttrStr("compHvDn")
 }
 
 func (o ApicObject) String() string {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -143,6 +143,9 @@ type ControllerConfig struct {
 	// set to "yes". If DisableResilientHashing is true, it will be set to "no"
 	DisableResilientHashing bool `json:"disable-resilient-hashing,omitempty"`
 
+	// To ignore the opflexODev which belongs to different vmmDomain
+	FilterOpflexDevice bool `json:"filter-opflex-device,omitempty"`
+
 	// The tenants related to AciVrf where BDs/EPGs/Subnets could exist.
 	// Usually AciVrfTenant and AciPolicyTenant
 	AciVrfRelatedTenants []string `json:"aci-vrf-related-tenants,omitempty"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -859,6 +859,9 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		panic(err)
 	}
 
+	cont.apicConn.FilterOpflexDevice = cont.config.FilterOpflexDevice
+	cont.apicConn.Flavor = cont.config.Flavor
+	cont.apicConn.VmmDomain = cont.config.AciVmmDomain
 	cont.apicConn.ReconnectRetryLimit = cont.config.ApicConnectionRetryLimit
 	cont.apicConn.RequestRetryDelay = cont.config.ApicRequestRetryDelay
 	cont.apicConn.EnableRequestRetry = cont.config.EnableApicRequestRetry


### PR DESCRIPTION
Since the controller subscribes to the entire opflexODev class, it receives notifications for opflexODev objects from all clusters. Each modified update triggers a GET operation to APIC, causing increased load.

To avoid this, the opflexODev objects corresponding to the cluster vmmDomain are stored in the cache. Updates for opflexODev objects not present in the cache are skipped, preventing unnecessary GET operations to APIC for objects that don't belong to the cluster.

(cherry picked from commit 6692f5be18531c9790c609d8e2db99781f50698e)