### PR TITLE
[mmr-6.1.1]Ensure DHCP lease exists for Multi-Pod migration

### DIFF
--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -67,6 +67,7 @@ type HostAgent struct {
 	snatPolicyLabelMutex sync.RWMutex
 	snatPolicyCacheMutex sync.RWMutex
 	proactiveConfMutex   sync.Mutex
+	dhcpMutex            sync.Mutex
 
 	opflexEps              map[string][]*opflexEndpoint
 	opflexServices         map[string]*opflexService
@@ -632,6 +633,9 @@ func (agent *HostAgent) Run(stopCh <-chan struct{}) {
 		go agent.checkSyncProcessorsCompletionStatus(stopCh)
 	} else {
 		agent.taintRemoved.Store(true)
+	}
+	if agent.config.AciMultipod {
+		go agent.ensureDhclientLease()
 	}
 	syncEnabled, err := agent.env.PrepareRun(stopCh)
 	if err != nil {


### PR DESCRIPTION
In Multi-Pod migration scenarios, the `hostagent` relies on the presence of the `dhclient` lease file for configuring networks for migrated VMs. If a node is missing the lease file (e.g., if the Network Manager or systemd dhcp client is managing the networks), migration tasks can fail due to this missing context.

This commit adds a check on `hostagent` startup. When Multi-Pod migration is enabled, it verifies the presence of the DHCP lease file. If the file is absent, it proactively triggers a one-shot DHCP renewal to generate it, ensuring the necessary information is available before any migration tasks are attempted.

(cherry picked from commit 36985b5add794b582cc49de52169c14525e1d38c)