### PR TITLE
Handle OpenSSL FIPS provider package conflict

### DIFF
--- a/docker/travis/Dockerfile-host
+++ b/docker/travis/Dockerfile-host
@@ -6,6 +6,7 @@ version="v1.1.0" \
 release="1" \
 summary="This is an ACI CNI Host-Agent." \
 description="This will deploy a single instance of ACI CNI Host-Agent."
+RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
 # For some reason this prevents the next RUN from installing the incompat fips module
 RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \

--- a/docker/travis/Dockerfile-openvswitch
+++ b/docker/travis/Dockerfile-openvswitch
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
 RUN microdnf install -y yum yum-utils
 RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
 RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \

--- a/docker/travis/Dockerfile-openvswitch-base
+++ b/docker/travis/Dockerfile-openvswitch-base
@@ -1,4 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
 RUN microdnf install -y yum yum-utils \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
  && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os


### PR DESCRIPTION
Newer `openssl-libs` packages bundle the FIPS provider, which was previously a separate `openssl-fips-provider-so` package. This causes a file conflict during upgrades.

Work around this by removing the old FIPS provider package before upgrading to the new `openssl-libs`.