### PR TITLE
[mmr-6.1.1] Fix empty endpoints list - hostagent status server

### DIFF
--- a/pkg/hostagent/status.go
+++ b/pkg/hostagent/status.go
@@ -42,13 +42,13 @@ func (agent *HostAgent) RunStatus() {
 	http.HandleFunc("/endpoints", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		agent.indexMutex.Lock()
-		eps := make([]*opflexEndpoint, 0, len(agent.opflexEps))
+		endpoints := make([]*opflexEndpoint, 0, len(agent.opflexEps))
 		for _, eps := range agent.opflexEps {
 			for _, ep := range eps {
-				eps = append(eps, ep)
+				endpoints = append(endpoints, ep)
 			}
 		}
-		json.NewEncoder(w).Encode(eps)
+		json.NewEncoder(w).Encode(endpoints)
 		agent.indexMutex.Unlock()
 	})
 	http.HandleFunc("/services", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Correct a variable redeclaration issue that caused the hostagent status server to always return an empty endpoints list.

(cherry picked from commit cdd53847bbc65c09b1918a49f6d0dd81b945a0f5)