### PR TITLE
Excludes rpm* and python3-rpm pkgs from yum update

### DIFF
--- a/docker/travis/Dockerfile-host
+++ b/docker/travis/Dockerfile-host
@@ -11,7 +11,7 @@ RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os
 
-RUN yum update --disablerepo=* --exclude=openssl* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os -y --nogpgcheck && rm -rf /var/cache/yum
+RUN yum update --disablerepo=* --exclude=openssl*,rpm*,python3-rpm --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os -y --nogpgcheck && rm -rf /var/cache/yum
 RUN yum install --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os dhcp-client curl iptables-nft jq nmstate tar -y --allowerasing --nogpgcheck && rm -rf /var/cache/yum
 
 RUN yum update --disablerepo=* --exclude=openssl* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y && rm -rf /var/cache/yum

--- a/docker/travis/Dockerfile-openvswitch
+++ b/docker/travis/Dockerfile-openvswitch
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 RUN microdnf install -y yum yum-utils
-RUN yum update --exclude=openssl* -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
+RUN yum update --exclude=openssl*,rpm*,python3-rpm -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
 RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
   logrotate conntrack-tools tcpdump strace ltrace iptables net-tools \
   libcap vi hostname iproute procps-ng kmod tar \

--- a/docker/travis/Dockerfile-openvswitch-base
+++ b/docker/travis/Dockerfile-openvswitch-base
@@ -3,7 +3,7 @@ RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os
 
-RUN yum update --exclude=openssl* -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
+RUN yum update --exclude=openssl*,rpm*,python3-rpm -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
 
 RUN yum --nogpgcheck --disablerepo=* install --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os -y \
   libtool pkgconfig autoconf automake make file python3-six \


### PR DESCRIPTION
while building aci-container-host, openvswitch and openvswitch-base images to avoid openssl version
dependency conflict