### PR TITLE
Added fixes for CDETS

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1031,12 +1031,12 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		cont.apicConn.SetSubscriptionHooks(
 			"infraAttEntityP",
 			func(obj apicapi.ApicObject) bool {
-				cont.log.Debug("[AAEP-EVENT] EPG attached to AAEP")
+				cont.log.Debug("EPG attached to AAEP")
 				cont.handleAaepEpgAttach(obj)
 				return true
 			},
 			func(dn string) {
-				cont.log.Debug("[AAEP-EVENT] EPG detached to AAEP")
+				cont.log.Debug("EPG detached from AAEP")
 				cont.handleAaepEpgDetach(dn)
 			},
 		)

--- a/pkg/webhook/networkattachmentdefinition/handlers.go
+++ b/pkg/webhook/networkattachmentdefinition/handlers.go
@@ -208,7 +208,7 @@ func handleVmmLiteNAD(ctx context.Context, req AdmissionRequest) AdmissionRespon
 		webhookHdlrLog.Info(nadOwner)
 		if nadOwner == "cisco-network-operator" {
 			webhookHdlrLog.Info("Denying deletion: NAD is managed by VMM Lite")
-			msg := "Denying deletion: NAD is managed by VMM Lite. Manual deletion is not recomended. Remove the 'managed-by' annotation from the NAD, then try deleting it manually."
+			msg := "Denying deletion: NAD is managed by VMM Lite. Manual deletion is not recommended. Remove the 'managed-by' annotation from the NAD, then try deleting it manually."
 			return Denied(msg)
 		}
 	}


### PR DESCRIPTION
- Moved log from error to debug, when annotation not provided in EPG
- Added support for single EPG attached with multiple AAEP
- Fixed naming convention for NAD name. New nad name will be in following format: <tenant name>-<application profile name>-<EPG name>-<hash> here, "tenant name", "application name", "EPG name" will not contain "_" or "." and hash is calculated from concatenating <tenant name>, <application profile name>, <EPG name> and <aaep name> and selecting only first 16 characters of hash
- Fixed event message in case of EPG deleted
- Added aaep name and EPG DN in NAD annotation

(cherry picked from commit 3ed6e0167f6b47c668cbe12bea442f98414b650e)