### PR TITLE
Remove stale binary dependencies from CNI images

### DIFF
--- a/docker/Dockerfile-cnideploy-base
+++ b/docker/Dockerfile-cnideploy-base
@@ -1,7 +1,8 @@
 ARG basetag=latest
 ARG baserepo=quay.io/noirolabs
 FROM ${baserepo}/aci-containers-base:${basetag}
+ARG CNI_PLUGINS_VERSION=v1.9.1
 RUN yum install -y wget ca-certificates tar gzip \
   && yum clean all \
-  && mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz | tar xz -C /opt/cni/bin
+  && mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-amd64-${CNI_PLUGINS_VERSION}.tgz | tar xz -C /opt/cni/bin
 CMD ["/usr/bin/sh"]

--- a/docker/Dockerfile-controller
+++ b/docker/Dockerfile-controller
@@ -10,6 +10,9 @@ summary="This is an ACI CNI Containers Controller." \
 description="This will deploy a single instance of ACI CNI Containers Controller."
 # Required Licenses
 COPY docker/licenses /licenses
-COPY pkg/istiocrd/upstream-istio-cr.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
+# Istio support is currently disabled (see Dockerfile-controller-base).
+# Directory was used to stage upstream-istio-cr.yaml for kubectl apply in
+# pkg/controller/aci_istio.go (now disabled).
+#COPY pkg/istiocrd/upstream-istio-cr.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
 COPY dist-static/aci-containers-controller /usr/local/bin/
 ENTRYPOINT exec /usr/local/bin/aci-containers-controller -config-path /usr/local/etc/aci-containers/controller.conf

--- a/docker/Dockerfile-controller-base
+++ b/docker/Dockerfile-controller-base
@@ -1,9 +1,15 @@
 ARG basetag=latest
 ARG baserepo=quay.io/noirolabs
 FROM ${baserepo}/aci-containers-base:${basetag}
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
-  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl \
-  && curl -sL "https://github.com/istio/istio/releases/download/1.6.5/istioctl-1.6.5-linux-amd64.tar.gz" | tar xz \
-  && chmod u+x istioctl && mv istioctl /usr/local/bin/istioctl \
-  && mkdir -p /usr/local/var/lib/aci-cni
+# Istio support is disabled due to security vulnerabilities detected in
+# istio.io/istio package.  The controller Go code that consumed kubectl and
+# istioctl is build-excluded / commented out.  Keeping these lines commented
+# so the dependency can be restored easily if needed in the future.
+#RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl \
+#  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl \
+#  && curl -sL "https://github.com/istio/istio/releases/download/1.6.5/istioctl-1.6.5-linux-amd64.tar.gz" | tar xz \
+#  && chmod u+x istioctl && mv istioctl /usr/local/bin/istioctl \
+# Directory was used to stage upstream-istio-cr.yaml for kubectl apply in
+# pkg/controller/aci_istio.go (now disabled).
+#  && mkdir -p /usr/local/var/lib/aci-cni
 CMD ["/usr/bin/sh"]

--- a/docker/Dockerfile-controller-dev
+++ b/docker/Dockerfile-controller-dev
@@ -1,9 +1,14 @@
 FROM noirolabs/ubibase:latest
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
-RUN chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
-RUN curl -sL "https://github.com/istio/istio/releases/download/1.6.5/istioctl-1.6.5-linux-amd64.tar.gz" | tar xz
-RUN chmod u+x istioctl && mv istioctl /usr/local/bin/istioctl
-RUN mkdir -p /usr/local/var/lib/aci-cni
-COPY pkg/istiocrd/upstream-istio-cr.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
+# Istio support is disabled due to security vulnerabilities detected in
+# istio.io/istio package.  The controller Go code that consumed kubectl and
+# istioctl is build-excluded / commented out.
+#RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
+#RUN chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
+#RUN curl -sL "https://github.com/istio/istio/releases/download/1.6.5/istioctl-1.6.5-linux-amd64.tar.gz" | tar xz
+#RUN chmod u+x istioctl && mv istioctl /usr/local/bin/istioctl
+# Directory was used to stage upstream-istio-cr.yaml for kubectl apply in
+# pkg/controller/aci_istio.go (now disabled).
+#RUN mkdir -p /usr/local/var/lib/aci-cni
+#COPY pkg/istiocrd/upstream-istio-cr.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
 COPY dist-static/aci-containers-controller /usr/local/bin/
 ENTRYPOINT exec /usr/local/bin/aci-containers-controller -config-path /usr/local/etc/aci-containers/controller.conf

--- a/docker/Dockerfile-operator
+++ b/docker/Dockerfile-operator
@@ -1,6 +1,6 @@
 ARG basetag=latest
 ARG baserepo=quay.io/noirolabs
-FROM ${baserepo}/aci-containers-operator-base:${basetag}
+FROM ${baserepo}/aci-containers-base:${basetag}
 # Required OpenShift Labels
 LABEL name="ACI CNI Operator" \
 vendor="Cisco" \

--- a/docker/Dockerfile-operator-base
+++ b/docker/Dockerfile-operator-base
@@ -1,8 +1,0 @@
-ARG basetag=latest
-ARG baserepo=quay.io/noirolabs
-FROM ${baserepo}/aci-containers-base:${basetag}
-RUN yum install -y git \
-  && yum clean all \
-  && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.3/bin/linux/amd64/kubectl \
-  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
-CMD ["/usr/bin/sh"]

--- a/docker/dev/alpine/Dockerfile-cnideploy
+++ b/docker/dev/alpine/Dockerfile-cnideploy
@@ -1,6 +1,7 @@
 FROM alpine:3.12.3
 RUN apk upgrade --no-cache && \
   apk add --no-cache wget ca-certificates && update-ca-certificates
-RUN mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz | tar xz -C /opt/cni/bin
+ARG CNI_PLUGINS_VERSION=v1.9.1
+RUN mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-amd64-${CNI_PLUGINS_VERSION}.tgz | tar xz -C /opt/cni/bin
 COPY launch-cnideploy.sh /usr/local/bin/
 CMD ["/usr/local/bin/launch-cnideploy.sh"]

--- a/docker/dev/alpine/Dockerfile-controller
+++ b/docker/dev/alpine/Dockerfile-controller
@@ -1,10 +1,15 @@
 FROM alpine:3.12.3
-RUN apk upgrade --no-cache && \
-    apk update && apk add curl && \
-    curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
-    chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl && \
-    curl -LO https://istio.io/operator.yaml && \
-    mkdir -p /usr/local/var/lib/aci-cni
-COPY pkg/istiocrd/upstream-istio-cr.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
+RUN apk upgrade --no-cache
+# Istio support is disabled due to security vulnerabilities detected in
+# istio.io/istio package.  The controller Go code that consumed kubectl and
+# istioctl is build-excluded / commented out.
+#RUN apk update && apk add curl && \
+#    curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && \
+#    chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl && \
+#    curl -LO https://istio.io/operator.yaml && \
+# Directory was used to stage upstream-istio-cr.yaml for kubectl apply in
+# pkg/controller/aci_istio.go (now disabled).
+#    mkdir -p /usr/local/var/lib/aci-cni
+#COPY pkg/istiocrd/upstream-istio-cr.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
 COPY dist-static/aci-containers-controller /usr/local/bin/
 ENTRYPOINT exec /usr/local/bin/aci-containers-controller -config-path /usr/local/etc/aci-containers/controller.conf

--- a/docker/dev/alpine/Dockerfile-operator
+++ b/docker/dev/alpine/Dockerfile-operator
@@ -1,7 +1,4 @@
 FROM alpine:3.12.3
 RUN apk upgrade --no-cache
-RUN apk update && apk add curl git
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.3/bin/linux/amd64/kubectl
-RUN chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
 COPY dist-static/aci-containers-operator /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/aci-containers-operator"]

--- a/docker/travis/Dockerfile-cnideploy
+++ b/docker/travis/Dockerfile-cnideploy
@@ -10,8 +10,9 @@ description="This operator will deploy a single instance of ACI CNI cnideploy."
 RUN yum update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y && rm -rf /var/cache/yum
 # Required Licenses
 COPY docker/licenses /licenses
+ARG CNI_PLUGINS_VERSION=v1.9.1
 RUN yum install --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y wget ca-certificates tar gzip \
   && yum clean all \
-  && mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/v0.9.1/cni-plugins-linux-amd64-v0.9.1.tgz | tar xz -C /opt/cni/bin
+  && mkdir -p /opt/cni/bin && wget -O- https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGINS_VERSION}/cni-plugins-linux-amd64-${CNI_PLUGINS_VERSION}.tgz | tar xz -C /opt/cni/bin
 COPY docker/launch-cnideploy.sh /usr/local/bin/
 CMD ["/usr/local/bin/launch-cnideploy.sh"]

--- a/docker/travis/Dockerfile-controller
+++ b/docker/travis/Dockerfile-controller
@@ -11,12 +11,17 @@ RUN yum update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ub
 RUN yum install --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms curl -y --allowerasing && rm -rf /var/cache/yum
 # Required Licenses
 COPY docker/licenses /licenses
-ARG KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
-RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
-  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl \
-  && curl -sL "https://github.com/istio/istio/releases/download/1.18.2/istio-1.18.2-linux-amd64.tar.gz" | tar xz \
-  && chmod u+x istio-1.18.2/bin/istioctl && mv istio-1.18.2/bin/istioctl /usr/local/bin/istioctl \
-  && mkdir -p /usr/local/var/lib/aci-cni
-COPY pkg/istiocrd/upstream-istio-cr.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
+# Istio support is disabled due to security vulnerabilities detected in
+# istio.io/istio package.  The controller Go code that consumed kubectl and
+# istioctl is build-excluded / commented out.
+#ARG KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+#RUN curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
+#  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl \
+#  && curl -sL "https://github.com/istio/istio/releases/download/1.18.2/istio-1.18.2-linux-amd64.tar.gz" | tar xz \
+#  && chmod u+x istio-1.18.2/bin/istioctl && mv istio-1.18.2/bin/istioctl /usr/local/bin/istioctl \
+# Directory was used to stage upstream-istio-cr.yaml for kubectl apply in
+# pkg/controller/aci_istio.go (now disabled).
+#  && mkdir -p /usr/local/var/lib/aci-cni
+#COPY pkg/istiocrd/upstream-istio-cr.yaml /usr/local/var/lib/aci-cni/upstream-istio-ctrlplane-resource.yaml
 COPY dist-static/aci-containers-controller /usr/local/bin/
 ENTRYPOINT exec /usr/local/bin/aci-containers-controller -config-path /usr/local/etc/aci-containers/controller.conf

--- a/docker/travis/Dockerfile-operator
+++ b/docker/travis/Dockerfile-operator
@@ -9,9 +9,6 @@ summary="This is an ACI CNI Operator." \
 description="This operator will deploy a single instance of ACI CNI Operator."
 # Required Licenses
 RUN yum update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y && rm -rf /var/cache/yum
-RUN yum install --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms curl -y --allowerasing && rm -rf /var/cache/yum
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.21.3/bin/linux/amd64/kubectl \
-  && chmod u+x kubectl && mv kubectl /usr/local/bin/kubectl
 COPY docker/licenses /licenses
 COPY dist-static/aci-containers-operator /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/aci-containers-operator"]

--- a/pkg/controller/acicontainersoperator.go
+++ b/pkg/controller/acicontainersoperator.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"reflect"
 	"strings"
 	"sync"
@@ -52,6 +51,7 @@ import (
 	accprovisioninputclientset "github.com/noironetworks/aci-containers/pkg/accprovisioninput/clientset/versioned"
 	operators "github.com/noironetworks/aci-containers/pkg/acicontainersoperator/apis/aci.ctrl/v1alpha1"
 	operatorclientset "github.com/noironetworks/aci-containers/pkg/acicontainersoperator/clientset/versioned"
+	"github.com/noironetworks/aci-containers/pkg/util"
 )
 
 func init() {
@@ -97,6 +97,7 @@ type Controller struct {
 	Informer_Route              cache.SharedIndexInformer
 	Informer_Config             cache.SharedIndexInformer
 	Resources                   AciResources
+	RuntimeClient               client.Client             // General-purpose controller-runtime client
 	DnsOperatorClient           client.Client             // This client is specific dnsopenshift operator
 	RoutesClient                routesClientset.Interface // This client is specific routes openshift operator
 	Openshiftflavor             bool
@@ -298,11 +299,21 @@ func NewAciContainersOperator(
 		}
 	}
 
+	restCfg, err := config.GetConfig()
+	if err != nil {
+		log.Fatalf("Failed to get in-cluster config: %v", err)
+	}
+	runtimeClient, err := client.New(restCfg, client.Options{})
+	if err != nil {
+		log.Fatalf("Failed to create controller-runtime client: %v", err)
+	}
+
 	controller := &Controller{
 		Logger:                      log.NewEntry(log.New()),
 		Operator_Clientset:          acicnioperatorclient,
 		AccProvisionInput_Clientset: accprovisioninputclient,
 		K8s_Clientset:               k8sclient,
+		RuntimeClient:               runtimeClient,
 		Informer_Operator:           aci_operator_informer,
 		Informer_Deployment:         aci_deployment_informer,
 		Informer_Daemonset:          aci_daemonset_informer,
@@ -1013,23 +1024,6 @@ func (c *Controller) handleOperatorCreate(obj interface{}) bool {
 		decString = strings.Replace(decString, "path: /var/lib/dhclient", "path: /var/lib/dhcp", 1)
 		dec = []byte(decString)
 	}
-	f, err := os.Create("aci-deployment.yaml")
-	if err != nil {
-		log.Error(err)
-		return true
-	}
-	if _, err := f.Write(dec); err != nil {
-		log.Error(err)
-		return true
-	}
-	if err := f.Sync(); err != nil {
-		log.Error(err)
-		return true
-	}
-	if err := f.Close(); err != nil {
-		log.Error(err)
-		return true
-	}
 
 	log.Info("Platform flavor is ", acicontainersoperator.Spec.Flavor)
 
@@ -1088,14 +1082,8 @@ func (c *Controller) handleOperatorCreate(obj interface{}) bool {
 
 	log.Info("Applying Aci Deployment")
 
-	//Currently the Kubectl version is v.1.14. This will be updated by the acc-provision according
-	//to the platform specification
-
-	cmd := exec.Command("kubectl", "apply", "-f", "aci-deployment.yaml")
-	log.Debug(cmd)
-	cmdOutput, err := cmd.Output()
-	if err != nil {
-		log.Errorf("cmdOutput: %s err: %v", cmdOutput, err)
+	if err := util.ApplyResources(c.RuntimeClient, dec, "aci-containers-operator"); err != nil {
+		log.Errorf("Failed to apply aci deployment: %v", err)
 		return true
 	}
 

--- a/pkg/util/applyresources.go
+++ b/pkg/util/applyresources.go
@@ -1,0 +1,109 @@
+// Copyright 2020 Cisco Systems, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ApplyResourcesFromFile reads a multi-document YAML file and applies each
+// resource to the cluster using server-side apply via controller-runtime.
+func ApplyResourcesFromFile(c client.Client, filename, fieldManager string) error {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", filename, err)
+	}
+	return ApplyResources(c, data, fieldManager)
+}
+
+// ApplyResources applies each resource in a multi-document YAML byte slice
+// to the cluster using server-side apply via controller-runtime.
+func ApplyResources(c client.Client, data []byte, fieldManager string) error {
+	decoder := utilyaml.NewYAMLOrJSONDecoder(strings.NewReader(string(data)), 4096)
+
+	var errs []error
+	for {
+		obj := &unstructured.Unstructured{}
+		err := decoder.Decode(obj)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("decoding YAML document: %w", err)
+		}
+		if obj.Object == nil {
+			continue
+		}
+
+		log.Infof("Applying %s %s/%s", obj.GetKind(), obj.GetNamespace(), obj.GetName())
+		if err := applyWithRetry(context.TODO(), c, obj, fieldManager); err != nil {
+			errs = append(errs, fmt.Errorf("applying %s %s/%s: %w",
+				obj.GetKind(), obj.GetNamespace(), obj.GetName(), err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// applyWithRetry applies a single resource using server-side apply.
+// It retries only on NoMatch errors (CRD-then-CR race); all other
+// errors are returned immediately, matching kubectl apply behaviour.
+func applyWithRetry(ctx context.Context, c client.Client, obj *unstructured.Unstructured, fieldManager string) error {
+	patch := func() error {
+		return c.Patch(ctx, obj, client.Apply, client.FieldOwner(fieldManager), client.ForceOwnership)
+	}
+
+	err := patch()
+	if err == nil || !meta.IsNoMatchError(err) {
+		return err
+	}
+
+	// CRD is not yet registered — back off and retry.
+	// The API server CRD controller typically establishes new
+	// endpoints within 1-3s; the DynamicRESTMapper auto-resets
+	// its discovery cache on NoMatchError.
+	backoff := wait.Backoff{
+		Steps:    4,
+		Duration: 1 * time.Second,
+		Factor:   2.0,
+		Cap:      10 * time.Second,
+	}
+
+	return wait.ExponentialBackoffWithContext(ctx, backoff, func(ctx context.Context) (bool, error) {
+		log.Debugf("API not yet available for %s %s/%s, retrying...",
+			obj.GetKind(), obj.GetNamespace(), obj.GetName())
+		err := patch()
+		if err == nil {
+			return true, nil
+		}
+		if meta.IsNoMatchError(err) {
+			return false, nil
+		}
+		return false, err
+	})
+}


### PR DESCRIPTION
Several pinned binaries in the ACI container images are outdated. Istio support was previously disabled due to known CVEs in istio.io/istio; the kubectl and istioctl installs in the controller images were the only remaining artefacts of that disabled code path. This change removes those stale installs and replaces the operator's kubectl dependency with a native Go implementation.

Operator

- Replace exec("kubectl apply") in handleOperatorCreate with native controller-runtime server-side apply via pkg/util/applyresources.go, using unstructured SSA
- Remove the aci-deployment.yaml file write round-trip, no longer needed
- Delete Dockerfile-operator-base and rebase Dockerfile-operator directly onto aci-containers-base
- Remove kubectl installation from dev/alpine and travis operator Dockerfiles

Controller

- Remove stale kubectl and istioctl installs from all controller Dockerfile variants; the Go code consuming them is already build-excluded
- Disable COPY of upstream-istio-cr.yaml in controller image

Cnideploy

- Bump CNI plugins from v0.9.1 to v1.9.1
- Parameterise with ARG CNI_PLUGINS_VERSION for easier future updates