### PR TITLE
[mmr-6.1.1] fix(acikubectl): Correct commands in debug cluster-report

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -522,24 +522,24 @@ func clusterReport(cmd *cobra.Command, args []string) {
 		},
 		{
 			path:     "cluster-report/cmds/node-%s/ip-a.log",
-			cont:     "aci-containers-openvswitch",
-			selector: openvswitchSelector,
-			argFunc:  otherNodeArgs,
-			args:     []string{"ip", "a"},
+			cont:     "aci-containers-host",
+			selector: hostAgentSelector,
+			argFunc:  hostAgentLogCmdArgs,
+			args:     []string{"--", "ip", "a"},
 		},
 		{
 			path:     "cluster-report/cmds/node-%s/ip-r.log",
-			cont:     "aci-containers-openvswitch",
-			selector: openvswitchSelector,
-			argFunc:  otherNodeArgs,
-			args:     []string{"ip", "r"},
+			cont:     "aci-containers-host",
+			selector: hostAgentSelector,
+			argFunc:  hostAgentLogCmdArgs,
+			args:     []string{"--", "ip", "r"},
 		},
 		{
 			path:     "cluster-report/cmds/node-%s/ovs-conf-db.log",
 			cont:     "aci-containers-openvswitch",
 			selector: openvswitchSelector,
 			argFunc:  otherNodeArgs,
-			args:     []string{"cat", "/etc/openvswitch/conf.db", "/usr/local/etc/openvswitch/conf.db"},
+			args:     []string{"cat", "/usr/local/etc/openvswitch/conf.db"},
 		},
 	}
 


### PR DESCRIPTION
This PR fixes two bugs within the acikubectl debug command.

- Moves `ip a` and `ip r` execution to the `aci-containers-host` pod. This resolves "Peer netns reference is invalid" errors by using `aci-containers-host` container with the required `/run/netns` mount.

- Fixes `ovs-conf-db` collection by removing the invalid path `/etc/openvswitch/conf.db` from the `cat` command, resolving the "No such file or directory" error.

(cherry picked from commit 808ca0c8e9e228d84c28a3b67ff2aab15388cc21)