### PR TITLE
Handle terminationGracePeriodSeconds in pods

### DIFF
--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -767,6 +767,11 @@ func (agent *HostAgent) podChangedLocked(podobj interface{}) {
 	if epAttributes == nil {
 		epAttributes = make(map[string]string)
 	}
+	isTerminating := pod.ObjectMeta.DeletionTimestamp != nil
+	if isTerminating {
+		logger.Debug("Pod is terminating")
+		epAttributes["terminating"] = "True"
+	}
 	epAttributes["vm-name"] = pod.ObjectMeta.Name
 	epAttributes["namespace"] = pod.ObjectMeta.Namespace
 

--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -877,12 +877,12 @@ func (seps *serviceEndpointSlice) SetOpflexService(ofas *opflexService, as *v1.S
 							nodeZone = zone
 							if !external && zoneOk && hintsEnabled && e.Hints != nil {
 								for _, hintZone := range e.Hints.ForZones {
-									if nodeZone == hintZone.Name && *e.Conditions.Ready {
+									if nodeZone == hintZone.Name && (*e.Conditions.Ready || (e.Conditions.Terminating != nil && *e.Conditions.Terminating)) {
 										nexthops["topologyawarehints"] =
 											append(nexthops["topologyawarehints"], a)
 									}
 								}
-							} else if *e.Conditions.Ready {
+							} else if *e.Conditions.Ready || (e.Conditions.Terminating != nil && *e.Conditions.Terminating) {
 								nexthops["any"] = append(nexthops["any"], a)
 							}
 						}


### PR DESCRIPTION
When pod is set to the “Terminating” State , the pod should stop getting the new traffic. But existing connections should work.

1) When a pod is in Terminating state, do not remove it from next hops in service file
2) Add terminating = "True" in attributes section of pod ep file when it goes to Terminating state.


 