### PR TITLE
Fix per-service SNAT IP assignment for no-SnatIp policies

### DIFF
--- a/pkg/controller/snatglobalinfo.go
+++ b/pkg/controller/snatglobalinfo.go
@@ -393,18 +393,18 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 					markready[name] = true
 				}
 				cont.updateGlobalInfoforPolicy(portrange, snatIp, nodename,
-					nodeinfo.Spec.Macaddress, name)
+					nodeinfo.Spec.Macaddress, name, "")
 				updated = true
 			} else {
-				snatIps := cont.getServiceIps(snatpolicy)
-				nodeSNATEntryFound := cont.checkIfPolicyApplied(nodename, name, snatIps)
+				svcIpMap := cont.getServiceIpMap(snatpolicy)
+				nodeSNATEntryFound := cont.checkIfPolicyApplied(nodename, name, cont.getServiceIps(snatpolicy))
 				if nodeSNATEntryFound {
 					cont.log.Debug("Allocation already done for nodename and snatpolicy", nodename, name)
 					continue
 				}
-				cont.log.Debug("Service Ips: ", snatIps)
-				for _, snatip := range snatIps {
-					snatIp, portrange, alloc := cont.getIpAndPortRange(nodename, snatpolicy, snatip)
+				cont.log.Debug("Service Ips: ", svcIpMap)
+				for ip, svcKey := range svcIpMap {
+					snatIp, portrange, alloc := cont.getIpAndPortRange(nodename, snatpolicy, ip)
 					cont.log.Infof("Handling nodeinfo for node %s and snatpolicy %s: ", nodename, name)
 					cont.log.Info("Allocated SNAT IP and Port Range: ", snatIp, portrange)
 					if !alloc {
@@ -415,7 +415,7 @@ func (cont *AciController) handleSnatNodeInfo(nodeinfo *nodeinfo.NodeInfo) bool 
 						markready[name] = true
 					}
 					cont.updateGlobalInfoforPolicy(portrange, snatIp, nodename,
-						nodeinfo.Spec.Macaddress, name)
+						nodeinfo.Spec.Macaddress, name, svcKey)
 					updated = true
 				}
 			}
@@ -514,7 +514,7 @@ func (cont *AciController) syncSnatGlobalInfo() bool {
 }
 
 func (cont *AciController) updateGlobalInfoforPolicy(portrange snatglobalinfo.PortRange,
-	snatIp, nodename, macaddr, plcyname string) {
+	snatIp, nodename, macaddr, plcyname, serviceKey string) {
 	portlist := []snatglobalinfo.PortRange{}
 	portlist = append(portlist, portrange)
 	ip := net.ParseIP(snatIp)
@@ -527,6 +527,7 @@ func (cont *AciController) updateGlobalInfoforPolicy(portrange snatglobalinfo.Po
 		SnatIp:         snatIp,
 		SnatIpUid:      snatIpUuid.String(),
 		SnatPolicyName: plcyname,
+		ServiceKey:     serviceKey,
 	}
 	if _, ok := cont.snatGlobalInfoCache[snatIp]; !ok {
 		cont.snatGlobalInfoCache[snatIp] = make(map[string]*snatglobalinfo.GlobalInfo)
@@ -650,17 +651,32 @@ func (cont *AciController) deleteNodeinfoFromGlInfoCache(snatPolicyNames map[str
 	return false
 }
 
-func (cont *AciController) getServiceIps(policy *ContSnatPolicy) (serviceIps []string) {
+// getServiceIps returns the external LB IPs for all services matching the policy's selector.
+func (cont *AciController) getServiceIps(policy *ContSnatPolicy) []string {
+	var result []string
 	services := cont.getServicesBySelector(labels.SelectorFromSet(policy.Selector.Labels),
 		policy.Selector.Namespace)
 	for _, service := range services {
-		var ips []string
 		for _, ip := range service.Status.LoadBalancer.Ingress {
-			ips = append(ips, ip.IP)
+			result = append(result, ip.IP)
 		}
-		serviceIps = append(serviceIps, ips...)
 	}
-	return serviceIps
+	return result
+}
+
+// getServiceIpMap returns a map of external LB IP → service key (namespace/name)
+// for all services matching the policy's selector.
+func (cont *AciController) getServiceIpMap(policy *ContSnatPolicy) map[string]string {
+	result := make(map[string]string)
+	services := cont.getServicesBySelector(labels.SelectorFromSet(policy.Selector.Labels),
+		policy.Selector.Namespace)
+	for _, service := range services {
+		svcKey := service.Namespace + "/" + service.Name
+		for _, ip := range service.Status.LoadBalancer.Ingress {
+			result[ip.IP] = svcKey
+		}
+	}
+	return result
 }
 
 func (cont *AciController) updateSnatIpandPorts(oldPolicyNames,

--- a/pkg/hostagent/integ_test.go
+++ b/pkg/hostagent/integ_test.go
@@ -923,8 +923,8 @@ func TestEPUpdateContainerId(t *testing.T) {
 	delVerify(0, 2)
 }
 
-func mkservice(namespace, name string, snatlabel map[string]string) *v1.Service {
-	return &v1.Service{
+func mkservice(namespace, name string, snatlabel map[string]string, lbIP ...string) *v1.Service {
+	svc := &v1.Service{
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeLoadBalancer,
 			Selector: map[string]string{
@@ -936,6 +936,41 @@ func mkservice(namespace, name string, snatlabel map[string]string) *v1.Service 
 			Name:        name,
 			Annotations: map[string]string{},
 			Labels:      snatlabel,
+		},
+	}
+	if len(lbIP) > 0 && lbIP[0] != "" {
+		svc.Status = v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{IP: lbIP[0]}},
+			},
+		}
+	}
+	return svc
+}
+
+// mkserviceForSnat creates a LoadBalancer service with a configurable pod
+// selector and optional LoadBalancer external IP, used for testing no-SnatIp
+// SNAT policies where the service's external IP drives pod SNAT assignment.
+func mkserviceForSnat(namespace, name string, svcSelector map[string]string, lbIP string) *v1.Service {
+	var lbIngress []v1.LoadBalancerIngress
+	if lbIP != "" {
+		lbIngress = []v1.LoadBalancerIngress{{IP: lbIP}}
+	}
+	return &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:     v1.ServiceTypeLoadBalancer,
+			Selector: svcSelector,
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: lbIngress,
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:   namespace,
+			Name:        name,
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
 		},
 	}
 }
@@ -975,7 +1010,10 @@ func TestSnatPolicyService(t *testing.T) {
 	snatlabel := map[string]string{
 		"app": "sample-app",
 	}
-	it.ta.fakeServiceSource.Add(mkservice("annNS", "testService", snatlabel))
+	// No-SnatIp policy: the controller derives the SNAT IP from the service's
+	// LB Ingress. Set snatGlobals[0].ip ("10.1.1.8") so test data matches the
+	// production flow where podBelongsToService uses the service's pod selector.
+	it.ta.fakeServiceSource.Add(mkservice("annNS", "testService", snatlabel, snatGlobals[0].ip))
 	podLabels := map[string]string{
 		"app":  "sample-app",
 		"tier": "sample-tier",
@@ -996,7 +1034,7 @@ func TestSnatPolicyService(t *testing.T) {
 	it.ta.fakeSnatGlobalSource.Delete(mkSnatGlobalObj())
 	var uids1 []string
 	it.checkEpSnatUids(6, uids1, emptyJSON)
-	it.ta.fakeServiceSource.Add(mkservice("annNS", "testService", snatlabel))
+	it.ta.fakeServiceSource.Add(mkservice("annNS", "testService", snatlabel, snatGlobals[0].ip))
 	time.Sleep(100 * time.Millisecond)
 	it.ta.fakeSnatGlobalSource.Add(mkSnatGlobalObj())
 	time.Sleep(100 * time.Millisecond)
@@ -1035,7 +1073,7 @@ func TestSnatPolicylabelUpdate(t *testing.T) {
 	it.cniAddParallel(6, 10)
 	it.ta.fakeDeploymentSource.Add(mkDeployment("annNS", "testDeployment", testEgAnnot4, sgAnnot2, qpAnnot1))
 	time.Sleep(10 * time.Millisecond)
-	it.ta.fakeServiceSource.Add(mkservice("annNS", "testService", map[string]string{"app": "sample-app"}))
+	it.ta.fakeServiceSource.Add(mkservice("annNS", "testService", map[string]string{"app": "sample-app"}, snatGlobals[0].ip))
 	podLabels := map[string]string{
 		"app":  "sample-app",
 		"tier": "sample-tier",
@@ -1058,4 +1096,175 @@ func TestSnatPolicylabelUpdate(t *testing.T) {
 	var uids1 []string
 	it.checkEpSnatUids(6, uids1, emptyJSON)
 	it.cniDelParallel(6, 10)
+}
+
+// TestSnatPolicyNamespaceMultiService verifies the fix for namespace-level
+// no-SnatIp SNAT policies with multiple LoadBalancer services.
+//
+// When a namespace contains two LB services (svc1 selecting app=lb1-ep with
+// external IP 10.3.0.4, svc2 selecting app=lb2-ep with external IP 10.3.0.5)
+// and a single namespace-scoped policy (no SnatIp, no labels), each pod must
+// egress with only the external IP of the service it is an endpoint of:
+//
+//   - pod-lb1 (app=lb1-ep, endpoint of svc1) → only uid-svc1 (10.3.0.4)
+//   - pod-lb2 (app=lb2-ep, endpoint of svc2) → only uid-svc2 (10.3.0.5)
+func TestSnatPolicyNamespaceMultiService(t *testing.T) {
+	ncf := cniNetConfig{Subnet: cnitypes.IPNet{IP: net.ParseIP("10.128.2.0"), Mask: net.CIDRMask(24, 32)}}
+	hcf := &HostAgentConfig{
+		NodeName:  "test-node",
+		EpRpcSock: "/tmp/aci-containers-ep-rpc.sock",
+		NetConfig: []cniNetConfig{ncf},
+		AciPrefix: "it",
+		GroupDefaults: GroupDefaults{
+			DefaultEg: metadata.OpflexGroup{
+				PolicySpace: "tenantA",
+				Name:        "defaultEPG",
+			},
+		},
+	}
+
+	it := SetupInteg(t, hcf)
+	it.setupNode(&itIpam, true)
+	defer it.tearDown()
+
+	it.ta.fakeNamespaceSource.Add(mkNamespace("lbns", testEgAnnot3, "", qpAnnot1))
+
+	it.testNS = "lbns"
+	it.cniAddParallel(11, 13)
+	time.Sleep(10 * time.Millisecond)
+
+	// pod11 is an endpoint of svc1 (IP 10.3.0.4); pod12 is an endpoint of svc2 (IP 10.3.0.5)
+	it.addPodObj(11, "lbns", "", "", map[string]string{"app": "lb1-ep"})
+	it.addPodObj(12, "lbns", "", "", map[string]string{"app": "lb2-ep"})
+
+	// Two LB services in the same namespace with different selectors and external IPs
+	svc1 := mkserviceForSnat("lbns", "svc1", map[string]string{"app": "lb1-ep"}, "10.3.0.4")
+	svc2 := mkserviceForSnat("lbns", "svc2", map[string]string{"app": "lb2-ep"}, "10.3.0.5")
+	it.ta.fakeServiceSource.Add(svc1)
+	it.ta.fakeServiceSource.Add(svc2)
+
+	// Namespace-level SNAT policy: no SnatIp, no labels, namespace only
+	snatNsPolicy := snatpolicydata("snat-ns", "lbns", []string{}, []string{}, map[string]string{})
+	snatNsPolicy.Spec.Selector.Namespace = "lbns"
+	it.ta.fakeSnatPolicySource.Add(snatNsPolicy)
+	time.Sleep(200 * time.Millisecond)
+
+	// Global info: controller allocates both service IPs under the same policy name
+	var globalInfos snatglobal.GlobalInfoList
+	pr1 := []snatglobal.PortRange{{Start: 5000, End: 6000}}
+	pr2 := []snatglobal.PortRange{{Start: 6001, End: 7000}}
+	globalInfos = append(globalInfos,
+		snatglobal.GlobalInfo{
+			MacAddress:     "aa:bb:cc:dd:ee:01",
+			SnatIp:         "10.3.0.4",
+			SnatIpUid:      "uid-svc1",
+			PortRanges:     pr1,
+			SnatPolicyName: "snat-ns",
+			ServiceKey:     "lbns/svc1",
+		},
+		snatglobal.GlobalInfo{
+			MacAddress:     "aa:bb:cc:dd:ee:02",
+			SnatIp:         "10.3.0.5",
+			SnatIpUid:      "uid-svc2",
+			PortRanges:     pr2,
+			SnatPolicyName: "snat-ns",
+			ServiceKey:     "lbns/svc2",
+		},
+	)
+	multiSvcGlobalObj := snatglobaldata("multi-svc-uid", "snatglobalinfo", "test-node", "lbns", globalInfos)
+	it.ta.fakeSnatGlobalSource.Add(multiSvcGlobalObj)
+	time.Sleep(200 * time.Millisecond)
+
+	// pod11 (endpoint of svc1 only) must receive only uid-svc1
+	it.checkEpSnatUids(11, []string{"uid-svc1"}, emptyJSON)
+	// pod12 (endpoint of svc2 only) must receive only uid-svc2
+	it.checkEpSnatUids(12, []string{"uid-svc2"}, emptyJSON)
+
+	it.cniDelParallel(11, 13)
+}
+
+// TestSnatPolicyExplicitSnatIpService verifies that an explicit-SnatIp SNAT
+// policy whose selector labels match a service correctly applies the SNAT to
+// the service's backend pods.
+//
+// Setup:
+//   - Service "svc-exp" in namespace "lbns" with selector {app: exp-ep} and
+//     metadata labels {app: exp-svc}
+//   - Pod with labels {app: exp-ep} (selected by the service)
+//   - Explicit-SnatIp policy with SnatIp=10.5.0.1 and selector labels
+//     {app: exp-svc} matching the service's metadata labels
+//   - GlobalInfo with the explicit SNAT IP and empty ServiceKey
+//
+// Expected: the backend pod gets the explicit SNAT UID.
+func TestSnatPolicyExplicitSnatIpService(t *testing.T) {
+	ncf := cniNetConfig{Subnet: cnitypes.IPNet{IP: net.ParseIP("10.128.2.0"), Mask: net.CIDRMask(24, 32)}}
+	hcf := &HostAgentConfig{
+		NodeName:  "test-node",
+		EpRpcSock: "/tmp/aci-containers-ep-rpc.sock",
+		NetConfig: []cniNetConfig{ncf},
+		AciPrefix: "it",
+		GroupDefaults: GroupDefaults{
+			DefaultEg: metadata.OpflexGroup{
+				PolicySpace: "tenantA",
+				Name:        "defaultEPG",
+			},
+		},
+	}
+
+	it := SetupInteg(t, hcf)
+	it.setupNode(&itIpam, true)
+	defer it.tearDown()
+
+	it.ta.fakeNamespaceSource.Add(mkNamespace("lbns", testEgAnnot3, "", qpAnnot1))
+
+	it.testNS = "lbns"
+	it.cniAddParallel(13, 15)
+	time.Sleep(10 * time.Millisecond)
+
+	// Pod is a backend of the service (service selects app=exp-ep)
+	it.addPodObj(13, "lbns", "", "", map[string]string{"app": "exp-ep"})
+
+	// Service metadata labels match the SNAT policy selector (app=exp-svc),
+	// service pod selector selects pods with app=exp-ep
+	svc := &v1.Service{
+		Spec: v1.ServiceSpec{
+			Type:     v1.ServiceTypeLoadBalancer,
+			Selector: map[string]string{"app": "exp-ep"},
+		},
+		Status: v1.ServiceStatus{
+			LoadBalancer: v1.LoadBalancerStatus{
+				Ingress: []v1.LoadBalancerIngress{{IP: "10.5.0.1"}},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "lbns",
+			Name:      "svc-exp",
+			Labels:    map[string]string{"app": "exp-svc"},
+		},
+	}
+	it.ta.fakeServiceSource.Add(svc)
+
+	// Explicit-SnatIp policy: selector labels match service metadata labels
+	snatPolicy := snatpolicydata("snat-exp", "lbns",
+		[]string{"10.5.0.1"}, []string{}, map[string]string{"app": "exp-svc"})
+	it.ta.fakeSnatPolicySource.Add(snatPolicy)
+	time.Sleep(200 * time.Millisecond)
+
+	// GlobalInfo: explicit SNAT IP with empty ServiceKey (no per-service filtering)
+	var globalInfos snatglobal.GlobalInfoList
+	globalInfos = append(globalInfos, snatglobal.GlobalInfo{
+		MacAddress:     "aa:bb:cc:dd:ee:03",
+		SnatIp:         "10.5.0.1",
+		SnatIpUid:      "uid-snat-exp",
+		PortRanges:     []snatglobal.PortRange{{Start: 8000, End: 9000}},
+		SnatPolicyName: "snat-exp",
+	})
+	globalObj := snatglobaldata("exp-svc-uid", "snatglobalinfo", "test-node", "lbns", globalInfos)
+	it.ta.fakeSnatGlobalSource.Add(globalObj)
+	time.Sleep(200 * time.Millisecond)
+
+	// Backend pod must receive the explicit SNAT UID
+	it.checkEpSnatUids(13, []string{"uid-snat-exp"}, emptyJSON)
+
+	it.cniDelParallel(13, 15)
 }

--- a/pkg/hostagent/snats.go
+++ b/pkg/hostagent/snats.go
@@ -93,6 +93,7 @@ type opflexSnatGlobalInfo struct {
 	PortRange      []OpflexPortRange
 	SnatIpUid      string
 	SnatPolicyName string
+	ServiceKey     string
 }
 
 type opflexSnatLocalInfo struct {
@@ -381,11 +382,12 @@ func (agent *HostAgent) handleSnatUpdate(policy *snatpolicy.SnatPolicy) {
 			})
 		uids[NAMESPACE] = poduids
 	default:
-		poduids, deppoduids, nspoduids :=
+		poduids, deppoduids, nspoduids, svcpoduids :=
 			agent.getPodUidsMatchingLabel(policy.Spec.Selector.Namespace, policy.Spec.Selector.Labels, policy.ObjectMeta.Name)
 		uids[POD] = poduids
 		uids[DEPLOYMENT] = deppoduids
 		uids[NAMESPACE] = nspoduids
+		uids[SERVICE] = svcpoduids
 	}
 	succeededPodUids := agent.getPodUidsSucceeded()
 	for res, poduids := range uids {
@@ -433,7 +435,7 @@ func (agent *HostAgent) updateSnatPolicyLabels(obj interface{}, policyname strin
 
 // Get all the pods matching the Policy Selector
 func (agent *HostAgent) getPodUidsMatchingLabel(namespace string, label map[string]string, policyname string) (poduids []string,
-	deppoduids []string, nspoduids []string) {
+	deppoduids []string, nspoduids []string, svcpoduids []string) {
 	selector := labels.SelectorFromSet(label)
 	cache.ListAll(agent.podInformer.GetIndexer(), selector,
 		func(podobj interface{}) {
@@ -449,6 +451,10 @@ func (agent *HostAgent) getPodUidsMatchingLabel(namespace string, label map[stri
 	cache.ListAll(agent.nsInformer.GetIndexer(), selector,
 		func(nsobj interface{}) {
 			nspoduids = append(nspoduids, agent.updateSnatPolicyLabels(nsobj, policyname)...)
+		})
+	cache.ListAllByNamespace(agent.serviceInformer.GetIndexer(), namespace, selector,
+		func(servobj interface{}) {
+			svcpoduids = append(svcpoduids, agent.updateSnatPolicyLabels(servobj, policyname)...)
 		})
 	return
 }
@@ -654,6 +660,7 @@ func (agent *HostAgent) snaGlobalInfoChanged(snatobj interface{}, logger *logrus
 				PortRange:      portrange,
 				SnatIpUid:      v.SnatIpUid,
 				SnatPolicyName: v.SnatPolicyName,
+				ServiceKey:     v.ServiceKey,
 			}
 			newglobalinfos = append(newglobalinfos, nodeInfo)
 		}
@@ -957,9 +964,17 @@ func (agent *HostAgent) updateEpFiles(poduids []string) {
 		var uids []string
 		for _, name := range policystack {
 			for _, val := range agent.opflexSnatGlobalInfos[agent.config.NodeName] {
-				if val.SnatPolicyName == name {
-					uids = append(uids, val.SnatIpUid)
+				if val.SnatPolicyName != name {
+					continue
 				}
+				// For no-SnatIp (service-based) policies, use the ServiceKey set
+				// by the controller to verify this pod belongs to that service.
+				if val.ServiceKey != "" {
+					if !agent.podBelongsToService(uid, val.ServiceKey) {
+						continue
+					}
+				}
+				uids = append(uids, val.SnatIpUid)
 			}
 			if len(agent.snatPolicyCache[name].Spec.DestIp) == 0 {
 				break
@@ -976,6 +991,30 @@ func (agent *HostAgent) updateEpFiles(poduids []string) {
 		agent.scheduleSyncEps()
 	}
 	agent.scheduleSyncLocalInfo()
+}
+
+// podBelongsToService checks whether the pod identified by podUID is selected
+// by the service identified by serviceKey (namespace/name).
+func (agent *HostAgent) podBelongsToService(podUID, serviceKey string) bool {
+	svcObj, exists, err := agent.serviceInformer.GetIndexer().GetByKey(serviceKey)
+	if err != nil || !exists {
+		return false
+	}
+	svc := svcObj.(*v1.Service)
+	if svc.Spec.Selector == nil {
+		return false
+	}
+	svcSelector := labels.SelectorFromSet(labels.Set(svc.Spec.Selector))
+	podKey, ok := agent.podUidToName[podUID]
+	if !ok {
+		return false
+	}
+	podObj, exists, err := agent.podInformer.GetIndexer().GetByKey(podKey)
+	if err != nil || !exists {
+		return false
+	}
+	pod := podObj.(*v1.Pod)
+	return svcSelector.Matches(labels.Set(pod.Labels))
 }
 
 func (agent *HostAgent) compare(plcy1, plcy2 string) bool {
@@ -1000,23 +1039,28 @@ func (agent *HostAgent) compare(plcy1, plcy2 string) bool {
 	return sort
 }
 
-func (agent *HostAgent) getMatchingServices(namespace string, label map[string]string) []*v1.Service {
-	var services, matchingServices []*v1.Service
-	cache.ListAllByNamespace(agent.serviceInformer.GetIndexer(), namespace, labels.Everything(),
+// hasMatchingService returns true if any service in the namespace has metadata
+// labels matching policyLabels (the SNAT policy's selector) AND a pod selector
+// that matches podLabels (the labels on the pod/deployment being evaluated).
+// ie, if the pod is an endpoint of any service that matches the SNAT policy selector.
+func (agent *HostAgent) hasMatchingService(namespace string, podLabels map[string]string, policyLabels map[string]string) bool {
+	found := false
+	selector := labels.SelectorFromSet(labels.Set(policyLabels))
+	cache.ListAllByNamespace(agent.serviceInformer.GetIndexer(), namespace, selector,
 		func(servobj interface{}) {
-			services = append(services, servobj.(*v1.Service))
+			if found {
+				return
+			}
+			service := servobj.(*v1.Service)
+			if service.Spec.Selector != nil {
+				svcSelector := labels.SelectorFromSet(service.Spec.Selector)
+				if svcSelector.Matches(labels.Set(podLabels)) {
+					agent.log.Debug("Found matching service ", service.Namespace, "/", service.Name)
+					found = true
+				}
+			}
 		})
-	for _, service := range services {
-		if service.Spec.Selector == nil {
-			continue
-		}
-		svcSelector := labels.SelectorFromSet(service.Spec.Selector)
-		if svcSelector.Matches(labels.Set(label)) {
-			matchingServices = append(matchingServices, service)
-		}
-	}
-
-	return matchingServices
+	return found
 }
 
 // Must acquire snatPolicyCacheMutex.RLock
@@ -1041,16 +1085,18 @@ func (agent *HostAgent) getMatchingSnatPolicy(obj interface{}) (snatPolicyNames 
 				append(snatPolicyNames[item.ObjectMeta.Name], CLUSTER)
 		} else if len(item.Spec.Selector.Labels) == 0 &&
 			item.Spec.Selector.Namespace == namespace { // check policy matches namespace
-			if res == SERVICE {
-				if len(item.Spec.SnatIp) == 0 {
+			if len(item.Spec.SnatIp) == 0 {
+				// Namespace-scoped no-SnatIp policy: mark as SERVICE if the
+				// object is a service itself, or if the pod is selected by
+				// any service in the namespace.
+				if res == SERVICE || (res == POD &&
+					agent.hasMatchingService(namespace, label, item.Spec.Selector.Labels)) {
 					snatPolicyNames[item.ObjectMeta.Name] =
 						append(snatPolicyNames[item.ObjectMeta.Name], SERVICE)
 				}
-			} else {
-				if len(item.Spec.SnatIp) > 0 {
-					snatPolicyNames[item.ObjectMeta.Name] =
-						append(snatPolicyNames[item.ObjectMeta.Name], NAMESPACE)
-				}
+			} else if len(item.Spec.SnatIp) > 0 {
+				snatPolicyNames[item.ObjectMeta.Name] =
+					append(snatPolicyNames[item.ObjectMeta.Name], NAMESPACE)
 			}
 		} else { //Check Policy matches the labels on the Object
 			if (item.Spec.Selector.Namespace != "" &&
@@ -1062,18 +1108,11 @@ func (agent *HostAgent) getMatchingSnatPolicy(obj interface{}) (snatPolicyNames 
 						append(snatPolicyNames[item.ObjectMeta.Name], res)
 				}
 				if res == POD {
-					if len(item.Spec.SnatIp) == 0 {
-						matchingServices := agent.getMatchingServices(namespace, label)
-						agent.log.Debug("Matching services for pod ", name, " : ", matchingServices)
-						for _, matchingSvc := range matchingServices {
-							if util.MatchLabels(item.Spec.Selector.Labels,
-								matchingSvc.ObjectMeta.Labels) {
-								snatPolicyNames[item.ObjectMeta.Name] =
-									append(snatPolicyNames[item.ObjectMeta.Name], SERVICE)
-								break
-							}
-						}
-					} else {
+					if agent.hasMatchingService(namespace, label, item.Spec.Selector.Labels) {
+						snatPolicyNames[item.ObjectMeta.Name] =
+							append(snatPolicyNames[item.ObjectMeta.Name], SERVICE)
+					}
+					if len(item.Spec.SnatIp) > 0 {
 						podKey, _ := cache.MetaNamespaceKeyFunc(obj)
 						for _, dpkey := range agent.depPods.GetObjForPod(podKey) {
 							depobj, exists, err :=
@@ -1109,18 +1148,7 @@ func (agent *HostAgent) getMatchingSnatPolicy(obj interface{}) (snatPolicyNames 
 						// check for namespace match
 					}
 				} else if res == DEPLOYMENT {
-					if len(item.Spec.SnatIp) == 0 {
-						matchingServices := agent.getMatchingServices(namespace, label)
-						agent.log.Debug("Matching services for deployment ", name, " : ", matchingServices)
-						for _, matchingSvc := range matchingServices {
-							if util.MatchLabels(item.Spec.Selector.Labels,
-								matchingSvc.ObjectMeta.Labels) {
-								snatPolicyNames[item.ObjectMeta.Name] =
-									append(snatPolicyNames[item.ObjectMeta.Name], SERVICE)
-								break
-							}
-						}
-					} else {
+					if len(item.Spec.SnatIp) > 0 {
 						nsobj, exists, err := agent.nsInformer.GetStore().GetByKey(namespace)
 						if err != nil {
 							agent.log.Error("Could not lookup snat for " +
@@ -1385,6 +1413,7 @@ func setDestIp(destIp []string) {
 	}
 }
 
+// most specific to least specific order.
 func compareIps(ipa, ipb string) bool {
 	ipB, ipnetB, _ := net.ParseCIDR(ipb)
 	_, ipnetA, _ := net.ParseCIDR(ipa)

--- a/pkg/snatglobalinfo/apis/aci.snat/v1/types.go
+++ b/pkg/snatglobalinfo/apis/aci.snat/v1/types.go
@@ -47,6 +47,7 @@ type GlobalInfo struct {
 	SnatIp         string      `json:"snatIp"`
 	SnatIpUid      string      `json:"snatIpUid"`
 	SnatPolicyName string      `json:"snatPolicyName"`
+	ServiceKey     string      `json:"serviceKey,omitempty"`
 }
 
 // +k8s:openapi-gen=true


### PR DESCRIPTION
Two bugs are fixed:

1. Namespace-level no-SnatIp SNAT policies with multiple LoadBalancer
   services incorrectly assigned all LB external IPs to all pods.
   The controller now tags each global info entry with the originating
   service key. The hostagent filters SNAT UIDs per-pod by checking
   service endpoint membership, ensuring each pod only egresses with
   the external IP of the service it belongs to.

2. After hostagent pod restarts, namespace-level no-SnatIp policies
   lost their service SNAT entries because pod events did not evaluate
   service membership for the namespace-scoped policy path. The
   namespace-scoped branch now checks for matching services when
   processing pod events, consistent with the label-scoped path.

Additionally, two  inconsistencies are corrected:

1. The deployment path for no-SnatIp policies incorrectly matched
deployment metadata labels against service pod selectors. Since
services select pods (not deployments), and pod template changes
produce new pod events handled separately, this check was both
inaccurate and redundant. It is removed.

2. Explicit-SnatIp policies matching services now consistently apply the
specified SNAT IP to the service's backend pods across all policy
evaluation paths