### PR TITLE
[mmr-6.1.1]Add support for Resilient Hashing

### DIFF
--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -300,6 +300,9 @@ type HostAgentConfig struct {
 
 	// Directory for writing oob policy data
 	OOBPolicyDir string `json:"oob-policy-dir,omitempty"`
+
+	// Disable resilient hashing
+	DisableOpflexResilientHashing bool `json:"disable-opflex-resilient-hashing,omitempty"`
 }
 
 func (config *HostAgentConfig) InitFlags() {


### PR DESCRIPTION
- Set `conntrack-nat: true` in service file if Resilient Hashing is enabled and Session Affinity is set for service.
- Introduce `disable-opflex-resilient-hashing` in host agent config which disables Resilient Hashing.
- Use DefaultSessionAffinityTimer if SessionAffinity is set to ClientIP and SessionAffinityConfig TimeoutSeconds is unspecified.

(cherry picked from commit 18e93c8103fe3636efe0867b3e1259bff63c5b70)