### PR TITLE
update the goproxy in travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: go
 env:
   global:
     - DEFAULT_BRANCH: master
-    - GOPROXY: https://proxy.golang.org,https://goproxy.io,direct
+    - GOPROXY: https://proxy.golang.org|https://goproxy.io|direct
 
 jobs:
   include:


### PR DESCRIPTION
In travis.yaml env, when used commas, go only falls back to the next source on 404. etc. A 502 usually stops the build instead of trying the next source. So, replacing the comma with '|' so as to try next.
This is to avoid any transient error like:
```
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.21: loading deprecation for sigs.k8s.io/controller-runtime/tools/setup-envtest: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260418192536-e4a998cc6b09: verifying go.mod: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260418192536-e4a998cc6b09/go.mod: reading https://goproxy.io/sumdb/sum.golang.org/lookup/sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20260418192536-e4a998cc6b09: 502 Bad Gateway
    server response: error code: 502
make: *** [Makefile:112: /home/travis/build/noironetworks/aci-containers/tools/bin/setup-envtest] Error 1
```