### PR TITLE
Fix LLDP subscription refresh timeout in CNO mode

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -130,6 +130,8 @@ type ApicConnection struct {
 
 	RefreshInterval         time.Duration
 	RefreshTickerAdjust     time.Duration
+	LldpRefreshInterval     time.Duration
+	LldpRefreshTickerAdjust time.Duration
 	LeafRebootCheckInterval time.Duration
 	SubscriptionDelay       time.Duration
 	RetryInterval           time.Duration

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -171,7 +171,9 @@ func configureTls(cert []byte) (*tls.Config, error) {
 func New(log *logrus.Logger, apic []string, user string,
 	password string, privKey []byte, cert []byte,
 	prefix string, refresh int, refreshTickerAdjust int,
-	leafRebootCheckInterval int, subscriptionDelay int, vrfTenant string,
+	leafRebootCheckInterval int, subscriptionDelay int,
+	lldpRefresh int, lldpRefreshTickerAdjust int,
+	vrfTenant string,
 	lldpIfHldr func(dn, lldpIf string) bool, cnoEnabled bool) (*ApicConnection, error) {
 	tls, err := configureTls(cert)
 	if err != nil {
@@ -213,6 +215,8 @@ func New(log *logrus.Logger, apic []string, user string,
 		RefreshInterval:         time.Duration(refresh) * time.Second,
 		LeafRebootCheckInterval: time.Duration(leafRebootCheckInterval) * time.Second,
 		RefreshTickerAdjust:     time.Duration(refreshTickerAdjust) * time.Second,
+		LldpRefreshInterval:     time.Duration(lldpRefresh) * time.Second,
+		LldpRefreshTickerAdjust: time.Duration(lldpRefreshTickerAdjust) * time.Second,
 		SubscriptionDelay:       time.Duration(subscriptionDelay) * time.Millisecond,
 
 		SyncDone:         false,
@@ -657,6 +661,25 @@ func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {
 		conn.initializeLeafDnCache()
 		defer leafRebootCheckTicker.Stop()
 	}
+
+	// LLDP subscription refresh ticker - uses separate shorter interval
+	// because LLDP subscriptions are created dynamically and have different
+	// refresh timeout requirements. Only needed in CNO/chained mode.
+	lldpRefreshInterval := conn.LldpRefreshInterval
+	if lldpRefreshInterval == 0 {
+		lldpRefreshInterval = 120 * time.Second // default 120 seconds
+	}
+	lldpRefreshTickerInterval := lldpRefreshInterval - conn.LldpRefreshTickerAdjust
+	if lldpRefreshTickerInterval <= 0 {
+		lldpRefreshTickerInterval = 100 * time.Second // fallback to 100 seconds
+	}
+	lldpRefreshTicker := time.NewTicker(lldpRefreshTickerInterval)
+	if conn.cnoEnabled {
+		defer lldpRefreshTicker.Stop()
+	} else {
+		lldpRefreshTicker.Stop()
+	}
+
 	var hasErr bool
 	for value, object := range conn.syncStore {
 		if !(conn.getSyncObject(value, object)) {
@@ -721,7 +744,9 @@ func (conn *ApicConnection) runConn(stopCh <-chan struct{}) {
 		conn.stopped = stop
 		conn.syncEnabled = false
 		conn.subscriptions.ids = make(map[string]string)
-		conn.version = ""
+		if !conn.cnoEnabled {
+			conn.version = ""
+		}
 		conn.indexMutex.Unlock()
 
 		conn.log.Debug("Shutting down web socket")
@@ -745,6 +770,8 @@ loop:
 			conn.fullSync()
 		case <-refreshTicker.C:
 			conn.refresh()
+		case <-lldpRefreshTicker.C:
+			conn.refreshLldp()
 		case <-leafRebootCheckTicker.C:
 			conn.checkLeafReboot()
 		case <-restart:
@@ -922,6 +949,44 @@ func (conn *ApicConnection) refresh() {
 		} else {
 			refreshId(sub.id)
 		}
+	}
+}
+
+// refreshLldp refreshes only LLDP-related subscriptions (lldpAdjEp)
+// These subscriptions are created dynamically and require a shorter
+// refresh interval than the main subscriptions
+func (conn *ApicConnection) refreshLldp() {
+	lldpCount := 0
+	for dn, sub := range conn.subscriptions.subs {
+		// Check if this is an LLDP subscription (contains "lldp" in the DN)
+		if !strings.Contains(strings.ToLower(dn), "lldp") {
+			continue
+		}
+		lldpCount++
+
+		refreshId := func(id string) {
+			uri := fmt.Sprintf("/api/subscriptionRefresh.json?id=%s", id)
+			resp, err := conn.sendHTTPSRequestToAPIC("GET", uri, nil, "", true, nil)
+			if err != nil {
+				conn.log.Errorf("LLDP subscription refresh failed for id=%s dn=%s: %v", id, dn, err)
+				return
+			}
+			complete(resp)
+			conn.log.Debugf("LLDP refresh sub: id=%s dn=%s url=%v", id, dn, resp.Request.URL)
+			time.Sleep(conn.SubscriptionDelay)
+		}
+
+		if len(sub.childSubs) > 0 {
+			for id := range sub.childSubs {
+				refreshId(id)
+			}
+		} else if sub.id != "" {
+			refreshId(sub.id)
+		}
+	}
+
+	if lldpCount > 0 {
+		conn.log.Debugf("LLDP subscription refresh completed for %d subscriptions", lldpCount)
 	}
 }
 

--- a/pkg/apicapi/apicapi_test.go
+++ b/pkg/apicapi/apicapi_test.go
@@ -184,7 +184,7 @@ func (server *testServer) testConn(key []byte) (*ApicConnection, error) {
 	})
 
 	n, err := New(log, []string{apic}, "admin", "noir0123", key, cert, "kube",
-		60, 5, 60, 5, "common", nil, false)
+		60, 5, 60, 5, 120, 20, "common", nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/annotation_test.go
+++ b/pkg/controller/annotation_test.go
@@ -175,7 +175,7 @@ func (server *testServer) testConn(key []byte) (*apicapi.ApicConnection, error) 
 	})
 
 	n, err := apicapi.New(log, []string{apic}, "admin", "noir0123", key, cert, "kube",
-		60, 5, 60, 5, "common", nil, false)
+		60, 5, 60, 5, 120, 20, "common", nil, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -102,6 +102,14 @@ type ControllerConfig struct {
 	// actual subscription refresh-timeout. Will be defaulted to 150Seconds.
 	ApicRefreshTickerAdjust string `json:"apic-refreshticker-adjust,omitempty"`
 
+	// LLDP subscription refresh timeout in seconds.
+	// Will be defaulted to 120 seconds.
+	ApicLldpRefreshTimer string `json:"apic-lldp-refreshtime,omitempty"`
+
+	// How early (seconds) the LLDP subscriptions to be refreshed than
+	// actual LLDP subscription refresh-timeout. Will be defaulted to 20 seconds.
+	ApicLldpRefreshTickerAdjust string `json:"apic-lldp-refreshticker-adjust,omitempty"`
+
 	// A path for a PEM-encoded private key for client certificate
 	// authentication for APIC API
 	ApicPrivateKeyPath string `json:"apic-private-key-path,omitempty"`

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -796,6 +796,26 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		panic(err)
 	}
 
+	// If not defined, default LLDP refresh timer to 120 seconds
+	if cont.config.ApicLldpRefreshTimer == "" {
+		cont.config.ApicLldpRefreshTimer = "120"
+	}
+	lldpRefreshTimeout, err := strconv.Atoi(cont.config.ApicLldpRefreshTimer)
+	if err != nil {
+		panic(err)
+	}
+	cont.log.Info("ApicLldpRefreshTimer conf is set to: ", lldpRefreshTimeout)
+
+	// If not defined, default LLDP refresh ticker adjust to 20 seconds
+	if cont.config.ApicLldpRefreshTickerAdjust == "" {
+		cont.config.ApicLldpRefreshTickerAdjust = "20"
+	}
+	lldpRefreshTickerAdjust, err := strconv.Atoi(cont.config.ApicLldpRefreshTickerAdjust)
+	if err != nil {
+		panic(err)
+	}
+	cont.log.Info("ApicLldpRefreshTickerAdjust conf is set to: ", lldpRefreshTickerAdjust)
+
 	// If not defined, default to 900s
 	if cont.config.LeafRebootCheckInterval == 0 {
 		cont.config.LeafRebootCheckInterval = 900
@@ -879,6 +899,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 		cont.config.ApicUsername, cont.config.ApicPassword,
 		privKey, apicCert, cont.config.AciPrefix,
 		refreshTimeout, refreshTickerAdjust, cont.config.LeafRebootCheckInterval, cont.config.ApicSubscriptionDelay,
+		lldpRefreshTimeout, lldpRefreshTickerAdjust,
 		cont.config.AciVrfTenant, cont.UpdateLLDPIfLocked, cont.isCNOEnabled())
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
LLDP subscriptions (lldpIf) are created dynamically via AddImmediateSubscriptionDnLocked and have a shorter timeout (~120s). This causes "Subscription refresh timeout" errors in CNO mode.

- Add separate LLDP refresh ticker with configurable interval (default: 120s timer, 20s adjust = 100s effective refresh)
- LLDP refresh ticker only runs in CNO/chained mode
- Add refreshLldp() function to refresh only LLDP subscriptions
- Add config options: apic-lldp-refreshtime, apic-lldp-refreshticker-adjust
- Preserve APIC version across reconnects in CNO mode to avoid unnecessary GetVersion() calls