### PR TITLE
Don't update name if chained-cni is pre-existing

### DIFF
--- a/pkg/webhook/networkattachmentdefinition/handlers.go
+++ b/pkg/webhook/networkattachmentdefinition/handlers.go
@@ -100,7 +100,6 @@ func addNetopToNAD(ctx context.Context, req AdmissionRequest) AdmissionResponse 
 	pluginExists := false
 	if name, ok := config["name"]; !ok || name == "" {
 		config["name"] = nad.Name
-		needsUpdate = true
 	}
 	if RequireNADAnnotation {
 		if enableChaining, ok := nad.ObjectMeta.Annotations["netop-cni.cisco.com/auto-chain-cni"]; !ok {


### PR DESCRIPTION
Once created, updating NAD is not allowed since pods don't have a mechanism to absorb updates. So add name only if a fresh insertion is being attempted.