### PR TITLE
Replace fixed retry delay with jitter backoff

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -117,16 +117,16 @@ type ApicConnection struct {
 	vrfTenant        string
 	version          string // APIC version
 
-	VersionUpdateHook   VersionUpdateHandler
-	VMMLiteSyncHook     VMMLiteSyncHandler
-	CachedVersion       string
-	ReconnectInterval   time.Duration
-	ReconnectRetryLimit int
-	RequestRetryDelay   int
-	EnableRequestRetry  bool
-	VmmDomain           string
-	Flavor              string
-	FilterOpflexDevice  bool
+	VersionUpdateHook     VersionUpdateHandler
+	VMMLiteSyncHook       VMMLiteSyncHandler
+	CachedVersion         string
+	ReconnectInterval     time.Duration
+	ReconnectRetryLimit   int
+	RequestRetryDelayBase int
+	EnableRequestRetry    bool
+	VmmDomain             string
+	Flavor                string
+	FilterOpflexDevice    bool
 
 	RefreshInterval         time.Duration
 	RefreshTickerAdjust     time.Duration

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/http/cookiejar"
 	"regexp"
@@ -996,7 +997,7 @@ func (conn *ApicConnection) checkLeafReboot() {
 }
 
 // sendHTTPSRequestToAPIC sends an HTTPS request to APIC.
-// - Retries on 503 when EnableRequestRetry is true, up to maxRequestRetry, waiting RequestRetryDelay minutes.
+// - Retries on 503 when EnableRequestRetry is true, up to maxRequestRetry times, using exponential backoff with jitter.
 // - If restart is true, the connection is restarted on request/transport errors, non-2xx responses, and after retry exhaustion.
 // - Status codes in exceptionStatusCode are returned as-is for the caller to handle.
 // Sets the Content-Type header when provided; pass nil for body and "" for contentType to omit them.
@@ -1056,7 +1057,18 @@ func (conn *ApicConnection) sendHTTPSRequestToAPIC(method string, uri string, bo
 				return resp, fmt.Errorf("Got error response from APIC")
 			}
 			complete(resp)
-			time.Sleep(time.Duration(conn.RequestRetryDelay) * time.Minute)
+			// Exponential backoff with jitter
+			// With default minBase=20s (configurable via RequestRetryDelayBase):
+			//   retry intervals: [20s, 40s], [40s, 60s], [80s, 100s], [160s, 180s], [320s, 340s]
+			// Intervals are strictly non-overlapping (each min >= previous max).
+			// For all retries to complete - min time: 620s ~ 10 min 20 sec, max time: 720s = 12 min.
+			minBase := time.Duration(conn.RequestRetryDelayBase) * time.Second
+			exp := time.Duration(1 << uint(retry-1)) // 2^(retry-1): 1, 2, 4, 8, 16
+			base := minBase * exp
+			jitter := time.Duration(rand.Int63n(int64(20 * time.Second)))
+			backoffDuration := base + jitter
+			conn.log.Debugf("Waiting %v before retry attempt %d", backoffDuration, retry)
+			time.Sleep(backoffDuration)
 			continue
 		}
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -313,8 +313,8 @@ type ControllerConfig struct {
 	// Number of times the connection to APIC should be retried before switching to another APIC
 	ApicConnectionRetryLimit int `json:"apic-connection-retry-limit,omitempty"`
 
-	// Timeout in minutes to wait in between retries before sending request to APIC
-	ApicRequestRetryDelay int `json:"apic-request-retry-delay,omitempty"`
+	// Base delay in seconds for exponential backoff between APIC request retries
+	ApicRequestRetryDelayBase int `json:"apic-request-retry-delay-base,omitempty"`
 
 	// Enable retying request to APIC when a 503 error is encountered
 	EnableApicRequestRetry bool `json:"enable-apic-request-retry-delay,omitempty"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -888,7 +888,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	cont.apicConn.Flavor = cont.config.Flavor
 	cont.apicConn.VmmDomain = cont.config.AciVmmDomain
 	cont.apicConn.ReconnectRetryLimit = cont.config.ApicConnectionRetryLimit
-	cont.apicConn.RequestRetryDelay = cont.config.ApicRequestRetryDelay
+	cont.apicConn.RequestRetryDelayBase = cont.config.ApicRequestRetryDelayBase
 	cont.apicConn.EnableRequestRetry = cont.config.EnableApicRequestRetry
 
 	if len(cont.config.ApicHosts) != 0 {


### PR DESCRIPTION
Previously, 503 responses triggered a flat sleep of RequestRetryDelay minutes between each retry, causing all instances to retry in lockstep (thundering herd).

Replace with exponential backoff and random jitter:

  backoff(n) = minBase * 2^(retry-1) + rand(0, minBase) [n = retry, 1-based]

With default minBase = 20s (configurable via RequestRetryDelayBase) Retry intervals:
  retry 1: [ 20s,  40s]
  retry 2: [ 40s,  60s]
  retry 3: [ 80s, 100s]
  retry 4: [160s, 180s]
  retry 5: [320s, 340s]

Total wait across all 5 retries is bounded between 10m 20s (best case) and 12m (worst case).