### PR TITLE
[mmr-6.1.1] Bump go version to 1.25.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
     - stage: check
       if: tag IS NOT present
       sudo: false
-      go: 1.25.0
+      go: 1.25.8
       before_install:
         - go install github.com/mattn/goveralls@v0.0.12
       install:
@@ -36,7 +36,7 @@ jobs:
         - pip install PyYAML
         - pip install pytz
         - curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
-      go: 1.25.0
+      go: 1.25.8
       go_import_path: github.com/noironetworks/aci-containers
       before_script:
         - export DOCKER_BUILDKIT=1


### PR DESCRIPTION
(cherry picked from commit 7ecebb86eb8be86a65345e2e1553e470e8073fac)