### PR TITLE
Add infra querier subnet handling for multipod migration

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -133,6 +133,7 @@ type ApicConnection struct {
 	SubscriptionDelay       time.Duration
 	RetryInterval           time.Duration
 	SnatPbrFltrChain        bool // Configure SNAT PBR to use filter-chain
+	ReconnectHook           func()
 	FullSyncHook            func()
 
 	dialer        *websocket.Dialer

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -676,6 +676,9 @@ func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {
 	}
 	if !hasErr {
 		conn.checkDeletes(oldState)
+		if conn.ReconnectHook != nil {
+			go conn.ReconnectHook()
+		}
 		go func() {
 			if conn.FullSyncHook != nil {
 				conn.FullSyncHook()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -172,6 +172,7 @@ type AciController struct {
 	nodeServiceMetaCache map[string]*nodeServiceMeta
 	nodeACIPod           map[string]aciPodAnnot
 	nodeACIPodAnnot      map[string]aciPodAnnot
+	infraQuerierSubnet   string
 	nodeOpflexDevice     map[string]apicapi.ApicSlice
 	nodePodNetCache      map[string]*nodePodNetMeta
 	serviceMetaCache     map[string]*serviceMeta
@@ -960,6 +961,12 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		panic(err.Error())
 	}
 
+	if !cont.isCNOEnabled() && cont.config.AciMultipod {
+		cont.apicConn.ReconnectHook = func() {
+			cont.initInfraQuerierSubnet()
+		}
+	}
+
 	cont.apicConn.FullSyncHook = func() {
 		// put a channel into each work queue and wait on it to
 		// checkpoint object syncing in response to new subscription
@@ -1170,6 +1177,63 @@ func (cont *AciController) syncNodeAciPods(stopCh <-chan struct{}, seconds time.
 			return
 		}
 	}
+}
+
+func (cont *AciController) updateInfraQuerierSubnet() bool {
+	args := []string{
+		"query-target=children",
+		"target-subtree-class=fvSubnet",
+	}
+	url := fmt.Sprintf("/api/node/mo/uni/tn-infra/BD-default.json?%s", strings.Join(args, "&"))
+	apicresp, err := cont.apicConn.GetApicResponse(url)
+	if err != nil {
+		cont.log.Debug("Failed to get APIC response for infra default BD subnet lookup, err: ", err.Error())
+		return false
+	}
+
+	var subnet string
+outer:
+	for _, obj := range apicresp.Imdata {
+		for _, body := range obj {
+			ctrl, _ := body.Attributes["ctrl"].(string)
+			if !strings.Contains(ctrl, "querier") {
+				continue
+			}
+			ip, ok := body.Attributes["ip"].(string)
+			if ok && ip != "" {
+				subnet = ip
+				break outer
+			}
+		}
+	}
+	if subnet == "" {
+		cont.log.Debug("Failed to find querier fvSubnet ip under uni/tn-infra/BD-default")
+		return false
+	}
+
+	cont.indexMutex.Lock()
+	defer cont.indexMutex.Unlock()
+	if cont.infraQuerierSubnet == subnet {
+		return false
+	}
+	cont.infraQuerierSubnet = subnet
+	return true
+}
+
+func (cont *AciController) initInfraQuerierSubnet() bool {
+	if !cont.updateInfraQuerierSubnet() {
+		return false
+	}
+
+	for _, obj := range cont.nodeIndexer.List() {
+		node := obj.(*v1.Node)
+		if node.ObjectMeta.Annotations[metadata.InfraQuerierSubnetAnnotation] == cont.infraQuerierSubnet {
+			continue
+		}
+		go cont.nodeChanged(obj)
+	}
+
+	return true
 }
 
 func (cont *AciController) syncOpflexDevices(stopCh <-chan struct{}, seconds time.Duration) {

--- a/pkg/controller/nodes.go
+++ b/pkg/controller/nodes.go
@@ -368,6 +368,18 @@ func (cont *AciController) nodeChanged(obj interface{}) {
 			var annot aciPodAnnot
 			cont.nodeACIPod[node.ObjectMeta.Name] = annot
 		}
+
+		infraQuerierSubnetAnn := node.ObjectMeta.Annotations[metadata.InfraQuerierSubnetAnnotation]
+		if cont.nodeSyncEnabled {
+			if cont.infraQuerierSubnet != "" && infraQuerierSubnetAnn != cont.infraQuerierSubnet {
+				node.ObjectMeta.Annotations[metadata.InfraQuerierSubnetAnnotation] = cont.infraQuerierSubnet
+				logger.WithFields(logrus.Fields{
+					"new": cont.infraQuerierSubnet,
+					"old": infraQuerierSubnetAnn,
+				}).Info("Updated infra querier subnet annotation")
+				nodeUpdated = true
+			}
+		}
 	}
 	cont.indexMutex.Unlock()
 

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -100,6 +100,7 @@ type HostAgent struct {
 	rcPods                 *index.PodSelectorIndex
 	podNetAnnotation       string
 	aciPodAnnotation       string
+	infraQuerierSubnet     atomic.Value
 	nodeAciPodAnnotation   string
 	podIps                 *ipam.IpCache
 	usedIPs                map[string]string
@@ -154,6 +155,7 @@ type HostAgent struct {
 	podNameToTimeStamps map[string]*epTimeStamps
 	completedSyncTypes  map[string]struct{}
 	taintRemoved        atomic.Value
+	infraRoutePending   atomic.Bool
 }
 
 type ServiceEndPointType interface {

--- a/pkg/hostagent/nodes.go
+++ b/pkg/hostagent/nodes.go
@@ -127,6 +127,11 @@ func (agent *HostAgent) nodeChanged(obj ...interface{}) {
 	}
 
 	if agent.config.AciMultipod {
+		infraQuerierSubnet, infraQuerierOk := node.ObjectMeta.Annotations[metadata.InfraQuerierSubnetAnnotation]
+		if infraQuerierOk {
+			agent.infraQuerierSubnet.Store(infraQuerierSubnet)
+		}
+
 		aciPod, acipodok := node.ObjectMeta.Annotations[metadata.AciPodAnnotation]
 		if acipodok {
 			eventReceived := false

--- a/pkg/hostagent/opflex.go
+++ b/pkg/hostagent/opflex.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -42,6 +43,7 @@ const (
 	PLATFORM_SUBSCRIPTION_FILE = "/usr/local/var/lib/opflex-agent-ovs/events/platformconfig.subscriptions"
 	PLATFORM_NOTIFICATION_FILE = "/usr/local/var/lib/opflex-agent-ovs/events/platformconfig.notifications"
 	MAX_PLATFORM_EVENT_AGE     = 120 * time.Second
+	infraRouteMetric           = 401
 )
 
 type opflexFault struct {
@@ -187,28 +189,119 @@ func (agent *HostAgent) isMultiCastRoutePresent(link netlink.Link) bool {
 	return false
 }
 
+// addStaticLinkRoute adds dst as a proto static, scope link route on link with
+// the given metric. It is the shared primitive used by both multicast and infra
+// querier subnet route addition.
+func (agent *HostAgent) addStaticLinkRoute(link netlink.Link, dst *net.IPNet, metric int) error {
+	route := &netlink.Route{
+		LinkIndex: link.Attrs().Index,
+		Dst:       dst,
+		Protocol:  syscall.RTPROT_STATIC,
+		Scope:     netlink.SCOPE_LINK,
+		Priority:  metric,
+	}
+	agent.log.Infof("Adding route %s dev %s proto static scope link metric %d", dst, link.Attrs().Name, metric)
+	return netlink.RouteAdd(route)
+}
+
 func (agent *HostAgent) addMultiCastRoute(link netlink.Link, name string) {
 	if agent.isMultiCastRoutePresent(link) {
 		agent.log.Info("Multicast route already present for interface ", name)
 		return
 	}
+	_, mcastNet, _ := net.ParseCIDR(MCAST_ROUTE_DEST)
 	retryCount := agent.config.DhcpRenewMaxRetryCount
 	for i := 0; i < retryCount; i++ {
-		cmd := exec.Command("ip", "route", "add", MCAST_ROUTE_DEST, "dev", name, "proto", "static", "scope", "link", "metric", "401")
-		agent.log.Info("Executing command:", cmd.String())
-		opt, err := cmd.Output()
-		if err != nil {
-			agent.log.Error("Failed to add multicast route : ", err.Error(), " ", string(opt))
+		if err := agent.addStaticLinkRoute(link, mcastNet, infraRouteMetric); err != nil {
+			agent.log.Errorf("Failed to add multicast route: %v (attempt %d)", err, i+1)
 			continue
-		} else {
-			agent.log.Info(string(opt))
 		}
 		if agent.isMultiCastRoutePresent(link) {
-			agent.log.Info("Added Multicast route successfully ")
+			agent.log.Info("Added Multicast route successfully")
 			return
 		}
-		agent.log.Error("Failed to add Multicast route...iteration:", i+1)
+		agent.log.Errorf("Failed to add multicast route (attempt %d)", i+1)
 	}
+	agent.log.Errorf("Failed to add multicast route for interface %s after %d attempts", name, retryCount)
+}
+
+func (agent *HostAgent) isInfraQuerierSubnetRoutePresent(link netlink.Link, targetNet *net.IPNet) bool {
+	routes, err := netlink.RouteList(link, netlink.FAMILY_V4)
+	if err != nil {
+		agent.log.Error("Failed to list routes: ", err)
+		return false
+	}
+	targetPrefix, _ := targetNet.Mask.Size()
+
+	for _, route := range routes {
+		if route.Dst == nil {
+			continue
+		}
+		routePrefix, _ := route.Dst.Mask.Size()
+		if routePrefix <= targetPrefix && route.Dst.Contains(targetNet.IP) {
+			agent.log.Info("Infra querier subnet route covered by existing route ", route.Dst.String(), " for interface ", link.Attrs().Name)
+			return true
+		}
+	}
+	return false
+}
+
+func (agent *HostAgent) addInfraQuerierSubnetRoute(link netlink.Link, name, subnet string) {
+	_, subnetNet, err := net.ParseCIDR(subnet)
+	if err != nil || subnetNet == nil {
+		agent.log.Error("Invalid infra querier subnet: ", subnet)
+		return
+	}
+
+	if agent.isInfraQuerierSubnetRoutePresent(link, subnetNet) {
+		agent.log.Info("Infra querier subnet route already present for interface ", name)
+		return
+	}
+
+	retryCount := agent.config.DhcpRenewMaxRetryCount
+	for i := 0; i < retryCount; i++ {
+		if err := agent.addStaticLinkRoute(link, subnetNet, infraRouteMetric); err != nil {
+			agent.log.Errorf("Failed to add infra querier subnet route: %v (attempt %d)", err, i+1)
+			continue
+		}
+		if agent.isInfraQuerierSubnetRoutePresent(link, subnetNet) {
+			agent.log.Info("Added infra querier subnet route successfully")
+			return
+		}
+		agent.log.Errorf("Failed to add infra querier subnet route (attempt %d)", i+1)
+	}
+	agent.log.Errorf("Failed to add infra querier subnet route for interface %s after %d attempts", name, retryCount)
+}
+
+// scheduleInfraQuerierSubnetRoute ensures the infra querier subnet has been populated.
+// If the subnet annotation is not yet available it retries with exponential backoff
+// (5→10→20→40→80→160s ≈ 5 min total), then gives up. Once the subnet is known, route
+// addition follows the same bounded-retry pattern as addMultiCastRoute.
+func (agent *HostAgent) scheduleInfraQuerierSubnetRoute(link netlink.Link, name string) {
+	if !agent.infraRoutePending.CompareAndSwap(false, true) {
+		agent.log.Info("Infra querier route addition already pending for ", name)
+		return
+	}
+	go func() {
+		defer agent.infraRoutePending.Store(false)
+		const (
+			baseDelay     = 5 * time.Second
+			backoffFactor = 2
+			maxIterations = 6
+		)
+		backoff := baseDelay
+		for range maxIterations {
+			subnet, _ := agent.infraQuerierSubnet.Load().(string)
+			if subnet != "" {
+				agent.addInfraQuerierSubnetRoute(link, name, subnet)
+				return
+			}
+			agent.log.Infof("Infra querier subnet not yet available, waiting for controller to annotate node. Retrying in %v", backoff)
+			time.Sleep(backoff)
+			backoff *= backoffFactor
+		}
+		agent.log.Error("Infra querier subnet annotation not available on node ", agent.config.NodeName, " even after ", maxIterations, " attempts, giving up trying to add infra querier subnet route for interface ", name)
+	}()
 }
 
 func (agent *HostAgent) getInterfaceIPv4s(iface string) []net.IP {
@@ -620,6 +713,7 @@ func (agent *HostAgent) doDhcpRenew(aciPodSubnet string) {
 				agent.log.Error("FAILURE: Failed to assign an ip from new pod subnet to vlan interface")
 			}
 			agent.addMultiCastRoute(link, link.Name)
+			agent.scheduleInfraQuerierSubnetRoute(link, link.Name)
 		}
 	}
 

--- a/pkg/metadata/annotations.go
+++ b/pkg/metadata/annotations.go
@@ -61,6 +61,7 @@ const PodNetworkRangeAnnotation = "opflex.cisco.com/pod-network-ranges"
 
 const AciPodAnnotation = "opflex.cisco.com/aci-pod"
 const NodeAciPodAnnotation = "opflex.cisco.com/node-aci-pod"
+const InfraQuerierSubnetAnnotation = "opflex.cisco.com/infra-querier-subnet"
 
 // Annotation for endpoint group designation for pod, deployment, etc.
 const EgAnnotation = "opflex.cisco.com/endpoint-group"


### PR DESCRIPTION
In a multipod ACI fabric, IGMP queries on the infra VLAN originate
from the Pod 1 TEP pool subnet (e.g. 10.0.0.30). VMs outside Pod 1
drop these queries due to reverse-path filtering — they have no route
to the source subnet, so the RPF check fails and IGMP reports are
never sent back. This breaks multicast group membership for migrated
VMs.

To address this, a static route for the infra querier subnet is added
on the infra VLAN interface — the same approach already used for the
224.0.0.0/4 multicast route. This commit handles the case where a
DHCP release-renew cycle during inter-pod migration clears the
existing routes.

Controller:
- Queries APIC for the querier subnet under tn-infra/BD-default on
  startup and on every APIC reconnect
- Propagates the subnet to nodes via a K8s annotation, updating only
  nodes that carry a stale or missing value

Hostagent:
- Reads the annotation and adds the route after each DHCP renew cycle
- Waits with exponential backoff if the annotation has not yet
  propagated, giving up after approximately five minutes
- Uses netlink for route management instead of shelling out
- Deduplicates concurrent route additions and detects existing
  superset routes to avoid redundant entries