### PR TITLE
Fix typo in config knob

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -290,7 +290,7 @@ type ControllerConfig struct {
 	AciUseGlobalScopeVlan bool `json:"aci-use-global-scope-vlan,omitempty"`
 
 	//In chained mode, use system-id for auto-generated names
-	AciUseSystemIdForSecondaryNames bool `aci-use-system-id-for-secondary-names,omitempty"`
+	AciUseSystemIdForSecondaryNames bool `json:"aci-use-system-id-for-secondary-names,omitempty"`
 
 	// Metrics
 	EnableMetrics bool `json:"enable-metrics,omitempty"`


### PR DESCRIPTION
AciUseSystemIdForSecondaryNames had a typo in json encoding.