### PR TITLE
Set `terminating` attribute in epfile for pods in Terminating state

### DIFF
--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -767,6 +767,11 @@ func (agent *HostAgent) podChangedLocked(podobj interface{}) {
 	if epAttributes == nil {
 		epAttributes = make(map[string]string)
 	}
+	isTerminating := pod.ObjectMeta.DeletionTimestamp != nil
+	if isTerminating {
+		logger.Debug("Pod is terminating")
+		epAttributes["terminating"] = "True"
+	}
 	epAttributes["vm-name"] = pod.ObjectMeta.Name
 	epAttributes["namespace"] = pod.ObjectMeta.Namespace
 


### PR DESCRIPTION
Add an attribute `terminating: "True"` to the pod epfile when it is in `Terminating` state. This attribute is used by opflex-agent to allow existing connections to the pod to continue working while preventing new connections, thereby enabling graceful shutdown.