### PR TITLE
Fix over-permissive named port resolution in NetworkPolicy

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -344,13 +344,44 @@ type ipIndexEntry struct {
 
 type targetPort struct {
 	proto v1.Protocol
-	ports map[int]bool
+	// portServiceMap maps a resolved numeric port number to the set of
+	// service keys whose endpoints resolve the named port to that number.
+	// eg.: {80: {"default/svc1": true, "default/svc2": true}, 8080: {"default/svc3": true}}
+	portServiceMap map[int]map[string]bool
 }
 
+// portIndexEntry is an entry in the targetPortIndex, keyed by a port
+// specification string (e.g. "tcp-name-http" or "tcp-num-80"). It tracks
+// which services have resolved endpoints to specific numeric ports for
+// this port spec, and which network policies reference it.
 type portIndexEntry struct {
-	port              targetPort
-	serviceKeys       map[string]bool
+	portMapping       targetPort
 	networkPolicyKeys map[string]bool
+}
+
+// hasServiceKeys returns true if any per-port inner map contains
+// at least one service key.
+func (e *portIndexEntry) hasServiceKeys() bool {
+	for _, svcKeys := range e.portMapping.portServiceMap {
+		if len(svcKeys) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+// removeServiceKey removes a service key from all per-port inner
+// maps. If an inner map becomes empty it is set to nil so the port
+// number itself is preserved (it may still be needed by NP tracking).
+func (e *portIndexEntry) removeServiceKey(key string) {
+	for p, svcKeys := range e.portMapping.portServiceMap {
+		if svcKeys != nil {
+			delete(svcKeys, key)
+			if len(svcKeys) == 0 {
+				e.portMapping.portServiceMap[p] = nil
+			}
+		}
+	}
 }
 
 type namedPortServiceIndexPort struct {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -297,10 +297,11 @@ type globalVlanConfig struct {
 }
 
 type hppReference struct {
-	RefCount uint              `json:"ref-count,omitempty"`
-	Npkeys   []string          `json:"npkeys,omitempty"`
-	HppObj   apicapi.ApicSlice `json:"hpp-obj,omitempty"`
-	HppCr    hppv1.HostprotPol `json:"hpp-cr,omitempty"`
+	RefCount       uint                       `json:"ref-count,omitempty"`
+	Npkeys         []string                   `json:"npkeys,omitempty"`
+	HppObj         apicapi.ApicSlice          `json:"hpp-obj,omitempty"`
+	HppCr          hppv1.HostprotPol          `json:"hpp-cr,omitempty"`
+	NpIngressRules map[string]map[string]bool `json:"-"` // npKey → set of ingress rule names
 }
 
 type DelayedEpSlice struct {

--- a/pkg/controller/environment.go
+++ b/pkg/controller/environment.go
@@ -286,6 +286,10 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 	cont.indexMutex.Unlock()
 	cont.nodeFullSync()
 	cont.log.Info("Node/namespace cache sync successful")
+	go cont.podInformer.Run(stopCh)
+	cont.log.Debug("Waiting for pod cache sync")
+	cache.WaitForCacheSync(stopCh, cont.podInformer.HasSynced)
+	cont.log.Info("Pod cache sync successful")
 	if !cont.isCNOEnabled() {
 		cont.serviceEndPoints.Run(stopCh)
 		go cont.serviceInformer.Run(stopCh)
@@ -305,7 +309,6 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 	}
 	go cont.replicaSetInformer.Run(stopCh)
 	go cont.deploymentInformer.Run(stopCh)
-	go cont.podInformer.Run(stopCh)
 	if !cont.isCNOEnabled() {
 		go cont.snatInformer.Run(stopCh)
 		go cont.processQueue(cont.snatQueue, cont.snatIndexer,
@@ -406,10 +409,8 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) error {
 	go cont.crdInformer.Run(stopCh)
 
 	cache.WaitForCacheSync(stopCh,
-		cont.namespaceInformer.HasSynced,
 		cont.replicaSetInformer.HasSynced,
-		cont.deploymentInformer.HasSynced,
-		cont.podInformer.HasSynced)
+		cont.deploymentInformer.HasSynced)
 
 	if !cont.isCNOEnabled() && !cont.config.DisableHppRendering {
 		cache.WaitForCacheSync(stopCh, cont.networkPolicyInformer.HasSynced)

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -1483,28 +1483,50 @@ func (cont *AciController) buildNetPolSubjRules(ruleName string,
 			// Port-scoped: only pod IPs that define the named port.
 			addPodSubnet = false
 		}
+		// In HPP-opt mode the HPP is shared across sibling NPs with the same
+		// spec hash. Using np.Name in rule names would cause gratuitous renames
+		// whenever a different sibling triggers the rebuild. Use proto-port
+		// instead to keep names stable and unique per port entry.
+		entryName := np.Name
+		if cont.config.HppOptimization {
+			if entry.proto != "" {
+				entryName = protoPortKey(entry.proto, entry.fromPort)
+			} else {
+				entryName = "unspecified"
+			}
+		}
 
 		if entry.proto == "" && entry.fromPort == "" {
 			if hasV4 {
-				policyRuleName := util.AciNameForKey(ruleName+"-ipv4", "", np.Name)
+				policyRuleName := util.AciNameForKey(ruleName+"-ipv4", "", entryName)
 				cont.buildNetPolSubjRule(subj, policyRuleName, direction,
 					"ipv4", "", "", "", entry.ips, addPodSubnet)
 			}
 			if hasV6 {
-				policyRuleName := util.AciNameForKey(ruleName+"-ipv6", "", np.Name)
+				policyRuleName := util.AciNameForKey(ruleName+"-ipv6", "", entryName)
 				cont.buildNetPolSubjRule(subj, policyRuleName, direction,
 					"ipv6", "", "", "", entry.ips, addPodSubnet)
 			}
 		} else {
 			if hasV4 {
-				prefix := fmt.Sprintf("%s_%d-ipv4", ruleName, ruleCounter)
-				policyRuleName := util.AciNameForKey(prefix, "", np.Name)
+				var prefix string
+				if cont.config.HppOptimization {
+					prefix = ruleName + "-ipv4"
+				} else {
+					prefix = fmt.Sprintf("%s_%d-ipv4", ruleName, ruleCounter)
+				}
+				policyRuleName := util.AciNameForKey(prefix, "", entryName)
 				cont.buildNetPolSubjRule(subj, policyRuleName, direction,
 					"ipv4", entry.proto, entry.fromPort, entry.toPort, entry.ips, addPodSubnet)
 			}
 			if hasV6 {
-				prefix := fmt.Sprintf("%s_%d-ipv6", ruleName, ruleCounter)
-				policyRuleName := util.AciNameForKey(prefix, "", np.Name)
+				var prefix string
+				if cont.config.HppOptimization {
+					prefix = ruleName + "-ipv6"
+				} else {
+					prefix = fmt.Sprintf("%s_%d-ipv6", ruleName, ruleCounter)
+				}
+				policyRuleName := util.AciNameForKey(prefix, "", entryName)
 				cont.buildNetPolSubjRule(subj, policyRuleName, direction,
 					"ipv6", entry.proto, entry.fromPort, entry.toPort, entry.ips, addPodSubnet)
 			}
@@ -1515,7 +1537,7 @@ func (cont *AciController) buildNetPolSubjRules(ruleName string,
 
 func (cont *AciController) buildLocalNetPolSubjRules(ruleName string,
 	subj *hppv1.HostprotSubj, direction string,
-	resolved *resolvedPeerPorts, np *v1net.NetworkPolicy) {
+	resolved *resolvedPeerPorts) {
 	hasV4 := !cont.configuredPodNetworkIps.V4.Empty()
 	hasV6 := !cont.configuredPodNetworkIps.V6.Empty()
 	ruleCounter := 0
@@ -1526,28 +1548,35 @@ func (cont *AciController) buildLocalNetPolSubjRules(ruleName string,
 			// Port-scoped: IPBlock CIDRs excluded for named ports.
 			peerIpBlock = nil
 		}
+		// HPP-Direct always shares the HPP CRD across sibling NPs
+		// (spec-hash based key). Use proto-port in rule names to
+		// keep names stable and unique per port entry.
+		entryName := "unspecified"
+		if entry.proto != "" {
+			entryName = protoPortKey(entry.proto, entry.fromPort)
+		}
 
 		if entry.proto == "" && entry.fromPort == "" {
 			if hasV4 {
-				policyRuleName := util.AciNameForKey(ruleName+"-ipv4", "", np.Name)
+				policyRuleName := util.AciNameForKey(ruleName+"-ipv4", "", entryName)
 				cont.buildLocalNetPolSubjRule(subj, policyRuleName, direction,
 					"ipv4", "", "", "", peerNsList, resolved.podSelectors, peerIpBlock)
 			}
 			if hasV6 {
-				policyRuleName := util.AciNameForKey(ruleName+"-ipv6", "", np.Name)
+				policyRuleName := util.AciNameForKey(ruleName+"-ipv6", "", entryName)
 				cont.buildLocalNetPolSubjRule(subj, policyRuleName, direction,
 					"ipv6", "", "", "", peerNsList, resolved.podSelectors, peerIpBlock)
 			}
 		} else {
 			if hasV4 {
-				prefix := fmt.Sprintf("%s_%d-ipv4", ruleName, ruleCounter)
-				policyRuleName := util.AciNameForKey(prefix, "", np.Name)
+				prefix := ruleName + "-ipv4"
+				policyRuleName := util.AciNameForKey(prefix, "", entryName)
 				cont.buildLocalNetPolSubjRule(subj, policyRuleName, direction,
 					"ipv4", entry.proto, entry.fromPort, entry.toPort, peerNsList, resolved.podSelectors, peerIpBlock)
 			}
 			if hasV6 {
-				prefix := fmt.Sprintf("%s_%d-ipv6", ruleName, ruleCounter)
-				policyRuleName := util.AciNameForKey(prefix, "", np.Name)
+				prefix := ruleName + "-ipv6"
+				policyRuleName := util.AciNameForKey(prefix, "", entryName)
 				cont.buildLocalNetPolSubjRule(subj, policyRuleName, direction,
 					"ipv6", entry.proto, entry.fromPort, entry.toPort, peerNsList, resolved.podSelectors, peerIpBlock)
 			}
@@ -2398,6 +2427,8 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 		}
 		hpp := apicapi.NewHostprotPol(cont.config.AciPolicyTenant, labelKey)
 
+		var hasNamedPorts bool
+
 		// Generate ingress policies
 		if np.Spec.PolicyTypes == nil || ptypeset[v1net.PolicyTypeIngress] {
 			subjIngress :=
@@ -2407,6 +2438,27 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 				resolved := cont.resolveNetPolPeersAndPorts("ingress",
 					ingress.From, ingress.Ports, peerPods, peerNs, np, logger)
 				cont.buildNetPolSubjRules(strconv.Itoa(i), subjIngress, "ingress", resolved, np)
+				if resolved.hasNamedPort {
+					hasNamedPorts = true
+				}
+			}
+
+			// Merge sibling NPs' named port resolutions into this subject.
+			// Rule names encode the ingress-rule index + proto-port so siblings
+			// produce identically-named rules. Cache full rule names and pull
+			// missing ones from the previously-written HPP object.
+			if cont.config.HppOptimization && hasNamedPorts {
+				ruleNames := make(map[string]bool)
+				for _, body := range subjIngress {
+					for _, rule := range body.Children {
+						name := rule.GetAttrStr("name")
+						if name != "" {
+							ruleNames[name] = true
+						}
+					}
+				}
+				cont.cacheNpIngressRules(labelKey, key, ruleNames)
+				cont.mergeHppIngressRules(labelKey, key, ruleNames, subjIngress)
 			}
 			hpp.AddChild(subjIngress)
 		}
@@ -2484,6 +2536,8 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 			}
 		}
 
+		var hasNamedPorts bool
+
 		// Generate ingress policies
 		if np.Spec.PolicyTypes == nil || ptypeset[v1net.PolicyTypeIngress] {
 			subjIngress := &hppv1.HostprotSubj{
@@ -2494,14 +2548,30 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 			for i, ingress := range np.Spec.Ingress {
 				resolved := cont.resolveNetPolPeersAndPorts("ingress",
 					ingress.From, ingress.Ports, peerPods, peerNs, np, logger)
+				if resolved.hasNamedPort {
+					hasNamedPorts = true
+				}
 				if isAllowAllForAllNamespaces(ingress.From) {
 					if !slices.Contains(resolved.peerNsList, "nodeips") {
 						resolved.peerNsList = append(resolved.peerNsList, "nodeips")
 					}
 				}
 				if !(!resolved.noPeers && len(resolved.subnetMap) == 0) {
-					cont.buildLocalNetPolSubjRules(strconv.Itoa(i), subjIngress, "ingress", resolved, np)
+					cont.buildLocalNetPolSubjRules(strconv.Itoa(i), subjIngress, "ingress", resolved)
 				}
+			}
+
+			// Merge sibling NPs' named port resolutions into this subject.
+			// Cache full rule names and pull missing ones from the HPP CR.
+			if hasNamedPorts {
+				ruleNames := make(map[string]bool)
+				for _, rule := range subjIngress.HostprotRule {
+					if rule.Name != "" {
+						ruleNames[rule.Name] = true
+					}
+				}
+				cont.cacheNpIngressRules(labelKey, key, ruleNames)
+				cont.mergeHppDirectIngressRules(labelKey, key, ruleNames, subjIngress)
 			}
 			hpp.Spec.HostprotSubj = append(hpp.Spec.HostprotSubj, *subjIngress)
 		}
@@ -2523,7 +2593,7 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 					}
 				}
 				if !(!resolved.noPeers && len(resolved.subnetMap) == 0) {
-					cont.buildLocalNetPolSubjRules(strconv.Itoa(i), subjEgress, "egress", resolved, np)
+					cont.buildLocalNetPolSubjRules(strconv.Itoa(i), subjEgress, "egress", resolved)
 				}
 
 				subnetMap := resolved.subnetMap
@@ -2610,6 +2680,122 @@ func (cont *AciController) updateNsRemoteIpCont(pod *v1.Pod, deleted bool) bool 
 	return true
 }
 
+// mergeHppIngressRules merges missing ingress rules from sibling NPs into
+// the current subject. It compares full rule names (which encode the ingress
+// rule index + proto-port) to avoid false positives from overlapping ports
+// in different ingress rules. Rules present in the HPP object but missing
+// from the current NP are added if claimed by a sibling's cached rule names.
+func (cont *AciController) mergeHppIngressRules(labelKey, key string,
+	ruleNames map[string]bool, subjIngress apicapi.ApicObject) {
+	cont.indexMutex.Lock()
+	defer cont.indexMutex.Unlock()
+
+	hppRef, ok := cont.hppRef[labelKey]
+	if !ok {
+		return
+	}
+
+	// Collect all rule names claimed by siblings but not in current NP.
+	siblingNames := make(map[string]bool)
+	for _, npKey := range hppRef.Npkeys {
+		if npKey == key {
+			continue
+		}
+		for name := range hppRef.NpIngressRules[npKey] {
+			if !ruleNames[name] {
+				siblingNames[name] = true
+			}
+		}
+	}
+	if len(siblingNames) == 0 {
+		return
+	}
+
+	// Find rules in the HPP object whose names are claimed by siblings.
+	for _, hppObj := range hppRef.HppObj {
+		hppBody, ok := hppObj["hostprotPol"]
+		if !ok || hppBody == nil {
+			continue
+		}
+		for _, child := range hppBody.Children {
+			subj, ok := child["hostprotSubj"]
+			if !ok || subj == nil || subj.Attributes["name"] != "networkpolicy-ingress" {
+				continue
+			}
+			for _, ruleChild := range subj.Children {
+				rule, ok := ruleChild["hostprotRule"]
+				if !ok || rule == nil {
+					continue
+				}
+				name, _ := rule.Attributes["name"].(string)
+				if siblingNames[name] {
+					subjIngress.AddChild(ruleChild)
+					delete(siblingNames, name)
+				}
+			}
+		}
+	}
+}
+
+// mergeHppDirectIngressRules merges missing ingress rules from sibling NPs
+// into the current HPP-Direct subject. Same approach as mergeHppIngressRules
+// but operates on the HPP CR struct instead of the APIC object tree.
+func (cont *AciController) mergeHppDirectIngressRules(labelKey, key string,
+	ruleNames map[string]bool, subjIngress *hppv1.HostprotSubj) {
+	cont.indexMutex.Lock()
+	defer cont.indexMutex.Unlock()
+
+	hppRef, ok := cont.hppRef[labelKey]
+	if !ok {
+		return
+	}
+
+	// Collect all rule names claimed by siblings but not in current NP.
+	siblingNames := make(map[string]bool)
+	for _, npKey := range hppRef.Npkeys {
+		if npKey == key {
+			continue
+		}
+		for name := range hppRef.NpIngressRules[npKey] {
+			if !ruleNames[name] {
+				siblingNames[name] = true
+			}
+		}
+	}
+	if len(siblingNames) == 0 {
+		return
+	}
+
+	// Find rules in the HPP CR whose names are claimed by siblings.
+	for i := range hppRef.HppCr.Spec.HostprotSubj {
+		subj := &hppRef.HppCr.Spec.HostprotSubj[i]
+		if subj.Name != "networkpolicy-ingress" {
+			continue
+		}
+		for _, rule := range subj.HostprotRule {
+			if siblingNames[rule.Name] {
+				subjIngress.HostprotRule = append(subjIngress.HostprotRule, rule)
+				delete(siblingNames, rule.Name)
+			}
+		}
+	}
+}
+
+// cacheNpIngressRules caches the set of ingress rule names produced by a
+// single NP within a shared HPP. Sibling NPs use these names to identify
+// which rules in the HPP object belong to which NP and should be preserved.
+func (cont *AciController) cacheNpIngressRules(labelKey, npKey string, names map[string]bool) {
+	cont.indexMutex.Lock()
+	defer cont.indexMutex.Unlock()
+
+	hppRef := cont.hppRef[labelKey]
+	if hppRef.NpIngressRules == nil {
+		hppRef.NpIngressRules = make(map[string]map[string]bool)
+	}
+	hppRef.NpIngressRules[npKey] = names
+	cont.hppRef[labelKey] = hppRef
+}
+
 func (cont *AciController) addToHppCache(labelKey, key string, hpp apicapi.ApicSlice, hppcr *hppv1.HostprotPol) {
 	cont.indexMutex.Lock()
 	hppRef, ok := cont.hppRef[labelKey]
@@ -2659,8 +2845,15 @@ func (cont *AciController) removeFromHppCache(np *v1net.NetworkPolicy, key strin
 				break
 			}
 		}
+		_, hadRuleCache := hppRef.NpIngressRules[key]
+		delete(hppRef.NpIngressRules, key)
 		if hppRef.RefCount > 0 {
 			cont.hppRef[labelKey] = hppRef
+			// Requeue one sibling so the HPP is rewritten without
+			// the departed NP's cached ingress rules.
+			if hadRuleCache {
+				cont.queueNetPolUpdateByKey(hppRef.Npkeys[0])
+			}
 		} else {
 			delete(cont.hppRef, labelKey)
 			noRef = true
@@ -2722,7 +2915,10 @@ func (cont *AciController) networkPolicyChanged(oldobj interface{},
 
 	if cont.config.HppOptimization || cont.config.EnableHppDirect {
 		if !reflect.DeepEqual(oldnp.Spec, newnp.Spec) {
-			cont.removeFromHppCache(oldnp, npkey)
+			labelKey, noHppRef := cont.removeFromHppCache(oldnp, npkey)
+			if noHppRef && labelKey != "" {
+				cont.apicConn.ClearApicObjects(labelKey)
+			}
 		}
 	}
 
@@ -2774,8 +2970,7 @@ func (cont *AciController) networkPolicyDeleted(obj interface{}) {
 		}
 		np, ok = deletedState.Obj.(*v1net.NetworkPolicy)
 		if !ok {
-			networkPolicyLogger(cont.log, np).
-				Error("DeletedFinalStateUnknown contained non-Networkpolicy object: ", deletedState.Obj)
+			cont.log.Error("DeletedFinalStateUnknown contained non-Networkpolicy object: ", deletedState.Obj)
 			return
 		}
 	}

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -917,9 +917,46 @@ func (cont *AciController) updateIpIndexEntry(index cidranger.Ranger,
 	}
 }
 
-type portRange struct {
+// resolvedPeerPorts holds the fully-resolved peer+port data for one NP
+// ingress/egress rule. Peer IP resolution and named port resolution are
+// performed together so that each resolvedPortEntry carries the exact set of
+// remote IPs to which the port applies.
+type resolvedPeerPorts struct {
+	// entries is the list of port-scoped IP groups. Each entry becomes one
+	// or more APIC/HPP rules (split by ethertype).
+	entries []resolvedPortEntry
+
+	// subnetMap is the set of all matched peer IPs + IPBlock subnets.
+	subnetMap map[string]bool
+	// ipBlockSubs is the sorted list of IPBlock-derived subnets only.
+	ipBlockSubs []string
+
+	// HPP-Direct metadata
+	peerNsList   []string
+	podSelectors []*metav1.LabelSelector
+
+	// noPeers is true when there are no peer selectors (egress no-To / ingress no-From).
+	noPeers bool
+	// addPodSubnetAsRemIp is true when the rule allows all namespaces.
+	addPodSubnetAsRemIp bool
+	// hasNamedPort is true when the rule contains at least one named port.
+	hasNamedPort bool
+}
+
+// resolvedPortEntry is a single port (or port range) with its associated remote IPs.
+type resolvedPortEntry struct {
+	proto    string
 	fromPort string
 	toPort   string
+	// ips contains the remote IPs for this entry. For non-port-scoped entries
+	// this is the full set of matched peer IPs (pod IPs + IPBlock CIDRs). For
+	// port-scoped entries (portScoped=true) this is the subset of pod IPs that
+	// define the named port at a specific number.
+	ips []string
+	// portScoped is true when ips contains only the pod IPs that define a named
+	// port at a specific number, rather than the full peer IP set. When true,
+	// consumption sites must also include ipBlockSubs alongside ips.
+	portScoped bool
 }
 
 func (cont *AciController) updateIpIndex(index cidranger.Ranger,
@@ -951,11 +988,11 @@ func (cont *AciController) updateTargetPortIndex(service bool, key string,
 		}
 
 		if service {
-			delete(entry.serviceKeys, key)
+			entry.removeServiceKey(key)
 		} else {
 			delete(entry.networkPolicyKeys, key)
 		}
-		if len(entry.serviceKeys) == 0 && len(entry.networkPolicyKeys) == 0 {
+		if !entry.hasServiceKeys() && len(entry.networkPolicyKeys) == 0 {
 			delete(cont.targetPortIndex, portkey)
 		}
 	}
@@ -966,20 +1003,23 @@ func (cont *AciController) updateTargetPortIndex(service bool, key string,
 		entry := cont.targetPortIndex[portkey]
 		if entry == nil {
 			entry = &portIndexEntry{
-				port:              port,
-				serviceKeys:       make(map[string]bool),
+				portMapping:       port,
 				networkPolicyKeys: make(map[string]bool),
 			}
 			cont.targetPortIndex[portkey] = entry
 		} else {
-			for p := range port.ports {
-				entry.port.ports[p] = true
+			for p, svcKeys := range port.portServiceMap {
+				if entry.portMapping.portServiceMap[p] == nil {
+					entry.portMapping.portServiceMap[p] = svcKeys
+				} else if svcKeys != nil {
+					for sk := range svcKeys {
+						entry.portMapping.portServiceMap[p][sk] = true
+					}
+				}
 			}
 		}
 
-		if service {
-			entry.serviceKeys[key] = true
-		} else {
+		if !service {
 			entry.networkPolicyKeys[key] = true
 		}
 	}
@@ -1022,15 +1062,18 @@ func (cont *AciController) getNetPolTargetPorts(np *v1net.NetworkPolicy) map[str
 			}
 			npKey, _ := cache.MetaNamespaceKeyFunc(np)
 			var key string
-			portnums := make(map[int]bool)
+			portnums := make(map[int]map[string]bool)
 			if port.Port.Type == intstr.Int {
 				key = portProto(&proto) + "-num-" + port.Port.String()
-				portnums[port.Port.IntValue()] = true
+				portnums[port.Port.IntValue()] = nil
 			} else {
 				if len(egress.To) != 0 {
 					// TODO optimize this code instead going through all matching pods every time
 					podKeys := cont.netPolEgressPods.GetPodForObj(npKey)
-					portnums = cont.getPortNumsFromPortName(podKeys, port.Port.String())
+					numericPorts := cont.getPortNumsFromPortName(podKeys, port.Port.String())
+					for p := range numericPorts {
+						portnums[p] = nil
+					}
 				} else {
 					ctrNmpEntry, ok := cont.ctrPortNameCache[port.Port.String()]
 					if ok {
@@ -1041,7 +1084,7 @@ func (cont *AciController) getNetPolTargetPorts(np *v1net.NetworkPolicy) map[str
 							}
 							if val[0] == portProto(&proto) {
 								port, _ := strconv.Atoi(val[1])
-								portnums[port] = true
+								portnums[port] = nil
 							}
 						}
 					}
@@ -1052,74 +1095,228 @@ func (cont *AciController) getNetPolTargetPorts(np *v1net.NetworkPolicy) map[str
 				key = portProto(&proto) + "-name-" + port.Port.String()
 			}
 			ports[key] = targetPort{
-				proto: proto,
-				ports: portnums,
+				proto:          proto,
+				portServiceMap: portnums,
 			}
 		}
 	}
 	return ports
 }
 
-type peerRemoteInfo struct {
-	remotePods   []*v1.Pod
-	podSelectors []*metav1.LabelSelector
-}
+// resolveNetPolPeersAndPorts resolves NP peers and ports together in a single
+// pass over matched pods. For egress named ports, port resolution is performed
+// during pod iteration so that each resolvedPortEntry carries the exact IPs
+// that define the named port at that number. This avoids repeated pod lookups.
+func (cont *AciController) resolveNetPolPeersAndPorts(
+	direction string,
+	peers []v1net.NetworkPolicyPeer,
+	ports []v1net.NetworkPolicyPort,
+	peerPods []*v1.Pod,
+	peerNs map[string]*v1.Namespace,
+	np *v1net.NetworkPolicy,
+	logger *logrus.Entry,
+) *resolvedPeerPorts {
+	namespace := np.Namespace
+	result := &resolvedPeerPorts{
+		subnetMap:           make(map[string]bool),
+		addPodSubnetAsRemIp: isAllowAllForAllNamespaces(peers),
+		noPeers:             len(peers) == 0,
+	}
 
-func (cont *AciController) getPeerRemoteSubnets(peers []v1net.NetworkPolicyPeer,
-	namespace string, peerPods []*v1.Pod, peerNs map[string]*v1.Namespace,
-	logger *logrus.Entry) ([]string, []string, peerRemoteInfo, map[string]bool, []string) {
-	var remoteSubnets []string
-	var peerremote peerRemoteInfo
-	subnetMap := make(map[string]bool)
-	var peerNsList []string
-	var ipBlockSubs []string
-	if len(peers) > 0 {
-		// only applies to matching pods
-		for _, pod := range peerPods {
-			for peerIx, peer := range peers {
-				if ns, ok := peerNs[pod.ObjectMeta.Namespace]; ok &&
-					cont.peerMatchesPod(namespace,
-						&peers[peerIx], pod, ns) {
-					podIps := ipsForPod(pod)
-					for _, ip := range podIps {
-						if _, exists := subnetMap[ip]; !exists {
-							subnetMap[ip] = true
-							if cont.config.EnableHppDirect {
-								peerremote.remotePods = append(peerremote.remotePods, pod)
-								if !slices.Contains(peerNsList, pod.ObjectMeta.Namespace) {
-									peerNsList = append(peerNsList, pod.ObjectMeta.Namespace)
-								}
-							}
-							remoteSubnets = append(remoteSubnets, ip)
-						}
-					}
-				}
-				if cont.config.EnableHppDirect && peer.PodSelector != nil {
-					if !cont.isPodSelectorPresent(peerremote.podSelectors, peer.PodSelector) {
-						peerremote.podSelectors = append(peerremote.podSelectors, peer.PodSelector)
-					}
-				}
-			}
-		}
-
-		for _, peer := range peers {
-			if peer.IPBlock == nil {
-				continue
-			}
-			subs, err := ipBlockToSubnets(peer.IPBlock)
-			if err != nil {
-				logger.Warning("Invalid IPBlock in network policy rule: ", err)
-			} else {
-				for _, subnet := range subs {
-					subnetMap[subnet] = true
-				}
-				remoteSubnets = append(remoteSubnets, subs...)
-				ipBlockSubs = append(ipBlockSubs, subs...)
+	// Collect HPP-Direct pod selectors from peers (independent of pod iteration).
+	if cont.config.EnableHppDirect {
+		for i := range peers {
+			if peers[i].PodSelector != nil &&
+				!cont.isPodSelectorPresent(result.podSelectors, peers[i].PodSelector) {
+				result.podSelectors = append(result.podSelectors, peers[i].PodSelector)
 			}
 		}
 	}
-	sort.Strings(remoteSubnets)
-	return remoteSubnets, peerNsList, peerremote, subnetMap, ipBlockSubs
+
+	// --- Phase 1: Resolve peers to IPs ---
+	var namedPortIps map[string]map[int][]string
+	var allRemoteIps []string
+	if result.addPodSubnetAsRemIp {
+		// Allow-all: peers match all pods in all namespaces. Skip per-pod
+		// iteration — individual IPs are not needed (pod subnets are used
+		// instead) and namespace list can be derived from peerNs directly.
+		result.subnetMap["0.0.0.0/0"] = true
+		for nsName := range peerNs {
+			result.peerNsList = append(result.peerNsList, nsName)
+		}
+	} else {
+		// For egress with specific peers, track named port → pod IP
+		// mappings during peer iteration to avoid repeated pod lookups later.
+		if direction == "egress" && len(peers) > 0 {
+			for _, p := range ports {
+				if p.Port != nil && p.Port.Type == intstr.String {
+					if namedPortIps == nil {
+						namedPortIps = make(map[string]map[int][]string)
+					}
+					namedPortIps[p.Port.String()] = make(map[int][]string)
+				}
+			}
+		}
+		for _, pod := range peerPods {
+			podNs, ok := peerNs[pod.ObjectMeta.Namespace]
+			if !ok {
+				continue
+			}
+			for peerIx := range peers {
+				if !cont.peerMatchesPod(namespace, &peers[peerIx], pod, podNs) {
+					continue
+				}
+				podIps := ipsForPod(pod)
+				if len(podIps) == 0 || result.subnetMap[podIps[0]] {
+					break // pod already processed or has no IPs
+				}
+				for _, ip := range podIps {
+					result.subnetMap[ip] = true
+				}
+				allRemoteIps = append(allRemoteIps, podIps...)
+				if !slices.Contains(result.peerNsList, pod.ObjectMeta.Namespace) {
+					result.peerNsList = append(result.peerNsList, pod.ObjectMeta.Namespace)
+				}
+				// Resolve named ports on this pod — port number is pod-level,
+				// so look it up once and associate all of the pod's IPs.
+				for portName, portMap := range namedPortIps {
+					if portNum, err := k8util.LookupContainerPortNumberByName(*pod, portName); err == nil {
+						portMap[int(portNum)] = append(portMap[int(portNum)], podIps...)
+					}
+				}
+				break // pod matched this peer; no need to check remaining peers
+			}
+		}
+	}
+
+	// IPBlock peers.
+	for i := range peers {
+		if peers[i].IPBlock == nil {
+			continue
+		}
+		subs, err := ipBlockToSubnets(peers[i].IPBlock)
+		if err != nil {
+			logger.Warning("Invalid IPBlock in network policy rule: ", err)
+			continue
+		}
+		for _, subnet := range subs {
+			result.subnetMap[subnet] = true
+		}
+		allRemoteIps = append(allRemoteIps, subs...)
+		result.ipBlockSubs = append(result.ipBlockSubs, subs...)
+	}
+	sort.Strings(allRemoteIps)
+
+	// --- Phase 2: Build port entries ---
+	if len(ports) == 0 {
+		result.entries = []resolvedPortEntry{{ips: allRemoteIps}}
+		return result
+	}
+
+	for j := range ports {
+		proto := portProto(ports[j].Protocol)
+
+		if ports[j].Port == nil {
+			result.entries = append(result.entries, resolvedPortEntry{proto: proto, ips: allRemoteIps})
+			continue
+		}
+
+		if ports[j].Port.Type == intstr.Int {
+			entry := resolvedPortEntry{
+				proto:    proto,
+				fromPort: ports[j].Port.String(),
+				ips:      allRemoteIps,
+			}
+			if ports[j].EndPort != nil {
+				entry.toPort = strconv.Itoa(int(*ports[j].EndPort))
+			}
+			result.entries = append(result.entries, entry)
+			continue
+		}
+
+		// Named port resolution.
+		portName := ports[j].Port.String()
+		result.hasNamedPort = true
+
+		if direction == "ingress" {
+			var portMap map[int]bool
+			if reflect.DeepEqual(np.Spec.PodSelector, metav1.LabelSelector{}) {
+				// Empty PodSelector = all pods in namespace. Use ctrPortNameCache
+				// filtered to the NP namespace to find port numbers efficiently.
+				portMap = cont.getNamedPortNumsForNs(portName, namespace)
+			} else {
+				npKey := np.Namespace + "/" + np.Name
+				podKeys := cont.netPolPods.GetPodForObj(npKey)
+				portMap = cont.getPortNumsFromPortName(podKeys, portName)
+			}
+			if len(portMap) > 1 {
+				resolved := make([]int, 0, len(portMap))
+				for p := range portMap {
+					resolved = append(resolved, p)
+				}
+				logger.WithFields(logrus.Fields{
+					"namedPort":     portName,
+					"resolvedPorts": resolved,
+				}).Warning("Ingress named port resolves to multiple port numbers " +
+					"across subject pods; rules will be over-permissive. " +
+					"Use numeric ports in this NetworkPolicy to avoid ambiguity.")
+			}
+			for portNum := range portMap {
+				result.entries = append(result.entries, resolvedPortEntry{
+					proto:    proto,
+					fromPort: strconv.Itoa(portNum),
+					ips:      allRemoteIps,
+				})
+			}
+			continue
+		}
+
+		// Egress named port: resolve portMap and determine scope.
+		// Three cases unified: with-peers (namedPortIps), allow-all, no-To (global cache).
+		var portMap map[int][]string
+		portScoped := true
+		switch {
+		case namedPortIps != nil:
+			portMap = namedPortIps[portName]
+		case result.addPodSubnetAsRemIp:
+			portScoped = false
+			portNums := cont.getPortNums(&ports[j])
+			portMap = make(map[int][]string, len(portNums))
+			for num := range portNums {
+				portMap[num] = allRemoteIps
+			}
+		default:
+			portMap = cont.getNamedPortIPMap(portName)
+		}
+		for portNum, ips := range portMap {
+			if portScoped {
+				sort.Strings(ips)
+			}
+			result.entries = append(result.entries, resolvedPortEntry{
+				proto:      proto,
+				fromPort:   strconv.Itoa(portNum),
+				ips:        ips,
+				portScoped: portScoped,
+			})
+		}
+	}
+
+	// Warn if egress has IPBlock CIDRs alongside port-scoped (named port) entries.
+	if direction == "egress" && len(result.ipBlockSubs) > 0 {
+		for _, e := range result.entries {
+			if e.portScoped {
+				logger.WithFields(logrus.Fields{
+					"ipBlocks":  result.ipBlockSubs,
+					"namedPort": e.fromPort,
+				}).Warning("Egress rule has IPBlock peers with named ports; " +
+					"named ports cannot be resolved for IPBlock destinations. " +
+					"Traffic to IPBlock CIDRs will be blocked by this policy rule.")
+				break
+			}
+		}
+	}
+
+	return result
 }
 
 func (cont *AciController) ipInPodSubnet(ip net.IP) bool {
@@ -1271,192 +1468,181 @@ func (cont *AciController) buildLocalNetPolSubjRule(subj *hppv1.HostprotSubj, ru
 }
 
 func (cont *AciController) buildNetPolSubjRules(ruleName string,
-	subj apicapi.ApicObject, direction string, peers []v1net.NetworkPolicyPeer,
-	remoteSubnets []string, ports []v1net.NetworkPolicyPort,
-	logger *logrus.Entry, npKey string, np *v1net.NetworkPolicy,
-	addPodSubnetAsRemIp bool) {
-	if len(peers) > 0 && len(remoteSubnets) == 0 {
-		// nonempty From matches no pods or IPBlocks; don't
-		// create the rule
+	subj apicapi.ApicObject, direction string,
+	resolved *resolvedPeerPorts, np *v1net.NetworkPolicy) {
+	if !resolved.noPeers && len(resolved.subnetMap) == 0 {
+		// Peers specified but match nothing; don't create rules.
 		return
 	}
-	if len(ports) == 0 {
-		if !cont.configuredPodNetworkIps.V4.Empty() {
-			prefix := fmt.Sprintf("%s-ipv4", ruleName)
-			policyRuleName := util.AciNameForKey(prefix, "", np.Name)
-			cont.buildNetPolSubjRule(subj, policyRuleName, direction,
-				"ipv4", "", "", "", remoteSubnets, addPodSubnetAsRemIp)
+	hasV4 := !cont.configuredPodNetworkIps.V4.Empty()
+	hasV6 := !cont.configuredPodNetworkIps.V6.Empty()
+	ruleCounter := 0
+	for _, entry := range resolved.entries {
+		addPodSubnet := resolved.addPodSubnetAsRemIp
+		if entry.portScoped {
+			// Port-scoped: only pod IPs that define the named port.
+			addPodSubnet = false
 		}
-		if !cont.configuredPodNetworkIps.V6.Empty() {
-			prefix := fmt.Sprintf("%s-ipv6", ruleName)
-			policyRuleName := util.AciNameForKey(prefix, "", np.Name)
-			cont.buildNetPolSubjRule(subj, policyRuleName, direction,
-				"ipv6", "", "", "", remoteSubnets, addPodSubnetAsRemIp)
-		}
-	} else {
-		ruleCounter := 0
-		for j := range ports {
-			proto := portProto(ports[j].Protocol)
-			var portRanges []portRange
 
-			if ports[j].Port != nil {
-				if ports[j].Port.Type == intstr.Int {
-					pr := portRange{fromPort: ports[j].Port.String()}
-					if ports[j].EndPort != nil {
-						pr.toPort = strconv.Itoa(int(*ports[j].EndPort))
-					}
-					portRanges = append(portRanges, pr)
-				} else {
-					var portMap map[int]bool
-					if direction == "egress" {
-						portMap = cont.getPortNums(&ports[j])
-					} else {
-						// TODO need to handle empty Pod Selector
-						if reflect.DeepEqual(np.Spec.PodSelector, metav1.LabelSelector{}) {
-							logger.Warning("Empty PodSelector for NamedPort is not supported in ingress direction "+
-								"port in network policy: ", ports[j].Port.String())
-							continue
-						}
-						podKeys := cont.netPolPods.GetPodForObj(npKey)
-						portMap = cont.getPortNumsFromPortName(podKeys, ports[j].Port.String())
-					}
-					if len(portMap) == 0 {
-						logger.Warning("There is no matching ports in ingress/egress direction "+
-							"port in network policy: ", ports[j].Port.String())
-						continue
-					}
-					for portnum := range portMap {
-						pr := portRange{fromPort: strconv.Itoa(portnum)}
-						portRanges = append(portRanges, pr)
-					}
-				}
+		if entry.proto == "" && entry.fromPort == "" {
+			if hasV4 {
+				policyRuleName := util.AciNameForKey(ruleName+"-ipv4", "", np.Name)
+				cont.buildNetPolSubjRule(subj, policyRuleName, direction,
+					"ipv4", "", "", "", entry.ips, addPodSubnet)
 			}
-			for _, pr := range portRanges {
-				if !cont.configuredPodNetworkIps.V4.Empty() {
-					prefix := fmt.Sprintf("%s_%d-ipv4", ruleName, ruleCounter)
-					policyRuleName := util.AciNameForKey(prefix, "", np.Name)
-					cont.buildNetPolSubjRule(subj, policyRuleName, direction,
-						"ipv4", proto, pr.fromPort, pr.toPort, remoteSubnets, addPodSubnetAsRemIp)
-				}
-				if !cont.configuredPodNetworkIps.V6.Empty() {
-					prefix := fmt.Sprintf("%s_%d-ipv6", ruleName, ruleCounter)
-					policyRuleName := util.AciNameForKey(prefix, "", np.Name)
-					cont.buildNetPolSubjRule(subj, policyRuleName, direction,
-						"ipv6", proto, pr.fromPort, pr.toPort, remoteSubnets, addPodSubnetAsRemIp)
-				}
-				ruleCounter++
+			if hasV6 {
+				policyRuleName := util.AciNameForKey(ruleName+"-ipv6", "", np.Name)
+				cont.buildNetPolSubjRule(subj, policyRuleName, direction,
+					"ipv6", "", "", "", entry.ips, addPodSubnet)
 			}
-			if len(portRanges) == 0 && proto != "" {
-				if !cont.configuredPodNetworkIps.V4.Empty() {
-					prefix := fmt.Sprintf("%s_%d-ipv4", ruleName, ruleCounter)
-					policyRuleName := util.AciNameForKey(prefix, "", np.Name)
-					cont.buildNetPolSubjRule(subj, policyRuleName, direction,
-						"ipv4", proto, "", "", remoteSubnets, addPodSubnetAsRemIp)
-				}
-				if !cont.configuredPodNetworkIps.V6.Empty() {
-					prefix := fmt.Sprintf("%s_%d-ipv6", ruleName, ruleCounter)
-					policyRuleName := util.AciNameForKey(prefix, "", np.Name)
-					cont.buildNetPolSubjRule(subj, policyRuleName, direction,
-						"ipv6", proto, "", "", remoteSubnets, addPodSubnetAsRemIp)
-				}
-				ruleCounter++
+		} else {
+			if hasV4 {
+				prefix := fmt.Sprintf("%s_%d-ipv4", ruleName, ruleCounter)
+				policyRuleName := util.AciNameForKey(prefix, "", np.Name)
+				cont.buildNetPolSubjRule(subj, policyRuleName, direction,
+					"ipv4", entry.proto, entry.fromPort, entry.toPort, entry.ips, addPodSubnet)
 			}
+			if hasV6 {
+				prefix := fmt.Sprintf("%s_%d-ipv6", ruleName, ruleCounter)
+				policyRuleName := util.AciNameForKey(prefix, "", np.Name)
+				cont.buildNetPolSubjRule(subj, policyRuleName, direction,
+					"ipv6", entry.proto, entry.fromPort, entry.toPort, entry.ips, addPodSubnet)
+			}
+			ruleCounter++
 		}
 	}
 }
 
 func (cont *AciController) buildLocalNetPolSubjRules(ruleName string,
-	subj *hppv1.HostprotSubj, direction string, peerNs []string,
-	podSelector []*metav1.LabelSelector, ports []v1net.NetworkPolicyPort,
-	logger *logrus.Entry, npKey string, np *v1net.NetworkPolicy, peerIpBlock []string) {
-	if len(ports) == 0 {
-		if !cont.configuredPodNetworkIps.V4.Empty() {
-			cont.buildLocalNetPolSubjRule(subj, ruleName+"-ipv4", direction,
-				"ipv4", "", "", "", peerNs, podSelector, peerIpBlock)
+	subj *hppv1.HostprotSubj, direction string,
+	resolved *resolvedPeerPorts, np *v1net.NetworkPolicy) {
+	hasV4 := !cont.configuredPodNetworkIps.V4.Empty()
+	hasV6 := !cont.configuredPodNetworkIps.V6.Empty()
+	ruleCounter := 0
+	peerNsList := resolved.peerNsList
+	for _, entry := range resolved.entries {
+		peerIpBlock := resolved.ipBlockSubs
+		if entry.portScoped {
+			// Port-scoped: IPBlock CIDRs excluded for named ports.
+			peerIpBlock = nil
 		}
-		if !cont.configuredPodNetworkIps.V6.Empty() {
-			cont.buildLocalNetPolSubjRule(subj, ruleName+"-ipv6", direction,
-				"ipv6", "", "", "", peerNs, podSelector, peerIpBlock)
-		}
-	} else {
-		ruleCounter := 0
-		for j := range ports {
-			proto := portProto(ports[j].Protocol)
-			var portRanges []portRange
 
-			if ports[j].Port != nil {
-				if ports[j].Port.Type == intstr.Int {
-					pr := portRange{fromPort: ports[j].Port.String()}
-					if ports[j].EndPort != nil {
-						pr.toPort = strconv.Itoa(int(*ports[j].EndPort))
-					}
-					portRanges = append(portRanges, pr)
-				} else {
-					var portMap map[int]bool
-					if direction == "egress" {
-						portMap = cont.getPortNums(&ports[j])
-					} else {
-						// TODO need to handle empty Pod Selector
-						if reflect.DeepEqual(np.Spec.PodSelector, metav1.LabelSelector{}) {
-							logger.Warning("Empty PodSelector for NamedPort is not supported in ingress direction "+
-								"port in network policy: ", ports[j].Port.String())
-							continue
-						}
-						podKeys := cont.netPolPods.GetPodForObj(npKey)
-						portMap = cont.getPortNumsFromPortName(podKeys, ports[j].Port.String())
-					}
-					if len(portMap) == 0 {
-						logger.Warning("There is no matching ports in ingress/egress direction "+
-							"port in network policy: ", ports[j].Port.String())
-						continue
-					}
-					for portnum := range portMap {
-						pr := portRange{fromPort: strconv.Itoa(portnum)}
-						portRanges = append(portRanges, pr)
-					}
-				}
+		if entry.proto == "" && entry.fromPort == "" {
+			if hasV4 {
+				policyRuleName := util.AciNameForKey(ruleName+"-ipv4", "", np.Name)
+				cont.buildLocalNetPolSubjRule(subj, policyRuleName, direction,
+					"ipv4", "", "", "", peerNsList, resolved.podSelectors, peerIpBlock)
 			}
-			for _, pr := range portRanges {
-				if !cont.configuredPodNetworkIps.V4.Empty() {
-					prefix := fmt.Sprintf("%s_%d-ipv4", ruleName, ruleCounter)
-					cont.buildLocalNetPolSubjRule(subj, prefix, direction,
-						"ipv4", proto, pr.fromPort, pr.toPort, peerNs, podSelector, peerIpBlock)
-				}
-				if !cont.configuredPodNetworkIps.V6.Empty() {
-					prefix := fmt.Sprintf("%s_%d-ipv6", ruleName, ruleCounter)
-					cont.buildLocalNetPolSubjRule(subj, prefix, direction,
-						"ipv6", proto, pr.fromPort, pr.toPort, peerNs, podSelector, peerIpBlock)
-				}
-				ruleCounter++
+			if hasV6 {
+				policyRuleName := util.AciNameForKey(ruleName+"-ipv6", "", np.Name)
+				cont.buildLocalNetPolSubjRule(subj, policyRuleName, direction,
+					"ipv6", "", "", "", peerNsList, resolved.podSelectors, peerIpBlock)
 			}
-			if len(portRanges) == 0 && proto != "" {
-				if !cont.configuredPodNetworkIps.V4.Empty() {
-					prefix := fmt.Sprintf("%s_%d-ipv4", ruleName, ruleCounter)
-					cont.buildLocalNetPolSubjRule(subj, prefix, direction,
-						"ipv4", proto, "", "", peerNs, podSelector, peerIpBlock)
-				}
-				if !cont.configuredPodNetworkIps.V6.Empty() {
-					prefix := fmt.Sprintf("%s_%d-ipv6", ruleName, ruleCounter)
-					cont.buildLocalNetPolSubjRule(subj, prefix, direction,
-						"ipv6", proto, "", "", peerNs, podSelector, peerIpBlock)
-				}
-				ruleCounter++
+		} else {
+			if hasV4 {
+				prefix := fmt.Sprintf("%s_%d-ipv4", ruleName, ruleCounter)
+				policyRuleName := util.AciNameForKey(prefix, "", np.Name)
+				cont.buildLocalNetPolSubjRule(subj, policyRuleName, direction,
+					"ipv4", entry.proto, entry.fromPort, entry.toPort, peerNsList, resolved.podSelectors, peerIpBlock)
 			}
+			if hasV6 {
+				prefix := fmt.Sprintf("%s_%d-ipv6", ruleName, ruleCounter)
+				policyRuleName := util.AciNameForKey(prefix, "", np.Name)
+				cont.buildLocalNetPolSubjRule(subj, policyRuleName, direction,
+					"ipv6", entry.proto, entry.fromPort, entry.toPort, peerNsList, resolved.podSelectors, peerIpBlock)
+			}
+			ruleCounter++
 		}
 	}
 }
 
-func (cont *AciController) getPortNums(port *v1net.NetworkPolicyPort) map[int]bool {
+func (cont *AciController) getPortNums(port *v1net.NetworkPolicyPort) map[int]map[string]bool {
 	portkey := portKey(port)
 	cont.indexMutex.Lock()
 	defer cont.indexMutex.Unlock()
 	cont.log.Debug("PortKey1: ", portkey)
 	entry := cont.targetPortIndex[portkey]
-	if entry == nil || len(entry.port.ports) == 0 {
-		return map[int]bool{}
+	if entry == nil || len(entry.portMapping.portServiceMap) == 0 {
+		return nil
 	}
-	return maps.Clone(entry.port.ports)
+	result := make(map[int]map[string]bool, len(entry.portMapping.portServiceMap))
+	for p, svcKeys := range entry.portMapping.portServiceMap {
+		result[p] = maps.Clone(svcKeys)
+	}
+	return result
 }
+
+// getNamedPortIPMap resolves a named port to a map of portNumber -> []podIPs.
+// Each pod that defines the named port contributes its IP to the list for the
+// specific port number that the named port resolves to on that pod. This allows
+// creating per-destination-IP scoped egress rules so that traffic is only
+// allowed to a port number on pods that actually define the named port as that
+// number.
+func (cont *AciController) getNamedPortIPMap(portName string) map[int][]string {
+	result := make(map[int][]string)
+	cont.indexMutex.Lock()
+	ctrNmpEntry, ok := cont.ctrPortNameCache[portName]
+	if !ok {
+		cont.indexMutex.Unlock()
+		return result
+	}
+	// ctrNmpToPods maps "proto-portnum" -> set of pod keys
+	for key, podkeys := range ctrNmpEntry.ctrNmpToPods {
+		val := strings.Split(key, "-")
+		if len(val) != 2 {
+			continue
+		}
+		portNum, err := strconv.Atoi(val[1])
+		if err != nil {
+			continue
+		}
+		for podkey := range podkeys {
+			podobj, exists, err := cont.podIndexer.GetByKey(podkey)
+			if !exists || err != nil {
+				continue
+			}
+			pod := podobj.(*v1.Pod)
+			for _, ip := range ipsForPod(pod) {
+				result[portNum] = append(result[portNum], ip)
+			}
+		}
+	}
+	cont.indexMutex.Unlock()
+	return result
+}
+
+// getNamedPortNumsForNs returns the set of numeric port numbers that a named
+// port resolves to on pods within a specific namespace. It uses ctrPortNameCache
+// rather than iterating all pods in the namespace.
+func (cont *AciController) getNamedPortNumsForNs(portName, namespace string) map[int]bool {
+	result := make(map[int]bool)
+	nsPrefix := namespace + "/"
+	cont.indexMutex.Lock()
+	ctrNmpEntry, ok := cont.ctrPortNameCache[portName]
+	if !ok {
+		cont.indexMutex.Unlock()
+		return result
+	}
+	for key, podkeys := range ctrNmpEntry.ctrNmpToPods {
+		val := strings.Split(key, "-")
+		if len(val) != 2 {
+			continue
+		}
+		portNum, err := strconv.Atoi(val[1])
+		if err != nil {
+			continue
+		}
+		for podkey := range podkeys {
+			if strings.HasPrefix(podkey, nsPrefix) {
+				result[portNum] = true
+				break
+			}
+		}
+	}
+	cont.indexMutex.Unlock()
+	return result
+}
+
 func portProto(protocol *v1.Protocol) string {
 	proto := "tcp"
 	if protocol != nil && *protocol == v1.ProtocolUDP {
@@ -1520,7 +1706,7 @@ func updatePortRemoteSubnets(portRemoteSubs map[string]*portRemoteSubnet,
 	}
 }
 
-func portServiceAugmentKey(proto, port string) string {
+func protoPortKey(proto, port string) string {
 	return proto + "-" + port
 }
 
@@ -1531,7 +1717,7 @@ type portServiceAugment struct {
 }
 
 func updateServiceAugment(portAugments map[string]*portServiceAugment, proto, port, ip string) {
-	key := portServiceAugmentKey(proto, port)
+	key := protoPortKey(proto, port)
 	if psa, ok := portAugments[key]; ok {
 		psa.ipMap[ip] = true
 	} else {
@@ -1609,8 +1795,8 @@ func (cont *AciController) getServiceAugmentBySubnet(
 	}
 }
 
-// build service augment by matching against services with a given
-// target port
+// getServiceAugmentByPort builds service augment by matching against
+// services with a given target port.
 func (cont *AciController) getServiceAugmentByPort(
 	prs *portRemoteSubnet, portAugments map[string]*portServiceAugment,
 	logger *logrus.Entry) {
@@ -1625,21 +1811,21 @@ func (cont *AciController) getServiceAugmentByPort(
 	portkey := portKey(prs.port)
 	cont.indexMutex.Lock()
 	defer cont.indexMutex.Unlock()
-	entries := make(map[string]*portIndexEntry)
+	entries := make(map[string]map[string]bool)
 	entry := cont.targetPortIndex[portkey]
 	if entry == nil {
 		return
 	}
 	if prs.port.Port.Type == intstr.String {
-		for port := range entry.port.ports {
-			portstring := strconv.Itoa(port)
-			key := portProto(prs.port.Protocol) + "-" + "num" + "-" + portstring
-			portEntry := cont.targetPortIndex[key]
-			if portEntry != nil {
-				entries[portstring] = portEntry
+		// Named port in netpol
+		for port, svcKeys := range entry.portMapping.portServiceMap {
+			if len(svcKeys) > 0 {
+				portstring := strconv.Itoa(port)
+				entries[portstring] = svcKeys
 			}
 		}
 	} else if prs.port.EndPort != nil {
+		// Port Range in netpol
 		startPort := prs.port.Port.IntValue()
 		endPort := int(*prs.port.EndPort)
 		rangeSize := endPort - startPort + 1
@@ -1650,7 +1836,7 @@ func (cont *AciController) getServiceAugmentByPort(
 				key := proto + "-num-" + portstring
 				portEntry := cont.targetPortIndex[key]
 				if portEntry != nil {
-					entries[portstring] = portEntry
+					entries[portstring] = portEntry.portMapping.portServiceMap[port]
 				}
 			}
 		} else {
@@ -1666,14 +1852,16 @@ func (cont *AciController) getServiceAugmentByPort(
 				}
 				if portNum >= startPort && portNum <= endPort {
 					portstring := strconv.Itoa(portNum)
-					entries[portstring] = portEntry
+					entries[portstring] = portEntry.portMapping.portServiceMap[portNum]
 				}
 			}
 		}
-		// Look through services with named target ports as well
+		// Look through services with named target ports as well.
 		for serviceKey, namedSvcEntry := range cont.namedPortServiceIndex {
 			for _, svcPortEntry := range *namedSvcEntry {
-				// named ports that resolve to a single port number are already handled above while processing the -num- ports in targetPortIndex
+				// Named ports that resolve to a single port number are
+				// already handled above via the -num- entries in
+				// targetPortIndex.
 				if len(svcPortEntry.resolvedPorts) <= 1 {
 					continue
 				}
@@ -1688,22 +1876,20 @@ func (cont *AciController) getServiceAugmentByPort(
 				if allInRange {
 					portstring := svcPortEntry.targetPortName
 					if _, ok := entries[portstring]; !ok {
-						entries[portstring] = &portIndexEntry{
-							serviceKeys: map[string]bool{serviceKey: true},
-						}
+						entries[portstring] = map[string]bool{serviceKey: true}
 					} else {
-						entries[portstring].serviceKeys[serviceKey] = true
+						entries[portstring][serviceKey] = true
 					}
 				}
 			}
 		}
+	} else if len(entry.portMapping.portServiceMap) > 0 {
+		// Single numeric portNum in netpol
+		portNum := prs.port.Port.IntValue()
+		entries[prs.port.Port.String()] = entry.portMapping.portServiceMap[portNum]
 	}
-	if len(entry.port.ports) > 0 {
-		portString := prs.port.Port.String()
-		entries[portString] = entry
-	}
-	for key, portentry := range entries {
-		for servicekey := range portentry.serviceKeys {
+	for key, servicekeys := range entries {
+		for servicekey := range servicekeys {
 			serviceobj, _, err := cont.serviceIndexer.GetByKey(servicekey)
 			if err != nil {
 				logger.Error("Could not lookup service for "+
@@ -1719,6 +1905,12 @@ func (cont *AciController) getServiceAugmentByPort(
 				if svcPort.Protocol != *prs.port.Protocol {
 					continue
 				}
+				// Handle the case where the NP specifies a numeric port
+				// but the service has a named targetPort. The key in
+				// entries is the resolved numeric port, so it won't match
+				// svcPort.TargetPort.String() directly. We check if the
+				// named targetPort resolves to exactly one numeric port
+				// (all-or-nothing) and whether that port matches the key.
 				match := false
 				if indexEntry, ok := cont.namedPortServiceIndex[servicekey]; ok {
 					if svcPortIdxEntry, ok := (*indexEntry)[svcPort.Name]; ok && len(svcPortIdxEntry.resolvedPorts) == 1 {
@@ -1728,7 +1920,8 @@ func (cont *AciController) getServiceAugmentByPort(
 						}
 					}
 				}
-				if !match && svcPort.TargetPort.String() != key {
+				svcTargetPort := svcPort.TargetPort.String()
+				if !match && svcTargetPort != key && svcTargetPort != prs.port.Port.String() {
 					continue
 				}
 				proto := portProto(&svcPort.Protocol)
@@ -2204,17 +2397,16 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 			labelKey = cont.aciNameForKey("np", key)
 		}
 		hpp := apicapi.NewHostprotPol(cont.config.AciPolicyTenant, labelKey)
+
 		// Generate ingress policies
 		if np.Spec.PolicyTypes == nil || ptypeset[v1net.PolicyTypeIngress] {
 			subjIngress :=
 				apicapi.NewHostprotSubj(hpp.GetDn(), "networkpolicy-ingress")
 
 			for i, ingress := range np.Spec.Ingress {
-				addPodSubnetAsRemIp := isAllowAllForAllNamespaces(ingress.From)
-				remoteSubnets, _, _, _, _ := cont.getPeerRemoteSubnets(ingress.From,
-					np.Namespace, peerPods, peerNs, logger)
-				cont.buildNetPolSubjRules(strconv.Itoa(i), subjIngress,
-					"ingress", ingress.From, remoteSubnets, ingress.Ports, logger, key, np, addPodSubnetAsRemIp)
+				resolved := cont.resolveNetPolPeersAndPorts("ingress",
+					ingress.From, ingress.Ports, peerPods, peerNs, np, logger)
+				cont.buildNetPolSubjRules(strconv.Itoa(i), subjIngress, "ingress", resolved, np)
 			}
 			hpp.AddChild(subjIngress)
 		}
@@ -2226,15 +2418,11 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 			portRemoteSubs := make(map[string]*portRemoteSubnet)
 
 			for i, egress := range np.Spec.Egress {
-				addPodSubnetAsRemIp := isAllowAllForAllNamespaces(egress.To)
-				remoteSubnets, _, _, subnetMap, _ := cont.getPeerRemoteSubnets(egress.To,
-					np.Namespace, peerPods, peerNs, logger)
-				cont.buildNetPolSubjRules(strconv.Itoa(i), subjEgress,
-					"egress", egress.To, remoteSubnets, egress.Ports, logger, key, np, addPodSubnetAsRemIp)
+				resolved := cont.resolveNetPolPeersAndPorts("egress",
+					egress.To, egress.Ports, peerPods, peerNs, np, logger)
+				cont.buildNetPolSubjRules(strconv.Itoa(i), subjEgress, "egress", resolved, np)
 
-				// creating a rule to egress to all on a given port needs
-				// to enable access to any service IPs/ports that have
-				// that port as their target port.
+				subnetMap := resolved.subnetMap
 				if len(egress.To) == 0 {
 					subnetMap = map[string]bool{
 						"0.0.0.0/0": true,
@@ -2251,6 +2439,7 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 						false)
 				}
 			}
+
 			cont.buildServiceAugment(subjEgress, nil, portRemoteSubs, logger)
 			hpp.AddChild(subjEgress)
 		}
@@ -2303,15 +2492,15 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 			}
 
 			for i, ingress := range np.Spec.Ingress {
-				remoteSubnets, peerNsList, peerremote, _, peerIpBlock := cont.getPeerRemoteSubnets(ingress.From,
-					np.Namespace, peerPods, peerNs, logger)
+				resolved := cont.resolveNetPolPeersAndPorts("ingress",
+					ingress.From, ingress.Ports, peerPods, peerNs, np, logger)
 				if isAllowAllForAllNamespaces(ingress.From) {
-					peerNsList = append(peerNsList, "nodeips")
+					if !slices.Contains(resolved.peerNsList, "nodeips") {
+						resolved.peerNsList = append(resolved.peerNsList, "nodeips")
+					}
 				}
-				if !(len(ingress.From) > 0 && len(remoteSubnets) == 0) {
-					cont.buildLocalNetPolSubjRules(strconv.Itoa(i), subjIngress,
-						"ingress", peerNsList, peerremote.podSelectors, ingress.Ports,
-						logger, key, np, peerIpBlock)
+				if !(!resolved.noPeers && len(resolved.subnetMap) == 0) {
+					cont.buildLocalNetPolSubjRules(strconv.Itoa(i), subjIngress, "ingress", resolved, np)
 				}
 			}
 			hpp.Spec.HostprotSubj = append(hpp.Spec.HostprotSubj, *subjIngress)
@@ -2326,16 +2515,18 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 			portRemoteSubs := make(map[string]*portRemoteSubnet)
 
 			for i, egress := range np.Spec.Egress {
-				remoteSubnets, peerNsList, peerremote, subnetMap, peerIpBlock := cont.getPeerRemoteSubnets(egress.To,
-					np.Namespace, peerPods, peerNs, logger)
+				resolved := cont.resolveNetPolPeersAndPorts("egress",
+					egress.To, egress.Ports, peerPods, peerNs, np, logger)
 				if isAllowAllForAllNamespaces(egress.To) {
-					peerNsList = append(peerNsList, "nodeips")
+					if !slices.Contains(resolved.peerNsList, "nodeips") {
+						resolved.peerNsList = append(resolved.peerNsList, "nodeips")
+					}
 				}
-				if !(len(egress.To) > 0 && len(remoteSubnets) == 0) {
-					cont.buildLocalNetPolSubjRules(strconv.Itoa(i), subjEgress,
-						"egress", peerNsList, peerremote.podSelectors, egress.Ports, logger, key, np, peerIpBlock)
+				if !(!resolved.noPeers && len(resolved.subnetMap) == 0) {
+					cont.buildLocalNetPolSubjRules(strconv.Itoa(i), subjEgress, "egress", resolved, np)
 				}
 
+				subnetMap := resolved.subnetMap
 				if len(egress.To) == 0 {
 					subnetMap = map[string]bool{"0.0.0.0/0": true}
 				}
@@ -2350,6 +2541,7 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 						false)
 				}
 			}
+
 			cont.buildServiceAugment(nil, subjEgress, portRemoteSubs, logger)
 			hpp.Spec.HostprotSubj = append(hpp.Spec.HostprotSubj, *subjEgress)
 		}
@@ -2638,7 +2830,12 @@ func (seps *serviceEndpointSlice) SetNpServiceAugmentForService(servicekey strin
 			return port >= prs.port.Port.IntValue() && port <= int(*prs.port.EndPort)
 		}
 		// Single port matching: check if port is in the target ports map
-		return npTargetPortsMap[port]
+		// and was registered by this service
+		svcKeys, ok := npTargetPortsMap[port]
+		if !ok {
+			return false
+		}
+		return svcKeys == nil || svcKeys[servicekey]
 	}
 
 	label := map[string]string{discovery.LabelServiceName: service.ObjectMeta.Name}

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -226,6 +226,22 @@ func addServices(cont *testAciController, augment *npTestAugment) {
 	}
 }
 
+// waitForPodIndexed polls the podIndexer until all specified pod keys are present.
+// This mirrors real K8s behavior: an EndpointSlice referencing a pod cannot arrive
+// before the pod exists in the API server (and thus in our informer cache).
+func waitForPodIndexed(t *testing.T, cont *testAciController, podKeys ...string) {
+	t.Helper()
+	tu.WaitFor(t, "pod-indexed", 2000*time.Millisecond, func(last bool) (bool, error) {
+		for _, key := range podKeys {
+			_, exists, _ := cont.podIndexer.GetByKey(key)
+			if !exists {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}
+
 func makeNp(ingress apicapi.ApicSlice,
 	egress apicapi.ApicSlice, name string) apicapi.ApicObject {
 	np1 := apicapi.NewHostprotPol("test-tenant", name)
@@ -1040,9 +1056,9 @@ func TestNetworkPolicy(t *testing.T) {
 		cont.log.Info("Starting npfirst ", npTests[ix].desc)
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, npTests[ix].augment)
 		addPods(cont, false, ips, true)
 		addPods(cont, true, ips, true)
+		addServices(cont, npTests[ix].augment)
 		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
@@ -1174,9 +1190,9 @@ func TestNetworkPolicyWithLongName(t *testing.T) {
 		cont.log.Info("Starting npfirst ", npTests[ix].desc)
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, npTests[ix].augment)
 		addPods(cont, false, ips, true)
 		addPods(cont, true, ips, true)
+		addServices(cont, npTests[ix].augment)
 		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
@@ -1933,9 +1949,9 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		cont.log.Info("Starting npfirst ", npTests[ix].desc)
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, npTests[ix].augment)
 		addPods(cont, false, ips, true)
 		addPods(cont, true, ips, true)
+		addServices(cont, npTests[ix].augment)
 		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
@@ -2522,9 +2538,9 @@ func TestNetworkPolicyv6(t *testing.T) {
 		cont.log.Info("Starting npfirst ", np6Tests[ix].desc)
 		cont.fakeNetworkPolicySource.Add(np6Tests[ix].netPol)
 		cont.run()
-		addServices(cont, np6Tests[ix].augment)
 		addPods(cont, false, ips, false)
 		addPods(cont, true, ips, false)
+		addServices(cont, np6Tests[ix].augment)
 		checkNp(t, &np6Tests[ix], "npfirst", cont)
 		cont.stop()
 	}
@@ -3086,9 +3102,9 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		cont.log.Info("Starting npfirst ", np6Tests[ix].desc)
 		cont.fakeNetworkPolicySource.Add(np6Tests[ix].netPol)
 		cont.run()
-		addServices(cont, np6Tests[ix].augment)
 		addPods(cont, false, ips, false)
 		addPods(cont, true, ips, false)
+		addServices(cont, np6Tests[ix].augment)
 		checkNp(t, &np6Tests[ix], "npfirst", cont)
 		cont.stop()
 	}
@@ -3533,9 +3549,9 @@ func TestNetworkPolicyWithEndPointSlice(t *testing.T) {
 		cont.log.Info("Starting npfirst ", npTests[ix].desc)
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, npTests[ix].augment)
 		addPods(cont, false, ips, true)
 		addPods(cont, true, ips, true)
+		addServices(cont, npTests[ix].augment)
 		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
@@ -3952,9 +3968,9 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		cont.log.Info("Starting npfirst ", npTests[ix].desc)
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
-		addServices(cont, npTests[ix].augment)
 		addPods(cont, false, ips, true)
 		addPods(cont, true, ips, true)
+		addServices(cont, npTests[ix].augment)
 		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
@@ -3976,6 +3992,8 @@ func TestNetworkPolicyEgressNmPort(t *testing.T) {
 	rule_1_0.SetAttr("ethertype", "ipv4")
 	rule_1_0.SetAttr("protocol", "tcp")
 	rule_1_0.SetAttr("fromPort", "80")
+	// Per-IP scoping: only allow egress to the pod that defines "serve-80".
+	rule_1_0.AddChild(apicapi.NewHostprotRemoteIp(rule_1_0.GetDn(), "1.1.1.1"))
 
 	rule_1_s := apicapi.NewHostprotRule(np1SDnE, "service_tcp_8080-ipv4")
 	rule_1_s.SetAttr("direction", "egress")
@@ -4075,30 +4093,27 @@ func TestNetworkPolicyEgressNmPort(t *testing.T) {
 			ContainerPort: int32(81),
 		},
 	}
-	addPod := func(cont *testAciController, namespace string,
-		name string, labels map[string]string, ports []v1.ContainerPort) {
+	addPodNmPort := func(cont *testAciController, namespace, name string,
+		labels map[string]string, ports []v1.ContainerPort, ip string) {
 		pod := &v1.Pod{
 			Spec: v1.PodSpec{
-				NodeName: "test-node",
-				Containers: []v1.Container{
-					{
-						Ports: ports,
-					},
-				},
+				NodeName:   "test-node",
+				Containers: []v1.Container{{Ports: ports}},
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 				Name:      name,
 				Labels:    labels,
 			},
+			Status: v1.PodStatus{PodIP: ip},
 		}
 		cont.fakePodSource.Add(pod)
 	}
 	for ix := range npTests {
 		cont := initCont()
 		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
-		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
-		addPod(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1)
+		addPodNmPort(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports, "1.1.1.1")
+		addPodNmPort(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1, "2.2.2.2")
 		addServices(cont, npTests[ix].augment)
 		cont.run()
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
@@ -4113,9 +4128,10 @@ func TestNetworkPolicyEgressNmPort(t *testing.T) {
 		cont.log.Info("Starting npfirst ", npTests[ix].desc)
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
+		addPodNmPort(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports, "1.1.1.1")
+		addPodNmPort(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1, "2.2.2.2")
+		waitForPodIndexed(t, cont, "testns/pod1", "testns/pod2")
 		addServices(cont, npTests[ix].augment)
-		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
-		addPod(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1)
 		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
@@ -4139,6 +4155,7 @@ func TestNetworkPolicyEgressNmPortHppOptimize(t *testing.T) {
 	hash, _ := util.CreateHashFromNetPol(test1_np)
 	test1_np_name := "kube_np_" + hash
 	test1_rule1 := createRule(test1_np_name, false, rule_1, "0_0-ipv4__np1")
+	test1_rule1.AddChild(apicapi.NewHostprotRemoteIp(test1_rule1.GetDn(), "1.1.1.1"))
 	test1_rule2 := createRule(test1_np_name, false, rule_2, "service_tcp_8080-ipv4")
 	test1_rule2.AddChild(apicapi.NewHostprotRemoteIp(test1_rule2.GetDn(), "9.0.0.42"))
 
@@ -4229,30 +4246,25 @@ func TestNetworkPolicyEgressNmPortHppOptimize(t *testing.T) {
 			ContainerPort: int32(81),
 		},
 	}
-	addPod := func(cont *testAciController, namespace string,
-		name string, labels map[string]string, ports []v1.ContainerPort) {
+	addPodHppOpt := func(cont *testAciController, namespace, name string,
+		labels map[string]string, ports []v1.ContainerPort, ip string) {
 		pod := &v1.Pod{
 			Spec: v1.PodSpec{
-				NodeName: "test-node",
-				Containers: []v1.Container{
-					{
-						Ports: ports,
-					},
-				},
+				NodeName:   "test-node",
+				Containers: []v1.Container{{Ports: ports}},
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      name,
-				Labels:    labels,
+				Namespace: namespace, Name: name, Labels: labels,
 			},
+			Status: v1.PodStatus{PodIP: ip},
 		}
 		cont.fakePodSource.Add(pod)
 	}
 	for ix := range npTests {
 		cont := initCont()
 		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
-		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
-		addPod(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1)
+		addPodHppOpt(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports, "1.1.1.1")
+		addPodHppOpt(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1, "2.2.2.2")
 		addServices(cont, npTests[ix].augment)
 		cont.run()
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
@@ -4267,9 +4279,10 @@ func TestNetworkPolicyEgressNmPortHppOptimize(t *testing.T) {
 		cont.log.Info("Starting npfirst ", npTests[ix].desc)
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
 		cont.run()
+		addPodHppOpt(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports, "1.1.1.1")
+		addPodHppOpt(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1, "2.2.2.2")
+		waitForPodIndexed(t, cont, "testns/pod1", "testns/pod2")
 		addServices(cont, npTests[ix].augment)
-		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
-		addPod(cont, "testns", "pod2", map[string]string{"l1": "v2"}, ports1)
 		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
@@ -4392,7 +4405,7 @@ func getContWithEnabledLocalHpp() *testAciController {
 	return cont
 }
 
-func TestGetPeerRemoteSubnets(t *testing.T) {
+func TestResolveNetPolPeersAndPorts(t *testing.T) {
 	cont := getContWithEnabledLocalHpp()
 	cont.run()
 	defer cont.stop()
@@ -4428,19 +4441,31 @@ func TestGetPeerRemoteSubnets(t *testing.T) {
 			},
 		},
 	}
-	logger := logrus.New().WithField("test", "getPeerRemoteSubnets")
+	logger := logrus.New().WithField("test", "resolveNetPolPeersAndPorts")
+
+	np := &v1net.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-np", Namespace: namespace},
+		Spec: v1net.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+		},
+	}
 
 	expectedPeerNsList := []string{"default"}
 	expectedSubnetMap := map[string]bool{"192.168.0.1": true}
 	expectedRemoteSubnets := []string{"192.168.0.1"}
 
-	remoteSubnets, peerNsList, peerremote, subnetMap, _ := cont.getPeerRemoteSubnets(peers, namespace, peerPods, peerNs, logger)
+	resolved := cont.resolveNetPolPeersAndPorts("ingress", peers, nil, peerPods, peerNs, np, logger)
 
-	assert.Equal(t, expectedRemoteSubnets, remoteSubnets)
-	assert.Equal(t, expectedPeerNsList, peerNsList)
-	assert.Equal(t, expectedSubnetMap, subnetMap)
-	assert.Equal(t, peerPods, peerremote.remotePods)
-	assert.Equal(t, peers[0].PodSelector, peerremote.podSelectors[0])
+	// allRemoteIps is now carried inside each entry's ips field
+	assert.Equal(t, 1, len(resolved.entries), "Should have 1 entry (no port restriction)")
+	assert.Equal(t, expectedRemoteSubnets, resolved.entries[0].ips)
+	assert.False(t, resolved.entries[0].portScoped)
+	assert.Equal(t, expectedPeerNsList, resolved.peerNsList)
+	assert.Equal(t, expectedSubnetMap, resolved.subnetMap)
+	assert.Equal(t, peers[0].PodSelector, resolved.podSelectors[0])
+	assert.False(t, resolved.noPeers, "noPeers should be false when peers are specified")
+	assert.Nil(t, resolved.ipBlockSubs, "ipBlockSubs should be nil (no IPBlock peers)")
+	assert.False(t, resolved.addPodSubnetAsRemIp, "addPodSubnetAsRemIp should be false (peer has a pod selector, not allow-all-namespaces)")
 }
 
 func TestBuildLocalNetPolSubjRule(t *testing.T) {
@@ -4627,10 +4652,14 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 	podSelectors := []*metav1.LabelSelector{
 		np.Spec.Ingress[0].From[0].PodSelector,
 	}
-	cont.buildLocalNetPolSubjRules("test-rule", subj, "ingress", []string{"test-namespace"}, podSelectors, np.Spec.Ingress[0].Ports, nil, "", np, nil)
+	cont.buildLocalNetPolSubjRules("test-rule", subj, "ingress", &resolvedPeerPorts{
+		entries:      []resolvedPortEntry{{proto: "tcp", fromPort: "8080"}},
+		peerNsList:   []string{"test-namespace"},
+		podSelectors: podSelectors,
+	}, np)
 
 	assert.Equal(t, 1, len(subj.HostprotRule))
-	assert.Equal(t, "test-rule_0-ipv4", subj.HostprotRule[0].Name)
+	assert.Equal(t, "test-rule_0-ipv4__test-network-policy", subj.HostprotRule[0].Name)
 	assert.Equal(t, "ingress", subj.HostprotRule[0].Direction)
 	assert.Equal(t, "ipv4", subj.HostprotRule[0].Ethertype)
 	assert.Equal(t, "tcp", subj.HostprotRule[0].Protocol)
@@ -4666,7 +4695,11 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 	podSelectors = []*metav1.LabelSelector{
 		np.Spec.Ingress[0].From[0].PodSelector,
 	}
-	cont.buildLocalNetPolSubjRules("test-rule", subj, "ingress", []string{"test-namespace"}, podSelectors, np.Spec.Ingress[0].Ports, nil, "", np, nil)
+	cont.buildLocalNetPolSubjRules("test-rule", subj, "ingress", &resolvedPeerPorts{
+		entries:      []resolvedPortEntry{{}},
+		peerNsList:   []string{"test-namespace"},
+		podSelectors: podSelectors,
+	}, np)
 
 	expected := hppv1.HostprotSubj{
 		HostprotRule: []hppv1.HostprotRule{
@@ -4677,7 +4710,7 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 				Protocol:            "unspecified",
 				FromPort:            "unspecified",
 				ToPort:              "unspecified",
-				Name:                "test-rule-ipv4",
+				Name:                "test-rule-ipv4__test-network-policy",
 				RsRemoteIpContainer: []string{"test-namespace"},
 				HostprotFilterContainer: []hppv1.HostprotFilterContainer{
 					{
@@ -4699,7 +4732,11 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 	assert.Equal(t, expected, *subj)
 
 	subj = &hppv1.HostprotSubj{}
-	cont.buildLocalNetPolSubjRules("test-rule", subj, "ingress", []string{}, podSelectors, np.Spec.Ingress[0].Ports, nil, "", np, nil)
+	cont.buildLocalNetPolSubjRules("test-rule", subj, "ingress", &resolvedPeerPorts{
+		entries:      []resolvedPortEntry{{}},
+		peerNsList:   nil,
+		podSelectors: podSelectors,
+	}, np)
 
 	expectedRule := []hppv1.HostprotRule{
 		{
@@ -4709,8 +4746,8 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 			Protocol:            "unspecified",
 			FromPort:            "unspecified",
 			ToPort:              "unspecified",
-			Name:                "test-rule-ipv4",
-			RsRemoteIpContainer: []string{},
+			Name:                "test-rule-ipv4__test-network-policy",
+			RsRemoteIpContainer: nil,
 			HostprotFilterContainer: []hppv1.HostprotFilterContainer{
 				{
 					HostprotFilter: []hppv1.HostprotFilter{
@@ -4767,8 +4804,8 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 			Protocol:            "tcp",
 			FromPort:            "8080",
 			ToPort:              "unspecified",
-			Name:                "test-rule_0-ipv4",
-			RsRemoteIpContainer: []string{},
+			Name:                "test-rule_0-ipv4__test-network-policy",
+			RsRemoteIpContainer: nil,
 			HostprotFilterContainer: []hppv1.HostprotFilterContainer{
 				{
 					HostprotFilter: []hppv1.HostprotFilter{
@@ -4789,7 +4826,11 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 	podSelectors = []*metav1.LabelSelector{
 		np.Spec.Ingress[0].From[0].PodSelector,
 	}
-	cont.buildLocalNetPolSubjRules("test-rule", subj, "ingress", []string{}, podSelectors, np.Spec.Ingress[0].Ports, nil, "", np, nil)
+	cont.buildLocalNetPolSubjRules("test-rule", subj, "ingress", &resolvedPeerPorts{
+		entries:      []resolvedPortEntry{{proto: "tcp", fromPort: "8080"}},
+		peerNsList:   nil,
+		podSelectors: podSelectors,
+	}, np)
 
 	assert.Equal(t, expectedRule, subj.HostprotRule)
 
@@ -4841,9 +4882,9 @@ func TestBuildServiceAugment(t *testing.T) {
 		cont.targetPortIndex = make(map[string]*portIndexEntry)
 
 		cont.targetPortIndex[portkey] = &portIndexEntry{
-			port: targetPort{
-				proto: "tcp",
-				ports: map[int]bool{8080: true},
+			portMapping: targetPort{
+				proto:          "tcp",
+				portServiceMap: map[int]map[string]bool{8080: nil},
 			},
 		}
 
@@ -4860,6 +4901,188 @@ func TestBuildServiceAugment(t *testing.T) {
 		assert.Empty(t, subj)
 		assert.Equal(t, expected, localsubj)
 	})
+
+	// Regression test: when the NP allows named port "http" and a
+	// service has two named target ports ("http"→9090, "http-alt"→8080),
+	// only the "http" service port (9090) should be augmented.
+	t.Run("NamedPortServiceAugmentNoMismatch", func(t *testing.T) {
+		serviceKey := "testns/bleh-svc"
+		svc := npservice("testns", "bleh-svc", "10.96.0.100",
+			[]v1.ServicePort{
+				servicePortNamed("p9090", v1.ProtocolTCP, 9090, "http"),
+				servicePortNamed("p8080", v1.ProtocolTCP, 8080, "http-alt"),
+			})
+		cont.fakeServiceSource.Add(svc)
+		time.Sleep(500 * time.Millisecond)
+
+		cont.indexMutex.Lock()
+		cont.namedPortServiceIndex[serviceKey] = &namedPortServiceIndexEntry{
+			"p9090": &namedPortServiceIndexPort{
+				targetPortName: "http",
+				resolvedPorts:  map[int]bool{9090: true},
+			},
+			"p8080": &namedPortServiceIndexPort{
+				targetPortName: "http-alt",
+				resolvedPorts:  map[int]bool{8080: true},
+			},
+		}
+		// "tcp-name-http" tracks only the "http" named port (9090), not "http-alt" (8080).
+		// The service key is set so getServiceAugmentByPort picks it up for augmentation.
+		cont.targetPortIndex["tcp-name-http"] = &portIndexEntry{
+			portMapping: targetPort{
+				proto:          v1.ProtocolTCP,
+				portServiceMap: map[int]map[string]bool{9090: {serviceKey: true}},
+			},
+			networkPolicyKeys: map[string]bool{"testns/np1": true},
+		}
+		cont.indexMutex.Unlock()
+
+		portAugments := make(map[string]*portServiceAugment)
+		proto := v1.ProtocolTCP
+		prs := &portRemoteSubnet{
+			port: &v1net.NetworkPolicyPort{
+				Protocol: &proto,
+				Port:     &intstr.IntOrString{Type: intstr.String, StrVal: "http"},
+			},
+			subnetMap: map[string]bool{"0.0.0.0/0": true},
+		}
+
+		cont.getServiceAugmentByPort(prs, portAugments, logger)
+
+		_, has9090 := portAugments[protoPortKey("tcp", "9090")]
+		assert.True(t, has9090, "service port 9090 (http) should be augmented")
+
+		_, has8080 := portAugments[protoPortKey("tcp", "8080")]
+		assert.False(t, has8080, "service port 8080 (http-alt) must NOT be augmented for NP named port 'http'")
+
+		// Clean up
+		cont.indexMutex.Lock()
+		delete(cont.namedPortServiceIndex, serviceKey)
+		delete(cont.targetPortIndex, "tcp-name-http")
+		delete(cont.targetPortIndex, "tcp-num-9090")
+		delete(cont.targetPortIndex, "tcp-num-8080")
+		cont.indexMutex.Unlock()
+	})
+}
+
+// TestEgressNamedPortPerIPScoping validates that egress rules for named
+// ports are scoped to the IPs of pods that resolve the named port to each
+// specific port number.
+func TestEgressNamedPortPerIPScoping(t *testing.T) {
+	name := "kube_np_testns_np1"
+	baseDn := makeNp(nil, nil, name).GetDn()
+	np1SDnE := fmt.Sprintf("%s/subj-networkpolicy-egress", baseDn)
+
+	// pod1 has named port "serve-80" → 80, IP 1.1.1.1
+	// pod2 has named port "serve-81" → 81 (different name, should NOT appear)
+	// Expected: one egress rule for port 80 scoped to pod1's IP (1.1.1.1)
+	rule_1_0 := apicapi.NewHostprotRule(np1SDnE, "0_0-ipv4__np1")
+	rule_1_0.SetAttr("direction", "egress")
+	rule_1_0.SetAttr("ethertype", "ipv4")
+	rule_1_0.SetAttr("protocol", "tcp")
+	rule_1_0.SetAttr("fromPort", "80")
+	rule_1_0.AddChild(apicapi.NewHostprotRemoteIp(rule_1_0.GetDn(), "1.1.1.1"))
+
+	// Service augment: service1 has targetPort 80, all endpoints (1.1.1.1) covered
+	rule_1_s := apicapi.NewHostprotRule(np1SDnE, "service_tcp_8080-ipv4")
+	rule_1_s.SetAttr("direction", "egress")
+	rule_1_s.SetAttr("ethertype", "ipv4")
+	rule_1_s.SetAttr("protocol", "tcp")
+	rule_1_s.SetAttr("fromPort", "8080")
+	rule_1_s.AddChild(apicapi.NewHostprotRemoteIp(rule_1_s.GetDn(), "9.0.0.42"))
+
+	var npTests = []npTest{
+		{netpol("testns", "np1", &metav1.LabelSelector{},
+			nil, []v1net.NetworkPolicyEgressRule{
+				egressRule([]v1net.NetworkPolicyPort{
+					{Protocol: func() *v1.Protocol { a := v1.ProtocolTCP; return &a }(),
+						Port: &intstr.IntOrString{Type: intstr.String, StrVal: "serve-80"},
+					},
+				}, nil),
+			}, allPolicyTypes),
+			makeNp(nil, apicapi.ApicSlice{rule_1_0, rule_1_s}, name),
+			&npTestAugment{
+				[]*v1.Service{
+					npservice("testns", "service1", "9.0.0.42",
+						[]v1.ServicePort{
+							servicePort("", v1.ProtocolTCP, 8080, 80),
+						}),
+				},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+				},
+			}, "egress-named-port-per-ip-scoping"},
+	}
+	initCont := func() *testAciController {
+		cont := testController()
+		cont.config.AciPolicyTenant = "test-tenant"
+		cont.config.NodeServiceIpPool = []ipam.IpRange{
+			{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.1.3")},
+		}
+		cont.config.PodIpPool = []ipam.IpRange{
+			{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.255.254")},
+		}
+		cont.AciController.initIpam()
+
+		cont.fakeNamespaceSource.Add(namespaceLabel("testns",
+			map[string]string{"test": "testv"}))
+		return cont
+	}
+
+	ports1 := []v1.ContainerPort{
+		{Name: "serve-80", ContainerPort: 80},
+	}
+	ports2 := []v1.ContainerPort{
+		{Name: "serve-81", ContainerPort: 81},
+	}
+
+	for ix := range npTests {
+		cont := initCont()
+		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
+		// Register pods in fakePodSource (populates podIndexer via informer).
+		pod1obj := &v1.Pod{
+			Spec: v1.PodSpec{
+				NodeName:   "test-node",
+				Containers: []v1.Container{{Ports: ports1}},
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "testns", Name: "pod1",
+				Labels: map[string]string{"l1": "v1"},
+			},
+			Status: v1.PodStatus{PodIP: "1.1.1.1"},
+		}
+		pod2obj := &v1.Pod{
+			Spec: v1.PodSpec{
+				NodeName:   "test-node",
+				Containers: []v1.Container{{Ports: ports2}},
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "testns", Name: "pod2",
+				Labels: map[string]string{"l1": "v2"},
+			},
+			Status: v1.PodStatus{PodIP: "2.2.2.2"},
+		}
+		cont.fakePodSource.Add(pod1obj)
+		cont.fakePodSource.Add(pod2obj)
+		addServices(cont, npTests[ix].augment)
+		cont.run()
+		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
+		checkNp(t, &npTests[ix], "podsfirst", cont)
+		cont.stop()
+	}
 }
 
 func getHppObj() *hppv1.HostprotPol {
@@ -5419,7 +5642,7 @@ func TestNetworkPolicyEgressMultipleNamedPortsUniqueRuleNames(t *testing.T) {
 	}
 
 	addPod := func(cont *testAciController, namespace string,
-		name string, labels map[string]string, ports []v1.ContainerPort) {
+		name string, labels map[string]string, ports []v1.ContainerPort, ip string) {
 		pod := &v1.Pod{
 			Spec: v1.PodSpec{
 				NodeName: "test-node",
@@ -5433,6 +5656,9 @@ func TestNetworkPolicyEgressMultipleNamedPortsUniqueRuleNames(t *testing.T) {
 				Namespace: namespace,
 				Name:      name,
 				Labels:    labels,
+			},
+			Status: v1.PodStatus{
+				PodIPs: []v1.PodIP{{IP: ip}},
 			},
 		}
 		cont.fakePodSource.Add(pod)
@@ -5472,8 +5698,8 @@ func TestNetworkPolicyEgressMultipleNamedPortsUniqueRuleNames(t *testing.T) {
 	cont := initCont()
 	// Add two pods: one with http=80, another with http=8080
 	// This makes the "http" named port resolve to multiple target ports
-	addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports1)
-	addPod(cont, "testns", "pod2", map[string]string{"l1": "v1"}, ports2)
+	addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports1, "1.1.1.1")
+	addPod(cont, "testns", "pod2", map[string]string{"l1": "v1"}, ports2, "2.2.2.2")
 	cont.fakeServiceSource.Add(service)
 	cont.fakeEndpointSliceSource.Add(epSlice)
 	cont.run()
@@ -5662,8 +5888,8 @@ func TestNamedPortMultipleServicesIndex(t *testing.T) {
 		[]discovery.EndpointPort{endpointSlicePort(v1.ProtocolTCP, 8080, "http")},
 		"api-service")
 
-	cont.resolveServiceNamedPortFromEpSlice(epSlice1, svcKey1, false)
-	cont.resolveServiceNamedPortFromEpSlice(epSlice2, svcKey2, false)
+	cont.resolveServiceNamedPortFromEpSlice(nil, epSlice1, svcKey1)
+	cont.resolveServiceNamedPortFromEpSlice(nil, epSlice2, svcKey2)
 
 	// Verify resolved ports
 	cont.indexMutex.Lock()
@@ -5724,40 +5950,51 @@ func TestTargetPortIndexServiceReferenceTracking(t *testing.T) {
 	// Manually update targetPortIndex to track service references
 	cont.indexMutex.Lock()
 	ports := &portIndexEntry{
-		port:              targetPort{ports: make(map[int]bool)},
-		serviceKeys:       make(map[string]bool),
+		portMapping:       targetPort{portServiceMap: make(map[int]map[string]bool)},
 		networkPolicyKeys: make(map[string]bool),
 	}
-	ports.port.ports[80] = true
-	ports.port.ports[8080] = true
-	ports.serviceKeys[svcKey1] = true
-	ports.serviceKeys[svcKey2] = true
+	ports.portMapping.portServiceMap[80] = map[string]bool{svcKey1: true}
+	ports.portMapping.portServiceMap[8080] = map[string]bool{svcKey2: true}
 	cont.targetPortIndex[portKey] = ports
 	cont.indexMutex.Unlock()
 
-	// Verify both services are tracked
+	// Verify both services are tracked — collect all svc keys from portServiceMap.
+	allSvcKeys := func(e *portIndexEntry) map[string]bool {
+		result := make(map[string]bool)
+		for _, svcSet := range e.portMapping.portServiceMap {
+			for k, v := range svcSet {
+				if v {
+					result[k] = true
+				}
+			}
+		}
+		return result
+	}
+
 	cont.indexMutex.Lock()
 	entry := cont.targetPortIndex[portKey]
 	assert.NotNil(t, entry, "targetPortIndex entry should exist")
 	if entry != nil {
-		assert.True(t, entry.serviceKeys[svcKey1], "web-service should be tracked")
-		assert.True(t, entry.serviceKeys[svcKey2], "api-service should be tracked")
-		assert.Equal(t, 2, len(entry.serviceKeys), "Should have 2 service references")
+		svcKeys := allSvcKeys(entry)
+		assert.True(t, svcKeys[svcKey1], "web-service should be tracked")
+		assert.True(t, svcKeys[svcKey2], "api-service should be tracked")
+		assert.Equal(t, 2, len(svcKeys), "Should have 2 service references")
 	}
 	cont.indexMutex.Unlock()
 
 	// Remove one service reference
 	cont.indexMutex.Lock()
-	delete(cont.targetPortIndex[portKey].serviceKeys, svcKey2)
+	cont.targetPortIndex[portKey].removeServiceKey(svcKey2)
 	cont.indexMutex.Unlock()
 
 	// Verify reference is removed
 	cont.indexMutex.Lock()
 	entry = cont.targetPortIndex[portKey]
 	if entry != nil {
-		assert.False(t, entry.serviceKeys[svcKey2], "api-service should be removed")
-		assert.True(t, entry.serviceKeys[svcKey1], "web-service should still be tracked")
-		assert.Equal(t, 1, len(entry.serviceKeys), "Should have 1 service reference")
+		svcKeys := allSvcKeys(entry)
+		assert.False(t, svcKeys[svcKey2], "api-service should be removed")
+		assert.True(t, svcKeys[svcKey1], "web-service should still be tracked")
+		assert.Equal(t, 1, len(svcKeys), "Should have 1 service reference")
 	}
 	cont.indexMutex.Unlock()
 }
@@ -5782,12 +6019,10 @@ func TestTargetPortIndexCleanupOnLastReference(t *testing.T) {
 	// Create targetPortIndex entry with service and netpol references
 	cont.indexMutex.Lock()
 	ports := &portIndexEntry{
-		port:              targetPort{ports: make(map[int]bool)},
-		serviceKeys:       make(map[string]bool),
+		portMapping:       targetPort{portServiceMap: make(map[int]map[string]bool)},
 		networkPolicyKeys: make(map[string]bool),
 	}
-	ports.port.ports[80] = true
-	ports.serviceKeys[svcKey] = true
+	ports.portMapping.portServiceMap[80] = map[string]bool{svcKey: true}
 	ports.networkPolicyKeys[npKey] = true
 	cont.targetPortIndex[portKey] = ports
 	cont.indexMutex.Unlock()
@@ -5796,7 +6031,7 @@ func TestTargetPortIndexCleanupOnLastReference(t *testing.T) {
 	cont.indexMutex.Lock()
 	entry := cont.targetPortIndex[portKey]
 	assert.NotNil(t, entry, "Entry should exist")
-	assert.Equal(t, 1, len(entry.serviceKeys), "Should have 1 service reference")
+	assert.True(t, entry.hasServiceKeys(), "Should have service references")
 	assert.Equal(t, 1, len(entry.networkPolicyKeys), "Should have 1 netpol reference")
 	cont.indexMutex.Unlock()
 
@@ -5810,14 +6045,14 @@ func TestTargetPortIndexCleanupOnLastReference(t *testing.T) {
 	entry = cont.targetPortIndex[portKey]
 	assert.NotNil(t, entry, "Entry should still exist")
 	assert.Equal(t, 0, len(entry.networkPolicyKeys), "Should have 0 netpol references")
-	assert.Equal(t, 1, len(entry.serviceKeys), "Should still have 1 service reference")
+	assert.True(t, entry.hasServiceKeys(), "Should still have service references")
 	cont.indexMutex.Unlock()
 
 	// Remove service reference
 	cont.indexMutex.Lock()
-	delete(cont.targetPortIndex[portKey].serviceKeys, svcKey)
+	cont.targetPortIndex[portKey].removeServiceKey(svcKey)
 	// When all references are gone, entry should be deleted
-	if len(cont.targetPortIndex[portKey].serviceKeys) == 0 &&
+	if !cont.targetPortIndex[portKey].hasServiceKeys() &&
 		len(cont.targetPortIndex[portKey].networkPolicyKeys) == 0 {
 		delete(cont.targetPortIndex, portKey)
 	}
@@ -6017,7 +6252,7 @@ func TestNetworkPolicyNamedPortEndpointSliceLifecycle(t *testing.T) {
 			endpointSlicePort(v1.ProtocolTCP, 80, "http"),
 		},
 		"service1")
-	cont.resolveServiceNamedPortFromEpSlice(epSlice1, svcKey, false)
+	cont.resolveServiceNamedPortFromEpSlice(nil, epSlice1, svcKey)
 
 	// Verify port 80 is now resolved
 	cont.indexMutex.Lock()
@@ -6048,7 +6283,7 @@ func TestNetworkPolicyNamedPortEndpointSliceLifecycle(t *testing.T) {
 			endpointSlicePort(v1.ProtocolTCP, 8080, "http"),
 		},
 		"service1")
-	cont.resolveServiceNamedPortFromEpSlice(epSlice2, svcKey, false)
+	cont.resolveServiceNamedPortFromEpSlice(nil, epSlice2, svcKey)
 
 	// Verify both ports are resolved
 	cont.indexMutex.Lock()
@@ -6063,7 +6298,7 @@ func TestNetworkPolicyNamedPortEndpointSliceLifecycle(t *testing.T) {
 	cont.indexMutex.Unlock()
 
 	// Step 4: Delete first EndpointSlice (old=true removes ports)
-	cont.resolveServiceNamedPortFromEpSlice(epSlice1, svcKey, true)
+	cont.resolveServiceNamedPortFromEpSlice(epSlice1, nil, svcKey)
 
 	// Verify port 80 is removed, 8080 remains
 	cont.indexMutex.Lock()
@@ -6078,7 +6313,7 @@ func TestNetworkPolicyNamedPortEndpointSliceLifecycle(t *testing.T) {
 	cont.indexMutex.Unlock()
 
 	// Step 5: Delete second EndpointSlice
-	cont.resolveServiceNamedPortFromEpSlice(epSlice2, svcKey, true)
+	cont.resolveServiceNamedPortFromEpSlice(epSlice2, nil, svcKey)
 
 	// Verify all ports are removed but entry still exists
 	cont.indexMutex.Lock()
@@ -6235,7 +6470,10 @@ func TestNetworkPolicyNamedPortMultipleEndpoints(t *testing.T) {
 	rule_80.SetAttr("direction", "egress")
 	rule_80.SetAttr("ethertype", "ipv4")
 	rule_80.SetAttr("protocol", "tcp")
-	rule_80.SetAttr("fromPort", "http")
+	rule_80.SetAttr("fromPort", "80")
+	// Per-IP scoping: both pod1 and pod2 define "http"=80 so both IPs appear in the same rule.
+	rule_80.AddChild(apicapi.NewHostprotRemoteIp(rule_80.GetDn(), "1.1.1.1"))
+	rule_80.AddChild(apicapi.NewHostprotRemoteIp(rule_80.GetDn(), "1.1.1.2"))
 
 	rule_svc := apicapi.NewHostprotRule(np1SDnE, "service_tcp_9090-ipv4")
 	rule_svc.SetAttr("direction", "egress")
@@ -6304,7 +6542,7 @@ func TestNetworkPolicyNamedPortMultipleEndpoints(t *testing.T) {
 	}
 
 	addPod := func(cont *testAciController, namespace string,
-		name string, labels map[string]string, ports []v1.ContainerPort) {
+		name string, labels map[string]string, ports []v1.ContainerPort, ip string) {
 		pod := &v1.Pod{
 			Spec: v1.PodSpec{
 				NodeName: "test-node",
@@ -6319,14 +6557,15 @@ func TestNetworkPolicyNamedPortMultipleEndpoints(t *testing.T) {
 				Name:      name,
 				Labels:    labels,
 			},
+			Status: v1.PodStatus{PodIP: ip},
 		}
 		cont.fakePodSource.Add(pod)
 	}
 
 	for ix := range npTests {
 		cont := initCont()
-		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
-		addPod(cont, "testns", "pod2", map[string]string{"l1": "v1"}, ports)
+		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports, "1.1.1.1")
+		addPod(cont, "testns", "pod2", map[string]string{"l1": "v1"}, ports, "1.1.1.2")
 		addServices(cont, npTests[ix].augment)
 		cont.run()
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
@@ -6358,12 +6597,13 @@ func TestNetworkPolicyEgressEmptyToWithNamedPort(t *testing.T) {
 	baseDn := makeNp(nil, nil, name).GetDn()
 	np1SDnE := fmt.Sprintf("%s/subj-networkpolicy-egress", baseDn)
 
-	// Rule for named port "http"
+	// Rule for named port "http" — resolved to numeric 80, scoped to pod IPs that define it.
 	rule_1_0 := apicapi.NewHostprotRule(np1SDnE, "0_0-ipv4__np1")
 	rule_1_0.SetAttr("direction", "egress")
 	rule_1_0.SetAttr("ethertype", "ipv4")
 	rule_1_0.SetAttr("protocol", "tcp")
-	rule_1_0.SetAttr("fromPort", "http")
+	rule_1_0.SetAttr("fromPort", "80")
+	rule_1_0.AddChild(apicapi.NewHostprotRemoteIp(rule_1_0.GetDn(), "1.1.1.1"))
 
 	// Service augmentation rule
 	rule_1_s := apicapi.NewHostprotRule(np1SDnE, "service_tcp_8080-ipv4")
@@ -6424,7 +6664,7 @@ func TestNetworkPolicyEgressEmptyToWithNamedPort(t *testing.T) {
 	}
 
 	addPod := func(cont *testAciController, namespace string,
-		name string, labels map[string]string, ports []v1.ContainerPort) {
+		name string, labels map[string]string, ports []v1.ContainerPort, ip string) {
 		pod := &v1.Pod{
 			Spec: v1.PodSpec{
 				NodeName: "test-node",
@@ -6439,6 +6679,7 @@ func TestNetworkPolicyEgressEmptyToWithNamedPort(t *testing.T) {
 				Name:      name,
 				Labels:    labels,
 			},
+			Status: v1.PodStatus{PodIP: ip},
 		}
 		cont.fakePodSource.Add(pod)
 	}
@@ -6446,7 +6687,7 @@ func TestNetworkPolicyEgressEmptyToWithNamedPort(t *testing.T) {
 	for ix := range npTests {
 		cont := initCont()
 		cont.log.Info("Starting podsfirst ", npTests[ix].desc)
-		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports)
+		addPod(cont, "testns", "pod1", map[string]string{"l1": "v1"}, ports, "1.1.1.1")
 		addServices(cont, npTests[ix].augment)
 		cont.run()
 		cont.fakeNetworkPolicySource.Add(npTests[ix].netPol)
@@ -6674,9 +6915,10 @@ func TestNetworkPolicyIngressMultipleNamedPorts(t *testing.T) {
 }
 
 // TestBuildLocalNetPolSubjRulesEgressNamedPort tests that buildLocalNetPolSubjRules
-// correctly resolves a named egress port to numeric ports in HppDirect mode.
-// The named port "http" is resolved via targetPortIndex to port 80, producing
-// a local HostprotRule with fromPort="80".
+// correctly processes a named egress port in HppDirect mode. Resolution of the
+// named port to a numeric port happens via resolvedPeerPorts (populated by
+// resolveNetPolPeersAndPorts / ctrPortNameCache). This test constructs resolved
+// directly to focus on buildLocalNetPolSubjRules behaviour.
 func TestBuildLocalNetPolSubjRulesEgressNamedPort(t *testing.T) {
 	cont := getContWithEnabledLocalHpp()
 	cont.run()
@@ -6691,26 +6933,19 @@ func TestBuildLocalNetPolSubjRulesEgressNamedPort(t *testing.T) {
 			}, nil),
 		}, allPolicyTypes)
 
-	// Populate targetPortIndex so named port "http" resolves to port 80
-	portkey := "tcp-name-http"
-	cont.indexMutex.Lock()
-	cont.targetPortIndex[portkey] = &portIndexEntry{
-		port: targetPort{
-			proto: "tcp",
-			ports: map[int]bool{80: true},
+	// Simulate the result of resolveNetPolPeersAndPorts for egress no-To with
+	// named port "http" resolved to port 80 (portScoped since IPs are per-pod).
+	resolved := &resolvedPeerPorts{
+		entries: []resolvedPortEntry{
+			{proto: "tcp", fromPort: "80", portScoped: true},
 		},
-		serviceKeys:       make(map[string]bool),
-		networkPolicyKeys: make(map[string]bool),
 	}
-	cont.indexMutex.Unlock()
 
 	subj := &hppv1.HostprotSubj{}
-	cont.buildLocalNetPolSubjRules("0", subj, "egress",
-		nil, nil, np.Spec.Egress[0].Ports, cont.log.WithField("test", "egress-named-port"),
-		"testns/np1", np, nil)
+	cont.buildLocalNetPolSubjRules("0", subj, "egress", resolved, np)
 
 	assert.Equal(t, 1, len(subj.HostprotRule), "Should have 1 rule for resolved named port")
-	assert.Equal(t, "0_0-ipv4", subj.HostprotRule[0].Name)
+	assert.Equal(t, "0_0-ipv4__np1", subj.HostprotRule[0].Name)
 	assert.Equal(t, "egress", subj.HostprotRule[0].Direction)
 	assert.Equal(t, "ipv4", subj.HostprotRule[0].Ethertype)
 	assert.Equal(t, "tcp", subj.HostprotRule[0].Protocol)
@@ -6738,31 +6973,18 @@ func TestBuildLocalNetPolSubjRulesEgressMultipleNamedPorts(t *testing.T) {
 			}, nil),
 		}, allPolicyTypes)
 
-	// "http" resolves to ports 80 and 8080 (two pods with different container ports)
-	cont.indexMutex.Lock()
-	cont.targetPortIndex["tcp-name-http"] = &portIndexEntry{
-		port: targetPort{
-			proto: "tcp",
-			ports: map[int]bool{80: true, 8080: true},
+	// Simulate the result of resolveNetPolPeersAndPorts: "http" resolved to ports
+	// 80 and 8080 (two pods), "https" to port 443. Each entry is portScoped.
+	resolved := &resolvedPeerPorts{
+		entries: []resolvedPortEntry{
+			{proto: "tcp", fromPort: "80", portScoped: true},
+			{proto: "tcp", fromPort: "8080", portScoped: true},
+			{proto: "tcp", fromPort: "443", portScoped: true},
 		},
-		serviceKeys:       make(map[string]bool),
-		networkPolicyKeys: make(map[string]bool),
 	}
-	// "https" resolves to port 443
-	cont.targetPortIndex["tcp-name-https"] = &portIndexEntry{
-		port: targetPort{
-			proto: "tcp",
-			ports: map[int]bool{443: true},
-		},
-		serviceKeys:       make(map[string]bool),
-		networkPolicyKeys: make(map[string]bool),
-	}
-	cont.indexMutex.Unlock()
 
 	subj := &hppv1.HostprotSubj{}
-	cont.buildLocalNetPolSubjRules("0", subj, "egress",
-		nil, nil, np.Spec.Egress[0].Ports, cont.log.WithField("test", "egress-multi-named"),
-		"testns/np1", np, nil)
+	cont.buildLocalNetPolSubjRules("0", subj, "egress", resolved, np)
 
 	// Expect 3 rules: http→80, http→8080, https→443
 	assert.Equal(t, 3, len(subj.HostprotRule),
@@ -6855,18 +7077,28 @@ func TestBuildLocalNetPolSubjRulesIngressNamedPort(t *testing.T) {
 		np.Spec.Ingress[0].From[0].PodSelector,
 	}
 
-	subj := &hppv1.HostprotSubj{}
-	cont.buildLocalNetPolSubjRules("0", subj, "ingress",
-		[]string{"testns"}, peerSelectors, np.Spec.Ingress[0].Ports,
-		cont.log.WithField("test", "ingress-named-port"), npKey, np, nil)
-
-	// Named port "http" should resolve to 8080 from pod's container port
+	// Named port "http" should resolve to 8080 from pod's container port.
 	assert.True(t, portMap[8080], "Port 8080 should be in portMap from pod")
-	if len(subj.HostprotRule) > 0 {
-		assert.Equal(t, "ingress", subj.HostprotRule[0].Direction)
-		assert.Equal(t, "tcp", subj.HostprotRule[0].Protocol)
-		assert.Equal(t, "8080", subj.HostprotRule[0].FromPort)
+
+	// Build resolved directly: port entries from the named-port resolution, peer
+	// metadata set explicitly so buildLocalNetPolSubjRules gets correct ns/selectors.
+	var entries []resolvedPortEntry
+	for portNum := range portMap {
+		entries = append(entries, resolvedPortEntry{proto: "tcp", fromPort: fmt.Sprintf("%d", portNum)})
 	}
+	resolved := &resolvedPeerPorts{
+		entries:      entries,
+		peerNsList:   []string{"testns"},
+		podSelectors: peerSelectors,
+	}
+
+	subj := &hppv1.HostprotSubj{}
+	cont.buildLocalNetPolSubjRules("0", subj, "ingress", resolved, np)
+
+	assert.Equal(t, 1, len(subj.HostprotRule), "Should have exactly 1 rule for named port")
+	assert.Equal(t, "ingress", subj.HostprotRule[0].Direction)
+	assert.Equal(t, "tcp", subj.HostprotRule[0].Protocol)
+	assert.Equal(t, "8080", subj.HostprotRule[0].FromPort)
 }
 
 // TestBuildLocalServiceAugmentNamedPort tests that buildServiceAugment correctly
@@ -6898,23 +7130,15 @@ func TestBuildLocalServiceAugmentNamedPort(t *testing.T) {
 
 	svcKey := "testns/service1"
 
-	// Populate targetPortIndex with named port entry that references the service
+	// Populate targetPortIndex with named port entry that references the service.
+	// portServiceMap must have a non-nil service key set; nil sets are skipped by
+	// getServiceAugmentByPort.
 	cont.indexMutex.Lock()
 	cont.targetPortIndex["tcp-name-http"] = &portIndexEntry{
-		port: targetPort{
-			proto: "tcp",
-			ports: map[int]bool{80: true},
+		portMapping: targetPort{
+			proto:          "tcp",
+			portServiceMap: map[int]map[string]bool{80: {svcKey: true}},
 		},
-		serviceKeys:       map[string]bool{svcKey: true},
-		networkPolicyKeys: make(map[string]bool),
-	}
-	// Also add numeric port entry for the resolved port
-	cont.targetPortIndex["tcp-num-80"] = &portIndexEntry{
-		port: targetPort{
-			proto: "tcp",
-			ports: map[int]bool{80: true},
-		},
-		serviceKeys:       map[string]bool{svcKey: true},
 		networkPolicyKeys: make(map[string]bool),
 	}
 	// Set up namedPortServiceIndex
@@ -6959,4 +7183,533 @@ func TestBuildLocalServiceAugmentNamedPort(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "Should find service augment rule with port 8080")
+}
+
+// TestBuildLocalNetPolSubjRulesEgressIPBlockNamedPort tests that egress rules
+// with IPBlock peers and named ports do NOT include IPBlock CIDRs in port-scoped
+// rules, since named ports cannot be resolved for non-pod destinations.
+func TestBuildLocalNetPolSubjRulesEgressIPBlockNamedPort(t *testing.T) {
+	cont := getContWithEnabledLocalHpp()
+	cont.run()
+	defer cont.stop()
+
+	np := &v1net.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "np1",
+			Namespace: "testns",
+		},
+		Spec: v1net.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+		},
+	}
+
+	// Simulate resolved egress state: one port-scoped entry (from named port)
+	// with pod IPs, plus ipBlockSubs from an IPBlock peer in the same rule.
+	resolved := &resolvedPeerPorts{
+		entries: []resolvedPortEntry{
+			{
+				proto:      "tcp",
+				fromPort:   "80",
+				ips:        []string{"10.0.0.1", "10.0.0.2"},
+				portScoped: true,
+			},
+		},
+		ipBlockSubs: []string{"1.1.1.0/24"},
+		peerNsList:  []string{"testns"},
+		podSelectors: []*metav1.LabelSelector{
+			{MatchLabels: map[string]string{"app": "web"}},
+		},
+	}
+
+	subj := &hppv1.HostprotSubj{}
+	cont.buildLocalNetPolSubjRules("0", subj, "egress", resolved, np)
+
+	// With the new behavior, port-scoped egress rules should NOT include
+	// the IPBlock CIDRs (1.1.1.0/24). Pod-level filtering is handled by
+	// the namespace reference (RsRemoteIpContainer) and pod selectors.
+	assert.Equal(t, 1, len(subj.HostprotRule), "Should have 1 rule")
+	rule := subj.HostprotRule[0]
+	assert.Equal(t, "egress", rule.Direction)
+	assert.Equal(t, "tcp", rule.Protocol)
+	assert.Equal(t, "80", rule.FromPort)
+
+	// IPBlock CIDRs should NOT be in HostprotRemoteIp
+	for _, rip := range rule.HostprotRemoteIp {
+		assert.NotEqual(t, "1.1.1.0/24", rip.Addr,
+			"IPBlock CIDR should NOT be in egress port-scoped rule")
+	}
+
+	// Namespace-based peer filtering should still be active
+	assert.Equal(t, []string{"testns"}, rule.RsRemoteIpContainer,
+		"Namespace reference should still be present for pod peers")
+
+	// Pod selector filtering should still be active
+	assert.Equal(t, 1, len(rule.HostprotFilterContainer),
+		"Pod selector filter should still be present")
+}
+
+// TestNetworkPolicyIngressNamedPortEmptySelector verifies that when a
+// NetworkPolicy has an empty PodSelector (applying to all pods in the
+// namespace) and an ingress rule with a named port, the named port is
+// resolved via getNamedPortNumsForNs (which uses ctrPortNameCache) rather
+// than the per-pod netPolPods lookup path used when a PodSelector is set.
+//
+// This covers the branch at network_policy.go:1242:
+//
+//	if reflect.DeepEqual(np.Spec.PodSelector, metav1.LabelSelector{}) {
+//	    portMap = cont.getNamedPortNumsForNs(portName, namespace)
+func TestNetworkPolicyIngressNamedPortEmptySelector(t *testing.T) {
+	// NP applies to ALL pods in "testns" (empty PodSelector).
+	// Ingress allows traffic on the named port "http" from any source.
+	test_np := netpol("testns", "np1", &metav1.LabelSelector{},
+		[]v1net.NetworkPolicyIngressRule{
+			{
+				Ports: []v1net.NetworkPolicyPort{
+					{Protocol: func() *v1.Protocol { a := v1.ProtocolTCP; return &a }(),
+						Port: &intstr.IntOrString{Type: intstr.String, StrVal: "http"},
+					},
+				},
+				// No From clause → allow ingress from all peers.
+			},
+		}, nil, allPolicyTypes)
+
+	name := "kube_np_testns_np1"
+	baseDn := makeNp(nil, nil, name).GetDn()
+	np1SDnI := fmt.Sprintf("%s/subj-networkpolicy-ingress", baseDn)
+
+	// Expected rule: named port "http" resolves to 8080 via ctrPortNameCache.
+	rule_http_8080 := apicapi.NewHostprotRule(np1SDnI, "0_0-ipv4__np1")
+	rule_http_8080.SetAttr("direction", "ingress")
+	rule_http_8080.SetAttr("ethertype", "ipv4")
+	rule_http_8080.SetAttr("protocol", "tcp")
+	rule_http_8080.SetAttr("fromPort", "8080")
+
+	initCont := func() *testAciController {
+		cont := testController()
+		cont.config.AciPolicyTenant = "test-tenant"
+		cont.config.NodeServiceIpPool = []ipam.IpRange{
+			{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.1.3")},
+		}
+		cont.config.PodIpPool = []ipam.IpRange{
+			{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.255.254")},
+		}
+		cont.AciController.initIpam()
+		cont.fakeNamespaceSource.Add(namespaceLabel("testns",
+			map[string]string{"test": "testv"}))
+		return cont
+	}
+
+	// A pod in "testns" that exposes the named port "http" on 8080.
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			NodeName: "test-node",
+			Containers: []v1.Container{
+				{
+					Ports: []v1.ContainerPort{
+						{Name: "http", ContainerPort: 8080, Protocol: v1.ProtocolTCP},
+					},
+				},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns",
+			Name:      "target-pod",
+			Labels:    map[string]string{"app": "target"},
+		},
+		Status: v1.PodStatus{PodIP: "1.1.1.2"},
+	}
+
+	// Verify that the NP rule with fromPort="8080" eventually appears.
+	// updateCtrNmPortForPod runs as a goroutine so we rely on the re-queue
+	// it triggers (nmPortNp re-queues the NP once the cache is populated).
+	cont := initCont()
+	cont.fakePodSource.Add(pod)
+	cont.run()
+	cont.fakeNetworkPolicySource.Add(test_np)
+
+	key := cont.aciNameForKey("np", "testns/np1")
+	tu.WaitFor(t, "ingress-named-port-empty-selector", 3500*time.Millisecond,
+		func(last bool) (bool, error) {
+			desiredState := cont.apicConn.GetDesiredState(key)
+			if len(desiredState) == 0 {
+				return false, nil
+			}
+			for _, obj := range desiredState {
+				hpp, ok := obj["hostprotPol"]
+				if !ok || hpp == nil {
+					continue
+				}
+				for _, child := range hpp.Children {
+					subj, ok := child["hostprotSubj"]
+					if !ok || subj == nil {
+						continue
+					}
+					if subj.Attributes["name"] != "networkpolicy-ingress" {
+						continue
+					}
+					for _, rc := range subj.Children {
+						rule, ok := rc["hostprotRule"]
+						if !ok || rule == nil {
+							continue
+						}
+						if rule.Attributes["fromPort"] == "8080" {
+							return true, nil
+						}
+					}
+				}
+			}
+			if last {
+				t.Logf("ingress-named-port-empty-selector: desiredState=%v", desiredState)
+			}
+			return false, nil
+		})
+
+	// Verify the HPP disappears when the NP is deleted.
+	cont.fakeNetworkPolicySource.Delete(test_np)
+	tu.WaitFor(t, "ingress-named-port-empty-selector-delete", 1*time.Second,
+		func(last bool) (bool, error) {
+			return len(cont.apicConn.GetDesiredState(key)) == 0, nil
+		})
+
+	cont.stop()
+}
+
+// TestGetNamedPortNumsForNs exercises getNamedPortNumsForNs directly,
+// covering namespace-scoped lookups into ctrPortNameCache, including
+// the case where the port does not exist in the cache, a pod in a
+// different namespace is skipped, and multiple pods contribute distinct
+// port numbers for the same named port.
+func TestGetNamedPortNumsForNs(t *testing.T) {
+	cont := testController()
+	cont.config.AciPolicyTenant = "test-tenant"
+
+	// Helper to add a pod to ctrPortNameCache as updateCtrNmPortForPod would.
+	addPodToCache := func(namespace, name string, portName string, portNum int) {
+		pod := &v1.Pod{
+			Spec: v1.PodSpec{
+				NodeName: "test-node",
+				Containers: []v1.Container{
+					{
+						Ports: []v1.ContainerPort{
+							{Name: portName, ContainerPort: int32(portNum), Protocol: v1.ProtocolTCP},
+						},
+					},
+				},
+			},
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+			Status:     v1.PodStatus{PodIP: "1.1.1.1"},
+		}
+		podkey := namespace + "/" + name
+		cont.podIndexer.Add(pod)
+		// Populate ctrPortNameCache synchronously (bypasses the goroutine).
+		cont.updateCtrNmPortForPod(pod, podkey)
+	}
+
+	// Case 1: cache is empty — should return empty map.
+	result := cont.getNamedPortNumsForNs("http", "testns")
+	if len(result) != 0 {
+		t.Errorf("expected empty map for unknown port name, got %v", result)
+	}
+
+	// Case 2: one pod in "testns" with "http"=8080.
+	addPodToCache("testns", "pod1", "http", 8080)
+	result = cont.getNamedPortNumsForNs("http", "testns")
+	if !result[8080] {
+		t.Errorf("expected port 8080 in result, got %v", result)
+	}
+
+	// Case 3: a pod in a different namespace should NOT contribute.
+	addPodToCache("otherNS", "pod2", "http", 9090)
+	result = cont.getNamedPortNumsForNs("http", "testns")
+	if result[9090] {
+		t.Errorf("pod in otherNS should not affect testns lookup, got %v", result)
+	}
+	if !result[8080] {
+		t.Errorf("pod in testns should still be present, got %v", result)
+	}
+
+	// Case 4: a second pod in "testns" with the same named port but a
+	// different number — both should appear (over-permissive warning path).
+	addPodToCache("testns", "pod3", "http", 80)
+	result = cont.getNamedPortNumsForNs("http", "testns")
+	if !result[8080] || !result[80] {
+		t.Errorf("expected both port 80 and 8080 in testns result, got %v", result)
+	}
+	// otherNS port should still be absent.
+	if result[9090] {
+		t.Errorf("otherNS port should not appear in testns result, got %v", result)
+	}
+}
+
+// TestGetServiceAugmentByPortRange exercises the port-range paths of
+// getServiceAugmentByPort that were previously uncovered.
+// The function has an early-exit when `cont.targetPortIndex[portkey]` is nil,
+// so the start port must exist in the index for the range code to execute.
+func TestGetServiceAugmentByPortRange(t *testing.T) {
+	logger := logrus.New().WithField("test", "TestGetServiceAugmentByPortRange")
+	proto := v1.ProtocolTCP
+
+	// Sub-test: rangeSize < len(targetPortIndex) → iterate port numbers one by one
+	t.Run("RangeSmall_iteratesPortNumbers", func(t *testing.T) {
+		cont := getContWithEnabledLocalHpp()
+		cont.run()
+		defer cont.stop()
+
+		serviceKey := "testns/svc-range-small"
+		svc := npservice("testns", "svc-range-small", "10.96.1.10",
+			[]v1.ServicePort{
+				servicePort("p8080", v1.ProtocolTCP, 8080, 8080),
+			})
+		cont.fakeServiceSource.Add(svc)
+		time.Sleep(500 * time.Millisecond)
+
+		// Range [8080, 8082] → rangeSize = 3.
+		// We set 5 entries in the index so rangeSize (3) < len(index) (5).
+		cont.indexMutex.Lock()
+		for _, p := range []int{8080, 9000, 9001, 9002, 9003} {
+			key := fmt.Sprintf("tcp-num-%d", p)
+			svcKeys := map[string]bool{}
+			if p == 8080 {
+				svcKeys = map[string]bool{serviceKey: true}
+			}
+			cont.targetPortIndex[key] = &portIndexEntry{
+				portMapping: targetPort{
+					proto:          v1.ProtocolTCP,
+					portServiceMap: map[int]map[string]bool{p: svcKeys},
+				},
+			}
+		}
+		cont.indexMutex.Unlock()
+
+		endPort := int32(8082)
+		prs := &portRemoteSubnet{
+			port: &v1net.NetworkPolicyPort{
+				Protocol: &proto,
+				Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				EndPort:  &endPort,
+			},
+			subnetMap: map[string]bool{"0.0.0.0/0": true},
+		}
+		portAugments := make(map[string]*portServiceAugment)
+		cont.getServiceAugmentByPort(prs, portAugments, logger)
+
+		_, has8080 := portAugments[protoPortKey("tcp", "8080")]
+		assert.True(t, has8080, "port 8080 in range [8080,8082] should be augmented via iterate-by-range path")
+
+		cont.indexMutex.Lock()
+		for _, p := range []int{8080, 9000, 9001, 9002, 9003} {
+			delete(cont.targetPortIndex, fmt.Sprintf("tcp-num-%d", p))
+		}
+		cont.indexMutex.Unlock()
+	})
+
+	// Sub-test: rangeSize >= len(targetPortIndex) → iterate index entries
+	t.Run("RangeLarge_iteratesIndex", func(t *testing.T) {
+		cont := getContWithEnabledLocalHpp()
+		cont.run()
+		defer cont.stop()
+
+		serviceKey := "testns/svc-range-large"
+		svc := npservice("testns", "svc-range-large", "10.96.1.11",
+			[]v1.ServicePort{
+				servicePort("p8080", v1.ProtocolTCP, 8080, 8080),
+			})
+		cont.fakeServiceSource.Add(svc)
+		time.Sleep(500 * time.Millisecond)
+
+		// Range [8080, 8090] → rangeSize = 11.
+		// Only one entry in index → rangeSize (11) >= len(1) → iterate index.
+		cont.indexMutex.Lock()
+		cont.targetPortIndex = map[string]*portIndexEntry{
+			"tcp-num-8080": {
+				portMapping: targetPort{
+					proto:          v1.ProtocolTCP,
+					portServiceMap: map[int]map[string]bool{8080: {serviceKey: true}},
+				},
+			},
+		}
+		cont.indexMutex.Unlock()
+
+		endPort := int32(8090)
+		prs := &portRemoteSubnet{
+			port: &v1net.NetworkPolicyPort{
+				Protocol: &proto,
+				Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 8080},
+				EndPort:  &endPort,
+			},
+			subnetMap: map[string]bool{"0.0.0.0/0": true},
+		}
+		portAugments := make(map[string]*portServiceAugment)
+		cont.getServiceAugmentByPort(prs, portAugments, logger)
+
+		_, has8080 := portAugments[protoPortKey("tcp", "8080")]
+		assert.True(t, has8080, "port 8080 should be augmented via iterate-index range path")
+
+		cont.indexMutex.Lock()
+		delete(cont.targetPortIndex, "tcp-num-8080")
+		cont.indexMutex.Unlock()
+	})
+
+	// Sub-test: namedPortServiceIndex multi-resolution, all resolved ports in range
+	t.Run("RangeWithNamedPortMultiResolution_allInRange", func(t *testing.T) {
+		cont := getContWithEnabledLocalHpp()
+		cont.run()
+		defer cont.stop()
+
+		serviceKey := "testns/svc-named-multi"
+		svc := npservice("testns", "svc-named-multi", "10.96.1.12",
+			[]v1.ServicePort{
+				servicePortNamed("p-svc", v1.ProtocolTCP, 8100, "multi"),
+			})
+		cont.fakeServiceSource.Add(svc)
+		time.Sleep(500 * time.Millisecond)
+
+		// Range [8100, 8201]; start port entry must exist to pass nil check.
+		// Named port "multi" resolves to two numeric ports (8100 and 8200) — both in range.
+		cont.indexMutex.Lock()
+		cont.targetPortIndex["tcp-num-8100"] = &portIndexEntry{
+			portMapping: targetPort{
+				proto:          v1.ProtocolTCP,
+				portServiceMap: map[int]map[string]bool{8100: {}},
+			},
+		}
+		cont.namedPortServiceIndex[serviceKey] = &namedPortServiceIndexEntry{
+			"p-svc": &namedPortServiceIndexPort{
+				targetPortName: "multi",
+				resolvedPorts:  map[int]bool{8100: true, 8200: true},
+			},
+		}
+		cont.indexMutex.Unlock()
+
+		endPort := int32(8201)
+		prs := &portRemoteSubnet{
+			port: &v1net.NetworkPolicyPort{
+				Protocol: &proto,
+				Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 8100},
+				EndPort:  &endPort,
+			},
+			subnetMap: map[string]bool{"0.0.0.0/0": true},
+		}
+		portAugments := make(map[string]*portServiceAugment)
+		cont.getServiceAugmentByPort(prs, portAugments, logger)
+
+		_, hasMulti := portAugments[protoPortKey("tcp", "8100")]
+		assert.True(t, hasMulti, "multi-resolution named port all-in-range should produce a service augment entry")
+
+		cont.indexMutex.Lock()
+		delete(cont.namedPortServiceIndex, serviceKey)
+		delete(cont.targetPortIndex, "tcp-num-8100")
+		cont.indexMutex.Unlock()
+	})
+}
+
+// TestGetServiceAugmentByPortNumeric exercises the single numeric port path
+// (the else-if branch at the end of getServiceAugmentByPort).
+func TestGetServiceAugmentByPortNumeric(t *testing.T) {
+	logger := logrus.New().WithField("test", "TestGetServiceAugmentByPortNumeric")
+	proto := v1.ProtocolTCP
+
+	cont := getContWithEnabledLocalHpp()
+	cont.run()
+	defer cont.stop()
+
+	serviceKey := "testns/svc-num"
+	svc := npservice("testns", "svc-num", "10.96.2.1",
+		[]v1.ServicePort{
+			servicePort("p7070", v1.ProtocolTCP, 7070, 7070),
+		})
+	cont.fakeServiceSource.Add(svc)
+	time.Sleep(500 * time.Millisecond)
+
+	cont.indexMutex.Lock()
+	cont.targetPortIndex["tcp-num-7070"] = &portIndexEntry{
+		portMapping: targetPort{
+			proto:          v1.ProtocolTCP,
+			portServiceMap: map[int]map[string]bool{7070: {serviceKey: true}},
+		},
+	}
+	cont.indexMutex.Unlock()
+
+	prs := &portRemoteSubnet{
+		port: &v1net.NetworkPolicyPort{
+			Protocol: &proto,
+			Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 7070},
+		},
+		subnetMap: map[string]bool{"0.0.0.0/0": true},
+	}
+	portAugments := make(map[string]*portServiceAugment)
+	cont.getServiceAugmentByPort(prs, portAugments, logger)
+
+	_, has7070 := portAugments[protoPortKey("tcp", "7070")]
+	assert.True(t, has7070, "numeric port 7070 should be augmented via single-port path")
+
+	cont.indexMutex.Lock()
+	delete(cont.targetPortIndex, "tcp-num-7070")
+	cont.indexMutex.Unlock()
+}
+
+// TestNetworkPolicyChangedHppOptimization exercises the HppOptimization and
+// EnableHppDirect branches of networkPolicyChanged that were previously uncovered.
+func TestNetworkPolicyChangedHppOptimization(t *testing.T) {
+	t.Run("HppOptimization_specChange_callsRemoveFromHppCache", func(t *testing.T) {
+		cont := testController()
+		cont.config.HppOptimization = true
+		cont.run()
+		defer cont.stop()
+
+		np := netpol("testns", "np-hpp", &metav1.LabelSelector{},
+			[]v1net.NetworkPolicyIngressRule{
+				ingressRule([]v1net.NetworkPolicyPort{port(&tcp, &port80)}, nil),
+			},
+			nil, allPolicyTypes)
+		cont.fakeNetworkPolicySource.Add(np)
+		time.Sleep(300 * time.Millisecond)
+
+		npNew := np.DeepCopy()
+		npNew.Spec.Ingress = []v1net.NetworkPolicyIngressRule{
+			ingressRule([]v1net.NetworkPolicyPort{port(&tcp, &port443)}, nil),
+		}
+
+		// Exercises the HppOptimization && spec-changed path (calls removeFromHppCache).
+		cont.networkPolicyChanged(np, npNew)
+	})
+
+	t.Run("EnableHppDirect_specChange_callsDeleteHppCr", func(t *testing.T) {
+		cont := getContWithEnabledLocalHpp()
+		cont.run()
+		defer cont.stop()
+
+		np := netpol("testns", "np-hppd", &metav1.LabelSelector{},
+			[]v1net.NetworkPolicyIngressRule{
+				ingressRule([]v1net.NetworkPolicyPort{port(&tcp, &port80)}, nil),
+			},
+			nil, allPolicyTypes)
+		cont.fakeNetworkPolicySource.Add(np)
+		time.Sleep(300 * time.Millisecond)
+
+		npNew := np.DeepCopy()
+		npNew.Spec.Ingress = []v1net.NetworkPolicyIngressRule{
+			ingressRule([]v1net.NetworkPolicyPort{port(&tcp, &port443)}, nil),
+		}
+
+		// Exercises EnableHppDirect && spec-changed path (calls removeFromHppCache + deleteHppCr).
+		cont.networkPolicyChanged(np, npNew)
+	})
+
+	t.Run("PolicyTypesChange_queues_podUpdates", func(t *testing.T) {
+		cont := testController()
+		cont.run()
+		defer cont.stop()
+
+		np := netpol("testns", "np-ptypes", &metav1.LabelSelector{},
+			nil, nil, []v1net.PolicyType{v1net.PolicyTypeIngress})
+		cont.fakeNetworkPolicySource.Add(np)
+		time.Sleep(300 * time.Millisecond)
+
+		npNew := np.DeepCopy()
+		npNew.Spec.PolicyTypes = allPolicyTypes
+
+		// Exercises the PolicyTypes diff path (enqueues subject pods).
+		cont.networkPolicyChanged(np, npNew)
+	})
 }

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -1225,7 +1225,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		nil, allPolicyTypes)
 	hash, _ := util.CreateHashFromNetPol(test0_np)
 	test0_np_name := "kube_np_" + hash
-	test0_rule := createRule(test0_np_name, true, rule_0, "0-ipv4__np1")
+	test0_rule := createRule(test0_np_name, true, rule_0, "0-ipv4__unspecified")
 
 	//allow-http
 	test1_np := netpol("testns", "np1", &metav1.LabelSelector{},
@@ -1234,7 +1234,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 				nil)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test1_np)
 	test1_np_name := "kube_np_" + hash
-	test1_rule := createRule(test1_np_name, true, rule_1, "0_0-ipv4__np1")
+	test1_rule := createRule(test1_np_name, true, rule_1, "0-ipv4__tcp-80")
 
 	//allow-http-from
 	test2_np := netpol("testns", "np1", &metav1.LabelSelector{},
@@ -1247,7 +1247,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 			)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test2_np)
 	test2_np_name := "kube_np_" + hash
-	test2_rule := createRule(test2_np_name, true, rule_1, "0_0-ipv4__np1")
+	test2_rule := createRule(test2_np_name, true, rule_1, "0-ipv4__tcp-80")
 	test2_rule.AddChild(
 		apicapi.NewHostprotRemoteIp(test2_rule.GetDn(), "8.8.8.0/29"))
 	test2_rule.AddChild(
@@ -1270,7 +1270,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 				port(nil, &port80)}, nil)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test3_np)
 	test3_np_name := "kube_np_" + hash
-	test3_rule := createRule(test3_np_name, true, rule_1, "0_0-ipv4__np1")
+	test3_rule := createRule(test3_np_name, true, rule_1, "0-ipv4__tcp-80")
 
 	//allow-80-udp
 	test4_np := netpol("testns", "np1", &metav1.LabelSelector{},
@@ -1279,7 +1279,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 				port(&udp, &port80)}, nil)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test4_np)
 	test4_np_name := "kube_np_" + hash
-	test4_rule := createRule(test4_np_name, true, rule_2, "0_0-ipv4__np1")
+	test4_rule := createRule(test4_np_name, true, rule_2, "0-ipv4__udp-80")
 
 	//allow-80-sctp
 	test5_np := netpol("testns", "np1", &metav1.LabelSelector{},
@@ -1288,7 +1288,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 				port(&sctp, &port80)}, nil)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test5_np)
 	test5_np_name := "kube_np_" + hash
-	test5_rule := createRule(test5_np_name, true, rule_4, "0_0-ipv4__np1")
+	test5_rule := createRule(test5_np_name, true, rule_4, "0-ipv4__sctp-80")
 
 	//allow-http-https
 	test6_np := netpol("testns", "np1", &metav1.LabelSelector{},
@@ -1298,8 +1298,8 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 			}, nil)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test6_np)
 	test6_np_name := "kube_np_" + hash
-	test6_rule1 := createRule(test6_np_name, true, rule_1, "0_0-ipv4__np1")
-	test6_rule2 := createRule(test6_np_name, true, rule_3, "0_1-ipv4__np1")
+	test6_rule1 := createRule(test6_np_name, true, rule_1, "0-ipv4__tcp-80")
+	test6_rule2 := createRule(test6_np_name, true, rule_3, "0-ipv4__tcp-443")
 
 	//allow-all-from-ns
 	test7_np := netpol("testns", "np1", &metav1.LabelSelector{},
@@ -1312,7 +1312,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test7_np)
 	test7_np_name := "kube_np_" + hash
-	test7_rule := createRule(test7_np_name, true, rule_0, "0-ipv4__np1")
+	test7_rule := createRule(test7_np_name, true, rule_0, "0-ipv4__unspecified")
 	test7_rule.AddChild(apicapi.NewHostprotRemoteIp(test7_rule.GetDn(), "1.1.1.1"))
 	test7_rule.AddChild(apicapi.NewHostprotRemoteIp(test7_rule.GetDn(), "1.1.1.2"))
 
@@ -1339,7 +1339,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test9_np)
 	test9_np_name := "kube_np_" + hash
-	test9_rule := createRule(test9_np_name, true, rule_0, "0-ipv4__np1")
+	test9_rule := createRule(test9_np_name, true, rule_0, "0-ipv4__unspecified")
 	test9_rule.AddChild(apicapi.NewHostprotRemoteIp(test9_rule.GetDn(), "1.1.1.3"))
 	test9_rule.AddChild(apicapi.NewHostprotRemoteIp(test9_rule.GetDn(), "1.1.1.4"))
 	test9_rule.AddChild(apicapi.NewHostprotRemoteIp(test9_rule.GetDn(), "1.1.1.5"))
@@ -1355,7 +1355,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test10_np)
 	test10_np_name := "kube_np_" + hash
-	test10_rule := createRule(test10_np_name, true, rule_0, "0-ipv4__np1")
+	test10_rule := createRule(test10_np_name, true, rule_0, "0-ipv4__unspecified")
 	test10_rule.AddChild(apicapi.NewHostprotRemoteIp(test10_rule.GetDn(), "1.1.1.1"))
 
 	//allow-all-select-pods-and-ns
@@ -1371,7 +1371,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test11_np)
 	test11_np_name := "kube_np_" + hash
-	test11_rule := createRule(test11_np_name, true, rule_0, "0-ipv4__np1")
+	test11_rule := createRule(test11_np_name, true, rule_0, "0-ipv4__unspecified")
 	test11_rule.AddChild(apicapi.NewHostprotRemoteIp(test11_rule.GetDn(), "1.1.1.3"))
 	test11_rule.AddChild(apicapi.NewHostprotRemoteIp(test11_rule.GetDn(), "1.1.1.5"))
 
@@ -1395,9 +1395,9 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test12_np)
 	test12_np_name := "kube_np_" + hash
-	test12_rule1 := createRule(test12_np_name, true, rule_1, "0_0-ipv4__np1")
+	test12_rule1 := createRule(test12_np_name, true, rule_1, "0-ipv4__tcp-80")
 	test12_rule1.AddChild(apicapi.NewHostprotRemoteIp(test12_rule1.GetDn(), "1.1.1.1"))
-	test12_rule2 := createRule(test12_np_name, true, rule_3, "1_0-ipv4__np1")
+	test12_rule2 := createRule(test12_np_name, true, rule_3, "1-ipv4__tcp-443")
 	test12_rule2.AddChild(apicapi.NewHostprotRemoteIp(test12_rule2.GetDn(), "1.1.1.2"))
 
 	//multiple-from-name
@@ -1422,9 +1422,9 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test13_np)
 	test13_np_name := "kube_np_" + hash
-	test13_rule1 := createRule(test13_np_name, true, rule_1, "0_0-ipv4__np1")
+	test13_rule1 := createRule(test13_np_name, true, rule_1, "0-ipv4__tcp-80")
 	test13_rule1.AddChild(apicapi.NewHostprotRemoteIp(test13_rule1.GetDn(), "1.1.1.1"))
-	test13_rule2 := createRule(test13_np_name, true, rule_3, "1_0-ipv4__np1")
+	test13_rule2 := createRule(test13_np_name, true, rule_3, "1-ipv4__tcp-443")
 	test13_rule2.AddChild(apicapi.NewHostprotRemoteIp(test13_rule2.GetDn(), "1.1.1.2"))
 
 	//egress-allow-all-select-pods-and-ns
@@ -1441,7 +1441,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test14_np)
 	test14_np_name := "kube_np_" + hash
-	test14_rule := createRule(test14_np_name, false, rule_5, "0-ipv4__np1")
+	test14_rule := createRule(test14_np_name, false, rule_5, "0-ipv4__unspecified")
 	test14_rule.AddChild(apicapi.NewHostprotRemoteIp(test14_rule.GetDn(), "1.1.1.3"))
 	test14_rule.AddChild(apicapi.NewHostprotRemoteIp(test14_rule.GetDn(), "1.1.1.5"))
 
@@ -1457,7 +1457,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test15_np)
 	test15_np_name := "kube_np_" + hash
-	test15_rule := createRule(test15_np_name, false, rule_6, "0_0-ipv4__np1")
+	test15_rule := createRule(test15_np_name, false, rule_6, "0-ipv4__tcp-80")
 	test15_rule.AddChild(apicapi.NewHostprotRemoteIp(test15_rule.GetDn(), "1.1.1.1"))
 
 	//egress-allow-http-augment
@@ -1472,7 +1472,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test16_np)
 	test16_np_name := "kube_np_" + hash
-	test16_rule1 := createRule(test16_np_name, false, rule_6, "0_0-ipv4__np1")
+	test16_rule1 := createRule(test16_np_name, false, rule_6, "0-ipv4__tcp-80")
 	test16_rule1.AddChild(apicapi.NewHostprotRemoteIp(test16_rule1.GetDn(), "1.1.1.1"))
 	test16_rule2 := createRule(test16_np_name, false, rule_7, "service_tcp_8080-ipv4")
 	test16_rule2.AddChild(apicapi.NewHostprotRemoteIp(test16_rule2.GetDn(), "9.0.0.42"))
@@ -1493,7 +1493,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test17_np)
 	test17_np_name := "kube_np_" + hash
-	test17_rule1 := createRule(test17_np_name, false, rule_6, "0_0-ipv4__np1")
+	test17_rule1 := createRule(test17_np_name, false, rule_6, "0-ipv4__tcp-80")
 	test17_rule1.AddChild(apicapi.NewHostprotRemoteIp(test17_rule1.GetDn(), "1.1.1.1"))
 	test17_rule2 := createRule(test17_np_name, false, rule_7, "service_tcp_8080-ipv4")
 	test17_rule2.AddChild(apicapi.NewHostprotRemoteIp(test17_rule2.GetDn(), "9.0.0.42"))
@@ -1506,7 +1506,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test18_np)
 	test18_np_name := "kube_np_" + hash
-	test18_rule1 := createRule(test18_np_name, false, rule_6, "0_0-ipv4__np1")
+	test18_rule1 := createRule(test18_np_name, false, rule_6, "0-ipv4__tcp-80")
 	test18_rule2 := createRule(test18_np_name, false, rule_7, "service_tcp_8080-ipv4")
 	test18_rule2.AddChild(apicapi.NewHostprotRemoteIp(test18_rule2.GetDn(), "9.0.0.42"))
 
@@ -1520,7 +1520,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test19_np)
 	test19_np_name := "kube_np_" + hash
-	test19_rule1 := createRule(test19_np_name, false, rule_5, "0-ipv4__np1")
+	test19_rule1 := createRule(test19_np_name, false, rule_5, "0-ipv4__unspecified")
 	test19_rule1.AddChild(apicapi.NewHostprotRemoteIp(test19_rule1.GetDn(), "1.1.1.0/24"))
 	test19_rule2 := createRule(test19_np_name, false, rule_7, "service_tcp_8080-ipv4")
 	test19_rule2.AddChild(apicapi.NewHostprotRemoteIp(test19_rule2.GetDn(), "9.0.0.44"))
@@ -1534,7 +1534,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test20_np)
 	test20_np_name := "kube_np_" + hash
-	test20_rule := createRule(test20_np_name, false, rule_5, "0-ipv4__np1")
+	test20_rule := createRule(test20_np_name, false, rule_5, "0-ipv4__unspecified")
 
 	//egress-allow-http-portrange
 	test21_np := netpol("testns", "np1", &metav1.LabelSelector{},
@@ -1548,7 +1548,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test21_np)
 	test21_np_name := "kube_np_" + hash
-	test21_rule := createRule(test21_np_name, false, rule_9, "0_0-ipv4__np1")
+	test21_rule := createRule(test21_np_name, false, rule_9, "0-ipv4__tcp-80")
 	test21_rule.AddChild(apicapi.NewHostprotRemoteIp(test21_rule.GetDn(), "1.1.1.1"))
 
 	//egress-allow-http-portrange-augment
@@ -1563,7 +1563,7 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test22_np)
 	test22_np_name := "kube_np_" + hash
-	test22_rule1 := createRule(test22_np_name, false, rule_9, "0_0-ipv4__np1")
+	test22_rule1 := createRule(test22_np_name, false, rule_9, "0-ipv4__tcp-80")
 	test22_rule1.AddChild(apicapi.NewHostprotRemoteIp(test22_rule1.GetDn(), "1.1.1.1"))
 	test22_rule2 := createRule(test22_np_name, false, rule_7, "service_tcp_8080-ipv4")
 	test22_rule2.AddChild(apicapi.NewHostprotRemoteIp(test22_rule2.GetDn(), "9.0.0.42"))
@@ -2569,7 +2569,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		nil, allPolicyTypes)
 	hash, _ := util.CreateHashFromNetPol(test0_np_v6)
 	test0_np_name_v6 := "kube_np_" + hash
-	test0_rule_v6 := createRule(test0_np_name_v6, true, rule_0_v6, "0-ipv6__npv6")
+	test0_rule_v6 := createRule(test0_np_name_v6, true, rule_0_v6, "0-ipv6__unspecified")
 
 	//allow-http
 	test1_np_v6 := netpol("testnsv6", "npv6", &metav1.LabelSelector{},
@@ -2578,7 +2578,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 				nil)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test1_np_v6)
 	test1_np_name_v6 := "kube_np_" + hash
-	test1_rule_v6 := createRule(test1_np_name_v6, true, rule_1_v6, "0_0-ipv6__npv6")
+	test1_rule_v6 := createRule(test1_np_name_v6, true, rule_1_v6, "0-ipv6__tcp-80")
 
 	//allow-http-from
 	test2_np_v6 := netpol("testnsv6", "npv6", &metav1.LabelSelector{},
@@ -2590,7 +2590,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 			)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test2_np_v6)
 	test2_np_name_v6 := "kube_np_" + hash
-	test2_rule_v6 := createRule(test2_np_name_v6, true, rule_1_v6, "0_0-ipv6__npv6")
+	test2_rule_v6 := createRule(test2_np_name_v6, true, rule_1_v6, "0-ipv6__tcp-80")
 	test2_rule_v6.AddChild(
 		apicapi.NewHostprotRemoteIp(test2_rule_v6.GetDn(), "2001:db8::/128"))
 	test2_rule_v6.AddChild(
@@ -2605,7 +2605,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 				port(nil, &port80)}, nil)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test3_np_v6)
 	test3_np_name_v6 := "kube_np_" + hash
-	test3_rule_v6 := createRule(test3_np_name_v6, true, rule_1_v6, "0_0-ipv6__npv6")
+	test3_rule_v6 := createRule(test3_np_name_v6, true, rule_1_v6, "0-ipv6__tcp-80")
 
 	//allow-80-udp
 	test4_np_v6 := netpol("testnsv6", "npv6", &metav1.LabelSelector{},
@@ -2614,7 +2614,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 				port(&udp, &port80)}, nil)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test4_np_v6)
 	test4_np_name_v6 := "kube_np_" + hash
-	test4_rule_v6 := createRule(test4_np_name_v6, true, rule_2_v6, "0_0-ipv6__npv6")
+	test4_rule_v6 := createRule(test4_np_name_v6, true, rule_2_v6, "0-ipv6__udp-80")
 
 	//allow-http-https
 	test5_np_v6 := netpol("testnsv6", "npv6", &metav1.LabelSelector{},
@@ -2624,8 +2624,8 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 			}, nil)}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test5_np_v6)
 	test5_np_name_v6 := "kube_np_" + hash
-	test5_rule1_v6 := createRule(test5_np_name_v6, true, rule_1_v6, "0_0-ipv6__npv6")
-	test5_rule2_v6 := createRule(test5_np_name_v6, true, rule_3_v6, "0_1-ipv6__npv6")
+	test5_rule1_v6 := createRule(test5_np_name_v6, true, rule_1_v6, "0-ipv6__tcp-80")
+	test5_rule2_v6 := createRule(test5_np_name_v6, true, rule_3_v6, "0-ipv6__tcp-443")
 
 	//allow-all-from-ns
 	test6_np_v6 := netpol("testnsv6", "npv6", &metav1.LabelSelector{},
@@ -2638,7 +2638,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test6_np_v6)
 	test6_np_name_v6 := "kube_np_" + hash
-	test6_rule_v6 := createRule(test6_np_name_v6, true, rule_0_v6, "0-ipv6__npv6")
+	test6_rule_v6 := createRule(test6_np_name_v6, true, rule_0_v6, "0-ipv6__unspecified")
 	test6_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test6_rule_v6.GetDn(), "2001::2"))
 	test6_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test6_rule_v6.GetDn(), "2001::3"))
 
@@ -2665,7 +2665,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test8_np_v6)
 	test8_np_name_v6 := "kube_np_" + hash
-	test8_rule_v6 := createRule(test8_np_name_v6, true, rule_0_v6, "0-ipv6__npv6")
+	test8_rule_v6 := createRule(test8_np_name_v6, true, rule_0_v6, "0-ipv6__unspecified")
 	test8_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test8_rule_v6.GetDn(), "2001::4"))
 	test8_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test8_rule_v6.GetDn(), "2001::5"))
 	test8_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test8_rule_v6.GetDn(), "2001::6"))
@@ -2681,7 +2681,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test9_np_v6)
 	test9_np_name_v6 := "kube_np_" + hash
-	test9_rule_v6 := createRule(test9_np_name_v6, true, rule_0_v6, "0-ipv6__npv6")
+	test9_rule_v6 := createRule(test9_np_name_v6, true, rule_0_v6, "0-ipv6__unspecified")
 	test9_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test9_rule_v6.GetDn(), "2001::2"))
 
 	//allow-all-select-pods-and-ns
@@ -2697,7 +2697,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test10_np_v6)
 	test10_np_name_v6 := "kube_np_" + hash
-	test10_rule_v6 := createRule(test10_np_name_v6, true, rule_0_v6, "0-ipv6__npv6")
+	test10_rule_v6 := createRule(test10_np_name_v6, true, rule_0_v6, "0-ipv6__unspecified")
 	test10_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test10_rule_v6.GetDn(), "2001::4"))
 	test10_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test10_rule_v6.GetDn(), "2001::6"))
 
@@ -2721,9 +2721,9 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, nil, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test11_np_v6)
 	test11_np_name_v6 := "kube_np_" + hash
-	test11_rule1_v6 := createRule(test11_np_name_v6, true, rule_1_v6, "0_0-ipv6__npv6")
+	test11_rule1_v6 := createRule(test11_np_name_v6, true, rule_1_v6, "0-ipv6__tcp-80")
 	test11_rule1_v6.AddChild(apicapi.NewHostprotRemoteIp(test11_rule1_v6.GetDn(), "2001::2"))
-	test11_rule2_v6 := createRule(test11_np_name_v6, true, rule_3_v6, "1_0-ipv6__npv6")
+	test11_rule2_v6 := createRule(test11_np_name_v6, true, rule_3_v6, "1-ipv6__tcp-443")
 	test11_rule2_v6.AddChild(apicapi.NewHostprotRemoteIp(test11_rule2_v6.GetDn(), "2001::3"))
 
 	//egress-allow-all-select-pods-and-ns
@@ -2740,7 +2740,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test12_np_v6)
 	test12_np_name_v6 := "kube_np_" + hash
-	test12_rule_v6 := createRule(test12_np_name_v6, false, rule_4_v6, "0-ipv6__npv6")
+	test12_rule_v6 := createRule(test12_np_name_v6, false, rule_4_v6, "0-ipv6__unspecified")
 	test12_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test12_rule_v6.GetDn(), "2001::4"))
 	test12_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test12_rule_v6.GetDn(), "2001::6"))
 
@@ -2756,7 +2756,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test13_np_v6)
 	test13_np_name_v6 := "kube_np_" + hash
-	test13_rule_v6 := createRule(test13_np_name_v6, false, rule_5_v6, "0_0-ipv6__npv6")
+	test13_rule_v6 := createRule(test13_np_name_v6, false, rule_5_v6, "0-ipv6__tcp-80")
 	test13_rule_v6.AddChild(apicapi.NewHostprotRemoteIp(test13_rule_v6.GetDn(), "2001::2"))
 
 	//egress-allow-http-augment
@@ -2772,7 +2772,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test14_np_v6)
 	test14_np_name_v6 := "kube_np_" + hash
-	test14_rule1_v6 := createRule(test14_np_name_v6, false, rule_5_v6, "0_0-ipv6__npv6")
+	test14_rule1_v6 := createRule(test14_np_name_v6, false, rule_5_v6, "0-ipv6__tcp-80")
 	test14_rule1_v6.AddChild(apicapi.NewHostprotRemoteIp(test14_rule1_v6.GetDn(), "2001::2"))
 	test14_rule2_v6 := createRule(test14_np_name_v6, false, rule_6_v6, "service_tcp_8080-ipv6")
 	test14_rule2_v6.AddChild(apicapi.NewHostprotRemoteIp(test14_rule2_v6.GetDn(), "fd00::1234"))
@@ -2785,7 +2785,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test15_np_v6)
 	test15_np_name_v6 := "kube_np_" + hash
-	test15_rule1_v6 := createRule(test15_np_name_v6, false, rule_5_v6, "0_0-ipv6__npv6")
+	test15_rule1_v6 := createRule(test15_np_name_v6, false, rule_5_v6, "0-ipv6__tcp-80")
 	test15_rule2_v6 := createRule(test15_np_name_v6, false, rule_6_v6, "service_tcp_8080-ipv6")
 	test15_rule2_v6.AddChild(apicapi.NewHostprotRemoteIp(test15_rule2_v6.GetDn(), "fd00::1234"))
 
@@ -2799,7 +2799,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test16_np_v6)
 	test16_np_name_v6 := "kube_np_" + hash
-	test16_rule1_v6 := createRule(test16_np_name_v6, false, rule_4_v6, "0-ipv6__npv6")
+	test16_rule1_v6 := createRule(test16_np_name_v6, false, rule_4_v6, "0-ipv6__unspecified")
 	test16_rule1_v6.AddChild(apicapi.NewHostprotRemoteIp(test16_rule1_v6.GetDn(), "2001::/64"))
 	test16_rule2_v6 := createRule(test16_np_name_v6, false, rule_6_v6, "service_tcp_8080-ipv6")
 	test16_rule2_v6.AddChild(apicapi.NewHostprotRemoteIp(test16_rule2_v6.GetDn(), "fd00::1236"))
@@ -2813,7 +2813,7 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test17_np_v6)
 	test17_np_name_v6 := "kube_np_" + hash
-	test17_rule_v6 := createRule(test17_np_name_v6, false, rule_4_v6, "0-ipv6__npv6")
+	test17_rule_v6 := createRule(test17_np_name_v6, false, rule_4_v6, "0-ipv6__unspecified")
 
 	var np6Tests = []npTest{
 		{test0_np_v6,
@@ -3578,7 +3578,7 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ := util.CreateHashFromNetPol(test15_np)
 	test15_np_name := "kube_np_" + hash
-	test15_rule := createRule(test15_np_name, false, rule_6, "0_0-ipv4__np1")
+	test15_rule := createRule(test15_np_name, false, rule_6, "0-ipv4__tcp-80")
 	test15_rule.AddChild(apicapi.NewHostprotRemoteIp(test15_rule.GetDn(), "1.1.1.1"))
 
 	//egress-allow-http-augment
@@ -3593,7 +3593,7 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test16_np)
 	test16_np_name := "kube_np_" + hash
-	test16_rule1 := createRule(test16_np_name, false, rule_6, "0_0-ipv4__np1")
+	test16_rule1 := createRule(test16_np_name, false, rule_6, "0-ipv4__tcp-80")
 	test16_rule1.AddChild(apicapi.NewHostprotRemoteIp(test16_rule1.GetDn(), "1.1.1.1"))
 	test16_rule2 := createRule(test16_np_name, false, rule_7, "service_tcp_8080-ipv4")
 	test16_rule2.AddChild(apicapi.NewHostprotRemoteIp(test16_rule2.GetDn(), "9.0.0.42"))
@@ -3614,7 +3614,7 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test17_np)
 	test17_np_name := "kube_np_" + hash
-	test17_rule1 := createRule(test17_np_name, false, rule_6, "0_0-ipv4__np1")
+	test17_rule1 := createRule(test17_np_name, false, rule_6, "0-ipv4__tcp-80")
 	test17_rule1.AddChild(apicapi.NewHostprotRemoteIp(test17_rule1.GetDn(), "1.1.1.1"))
 	test17_rule2 := createRule(test17_np_name, false, rule_7, "service_tcp_8080-ipv4")
 	test17_rule2.AddChild(apicapi.NewHostprotRemoteIp(test17_rule2.GetDn(), "9.0.0.42"))
@@ -3627,7 +3627,7 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test18_np)
 	test18_np_name := "kube_np_" + hash
-	test18_rule1 := createRule(test18_np_name, false, rule_6, "0_0-ipv4__np1")
+	test18_rule1 := createRule(test18_np_name, false, rule_6, "0-ipv4__tcp-80")
 	test18_rule2 := createRule(test18_np_name, false, rule_7, "service_tcp_8080-ipv4")
 	test18_rule2.AddChild(apicapi.NewHostprotRemoteIp(test18_rule2.GetDn(), "9.0.0.42"))
 
@@ -3641,7 +3641,7 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test19_np)
 	test19_np_name := "kube_np_" + hash
-	test19_rule1 := createRule(test19_np_name, false, rule_5, "0-ipv4__np1")
+	test19_rule1 := createRule(test19_np_name, false, rule_5, "0-ipv4__unspecified")
 	test19_rule1.AddChild(apicapi.NewHostprotRemoteIp(test19_rule1.GetDn(), "1.1.1.0/24"))
 	test19_rule2 := createRule(test19_np_name, false, rule_7, "service_tcp_8080-ipv4")
 	test19_rule2.AddChild(apicapi.NewHostprotRemoteIp(test19_rule2.GetDn(), "9.0.0.44"))
@@ -3655,7 +3655,7 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ = util.CreateHashFromNetPol(test20_np)
 	test20_np_name := "kube_np_" + hash
-	test20_rule := createRule(test20_np_name, false, rule_5, "0-ipv4__np1")
+	test20_rule := createRule(test20_np_name, false, rule_5, "0-ipv4__unspecified")
 
 	var npTests = []npTest{
 		{test15_np,
@@ -4154,7 +4154,7 @@ func TestNetworkPolicyEgressNmPortHppOptimize(t *testing.T) {
 		}, allPolicyTypes)
 	hash, _ := util.CreateHashFromNetPol(test1_np)
 	test1_np_name := "kube_np_" + hash
-	test1_rule1 := createRule(test1_np_name, false, rule_1, "0_0-ipv4__np1")
+	test1_rule1 := createRule(test1_np_name, false, rule_1, "0-ipv4__tcp-80")
 	test1_rule1.AddChild(apicapi.NewHostprotRemoteIp(test1_rule1.GetDn(), "1.1.1.1"))
 	test1_rule2 := createRule(test1_np_name, false, rule_2, "service_tcp_8080-ipv4")
 	test1_rule2.AddChild(apicapi.NewHostprotRemoteIp(test1_rule2.GetDn(), "9.0.0.42"))
@@ -4286,6 +4286,221 @@ func TestNetworkPolicyEgressNmPortHppOptimize(t *testing.T) {
 		checkNp(t, &npTests[ix], "npfirst", cont)
 		cont.stop()
 	}
+}
+
+// TestNetworkPolicyMultipleNPsSharedHPPNamedPorts tests the scenario where
+// multiple NetworkPolicies with identical rules but different PodSelectors
+// share the same HPP, and use named ports that resolve to different port numbers
+func TestNetworkPolicyMultipleNPsSharedHPPNamedPorts(t *testing.T) {
+	// Simple test to verify the fix works in hpp-optimization mode
+	cont := testController()
+	cont.config.HppOptimization = true
+	cont.config.AciPolicyTenant = "test-tenant"
+	cont.config.NodeServiceIpPool = []ipam.IpRange{
+		{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.1.3")},
+	}
+	cont.config.PodIpPool = []ipam.IpRange{
+		{Start: net.ParseIP("10.1.1.2"), End: net.ParseIP("10.1.255.254")},
+	}
+	cont.AciController.initIpam()
+	cont.fakeNamespaceSource.Add(namespaceLabel("testns",
+		map[string]string{"test": "testv"}))
+
+	// Create two pods with different named ports
+	pod1 := &v1.Pod{
+		Spec: v1.PodSpec{
+			NodeName:   "test-node",
+			Containers: []v1.Container{{Ports: []v1.ContainerPort{{Name: "http", ContainerPort: 80}}}},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns", Name: "pod1",
+			Labels: map[string]string{"app": "web1"},
+		},
+		Status: v1.PodStatus{PodIP: "1.1.1.1"},
+	}
+
+	pod2 := &v1.Pod{
+		Spec: v1.PodSpec{
+			NodeName:   "test-node",
+			Containers: []v1.Container{{Ports: []v1.ContainerPort{{Name: "http", ContainerPort: 8080}}}},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns", Name: "pod2",
+			Labels: map[string]string{"app": "web2"},
+		},
+		Status: v1.PodStatus{PodIP: "1.1.1.2"},
+	}
+	// Two NetworkPolicies with same rules but different PodSelectors
+	np1 := netpol("testns", "np1",
+		&metav1.LabelSelector{MatchLabels: map[string]string{"app": "web1"}},
+		[]v1net.NetworkPolicyIngressRule{
+			ingressRule([]v1net.NetworkPolicyPort{
+				{Protocol: func() *v1.Protocol { p := v1.ProtocolTCP; return &p }(),
+					Port: &intstr.IntOrString{Type: intstr.String, StrVal: "http"}},
+			}, nil),
+		}, nil, allPolicyTypes)
+
+	np2 := netpol("testns", "np2",
+		&metav1.LabelSelector{MatchLabels: map[string]string{"app": "web2"}},
+		[]v1net.NetworkPolicyIngressRule{
+			ingressRule([]v1net.NetworkPolicyPort{
+				{Protocol: func() *v1.Protocol { p := v1.ProtocolTCP; return &p }(),
+					Port: &intstr.IntOrString{Type: intstr.String, StrVal: "http"}},
+			}, nil),
+		}, nil, allPolicyTypes)
+
+	cont.fakePodSource.Add(pod1)
+	cont.fakePodSource.Add(pod2)
+	cont.run()
+	cont.fakeNetworkPolicySource.Add(np1)
+	cont.fakeNetworkPolicySource.Add(np2)
+
+	// Wait for controller to process the network policies
+	hash, _ := util.CreateHashFromNetPol(np1)
+	labelKey := cont.aciNameForKey("np", hash)
+
+	foundNp1Rule := false
+	foundNp2Rule := false
+
+	tu.WaitFor(t, "multiple-nps-shared-hpp-named-ports", 2000*time.Millisecond,
+		func(last bool) (bool, error) {
+			desiredState := cont.apicConn.GetDesiredState(labelKey)
+			if len(desiredState) == 0 {
+				return false, nil
+			}
+
+			// Verify rules exist for both NPs
+			hppObj := desiredState[0]
+			hppMap, ok := hppObj["hostprotPol"]
+			if !ok || hppMap == nil {
+				return false, nil
+			}
+
+			foundNp1Rule = false
+			foundNp2Rule = false
+
+			for _, child := range hppMap.Children {
+				if subj, ok := child["hostprotSubj"]; ok {
+					if subj != nil && subj.Attributes["name"] == "networkpolicy-ingress" {
+						for _, ruleChild := range subj.Children {
+							if rule, ok := ruleChild["hostprotRule"]; ok {
+								if rule != nil {
+									fromPort, _ := rule.Attributes["fromPort"].(string)
+									if fromPort == "http" {
+										foundNp1Rule = true
+									}
+									if fromPort == "8080" {
+										foundNp2Rule = true
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+
+			return foundNp1Rule && foundNp2Rule, nil
+		})
+
+	cont.stop()
+}
+
+// TestNetworkPolicyMultipleNPsSharedHPPNamedPortsDirect tests the same
+// sibling-NP merge scenario as TestNetworkPolicyMultipleNPsSharedHPPNamedPorts
+// but for the HPP-Direct (EnableHppDirect) code path, verifying that the
+// HostprotPol CRD contains merged ingress rules from both NPs.
+func TestNetworkPolicyMultipleNPsSharedHPPNamedPortsDirect(t *testing.T) {
+	cont := getContWithEnabledLocalHpp()
+	os.Setenv("SYSTEM_NAMESPACE", "kube-system")
+	defer os.Unsetenv("SYSTEM_NAMESPACE")
+
+	// Create two pods with different named port resolutions
+	pod1 := &v1.Pod{
+		Spec: v1.PodSpec{
+			NodeName:   "test-node",
+			Containers: []v1.Container{{Ports: []v1.ContainerPort{{Name: "http", ContainerPort: 80}}}},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns", Name: "pod1",
+			Labels: map[string]string{"app": "web1"},
+		},
+		Status: v1.PodStatus{PodIP: "1.1.1.1"},
+	}
+
+	pod2 := &v1.Pod{
+		Spec: v1.PodSpec{
+			NodeName:   "test-node",
+			Containers: []v1.Container{{Ports: []v1.ContainerPort{{Name: "http", ContainerPort: 8080}}}},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "testns", Name: "pod2",
+			Labels: map[string]string{"app": "web2"},
+		},
+		Status: v1.PodStatus{PodIP: "1.1.1.2"},
+	}
+
+	// Two NetworkPolicies with identical rules but different PodSelectors
+	np1 := netpol("testns", "np1",
+		&metav1.LabelSelector{MatchLabels: map[string]string{"app": "web1"}},
+		[]v1net.NetworkPolicyIngressRule{
+			ingressRule([]v1net.NetworkPolicyPort{
+				{Protocol: func() *v1.Protocol { p := v1.ProtocolTCP; return &p }(),
+					Port: &intstr.IntOrString{Type: intstr.String, StrVal: "http"}},
+			}, nil),
+		}, nil, allPolicyTypes)
+
+	np2 := netpol("testns", "np2",
+		&metav1.LabelSelector{MatchLabels: map[string]string{"app": "web2"}},
+		[]v1net.NetworkPolicyIngressRule{
+			ingressRule([]v1net.NetworkPolicyPort{
+				{Protocol: func() *v1.Protocol { p := v1.ProtocolTCP; return &p }(),
+					Port: &intstr.IntOrString{Type: intstr.String, StrVal: "http"}},
+			}, nil),
+		}, nil, allPolicyTypes)
+
+	cont.fakePodSource.Add(pod1)
+	cont.fakePodSource.Add(pod2)
+	cont.run()
+	cont.fakeNetworkPolicySource.Add(np1)
+	cont.fakeNetworkPolicySource.Add(np2)
+
+	hash, _ := util.CreateHashFromNetPol(np1)
+	labelKey := cont.aciNameForKey("np", hash)
+	hppName := strings.ReplaceAll(labelKey, "_", "-")
+	ns := os.Getenv("SYSTEM_NAMESPACE")
+
+	tu.WaitFor(t, "multiple-nps-shared-hpp-named-ports-direct", 2000*time.Millisecond,
+		func(last bool) (bool, error) {
+			hpp, err := cont.getHostprotPol(hppName, ns)
+			if err != nil {
+				return false, nil
+			}
+
+			// Find ingress subject
+			var ingressSubj *hppv1.HostprotSubj
+			for i := range hpp.Spec.HostprotSubj {
+				if hpp.Spec.HostprotSubj[i].Name == "networkpolicy-ingress" {
+					ingressSubj = &hpp.Spec.HostprotSubj[i]
+					break
+				}
+			}
+			if ingressSubj == nil {
+				return false, nil
+			}
+
+			// Collect all fromPort values from ingress rules
+			ports := make(map[string]bool)
+			for _, rule := range ingressSubj.HostprotRule {
+				if rule.FromPort != "" && rule.FromPort != "unspecified" {
+					ports[rule.FromPort] = true
+				}
+			}
+
+			// Both port 80 (from NP1/pod1) and 8080 (from NP2/pod2) must be present
+			return ports["80"] && ports["8080"], nil
+		})
+
+	cont.stop()
 }
 
 func TestCreateStaticNetPolCrs(t *testing.T) {
@@ -4656,10 +4871,10 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 		entries:      []resolvedPortEntry{{proto: "tcp", fromPort: "8080"}},
 		peerNsList:   []string{"test-namespace"},
 		podSelectors: podSelectors,
-	}, np)
+	})
 
 	assert.Equal(t, 1, len(subj.HostprotRule))
-	assert.Equal(t, "test-rule_0-ipv4__test-network-policy", subj.HostprotRule[0].Name)
+	assert.Equal(t, "test-rule-ipv4__tcp-8080", subj.HostprotRule[0].Name)
 	assert.Equal(t, "ingress", subj.HostprotRule[0].Direction)
 	assert.Equal(t, "ipv4", subj.HostprotRule[0].Ethertype)
 	assert.Equal(t, "tcp", subj.HostprotRule[0].Protocol)
@@ -4699,7 +4914,7 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 		entries:      []resolvedPortEntry{{}},
 		peerNsList:   []string{"test-namespace"},
 		podSelectors: podSelectors,
-	}, np)
+	})
 
 	expected := hppv1.HostprotSubj{
 		HostprotRule: []hppv1.HostprotRule{
@@ -4710,7 +4925,7 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 				Protocol:            "unspecified",
 				FromPort:            "unspecified",
 				ToPort:              "unspecified",
-				Name:                "test-rule-ipv4__test-network-policy",
+				Name:                "test-rule-ipv4__unspecified",
 				RsRemoteIpContainer: []string{"test-namespace"},
 				HostprotFilterContainer: []hppv1.HostprotFilterContainer{
 					{
@@ -4736,7 +4951,7 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 		entries:      []resolvedPortEntry{{}},
 		peerNsList:   nil,
 		podSelectors: podSelectors,
-	}, np)
+	})
 
 	expectedRule := []hppv1.HostprotRule{
 		{
@@ -4746,7 +4961,7 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 			Protocol:            "unspecified",
 			FromPort:            "unspecified",
 			ToPort:              "unspecified",
-			Name:                "test-rule-ipv4__test-network-policy",
+			Name:                "test-rule-ipv4__unspecified",
 			RsRemoteIpContainer: nil,
 			HostprotFilterContainer: []hppv1.HostprotFilterContainer{
 				{
@@ -4804,7 +5019,7 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 			Protocol:            "tcp",
 			FromPort:            "8080",
 			ToPort:              "unspecified",
-			Name:                "test-rule_0-ipv4__test-network-policy",
+			Name:                "test-rule-ipv4__tcp-8080",
 			RsRemoteIpContainer: nil,
 			HostprotFilterContainer: []hppv1.HostprotFilterContainer{
 				{
@@ -4830,7 +5045,7 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 		entries:      []resolvedPortEntry{{proto: "tcp", fromPort: "8080"}},
 		peerNsList:   nil,
 		podSelectors: podSelectors,
-	}, np)
+	})
 
 	assert.Equal(t, expectedRule, subj.HostprotRule)
 
@@ -6924,15 +7139,6 @@ func TestBuildLocalNetPolSubjRulesEgressNamedPort(t *testing.T) {
 	cont.run()
 	defer cont.stop()
 
-	np := netpol("testns", "np1", &metav1.LabelSelector{},
-		nil, []v1net.NetworkPolicyEgressRule{
-			egressRule([]v1net.NetworkPolicyPort{
-				{Protocol: func() *v1.Protocol { a := v1.ProtocolTCP; return &a }(),
-					Port: &intstr.IntOrString{Type: intstr.String, StrVal: "http"},
-				},
-			}, nil),
-		}, allPolicyTypes)
-
 	// Simulate the result of resolveNetPolPeersAndPorts for egress no-To with
 	// named port "http" resolved to port 80 (portScoped since IPs are per-pod).
 	resolved := &resolvedPeerPorts{
@@ -6942,10 +7148,10 @@ func TestBuildLocalNetPolSubjRulesEgressNamedPort(t *testing.T) {
 	}
 
 	subj := &hppv1.HostprotSubj{}
-	cont.buildLocalNetPolSubjRules("0", subj, "egress", resolved, np)
+	cont.buildLocalNetPolSubjRules("0", subj, "egress", resolved)
 
 	assert.Equal(t, 1, len(subj.HostprotRule), "Should have 1 rule for resolved named port")
-	assert.Equal(t, "0_0-ipv4__np1", subj.HostprotRule[0].Name)
+	assert.Equal(t, "0-ipv4__tcp-80", subj.HostprotRule[0].Name)
 	assert.Equal(t, "egress", subj.HostprotRule[0].Direction)
 	assert.Equal(t, "ipv4", subj.HostprotRule[0].Ethertype)
 	assert.Equal(t, "tcp", subj.HostprotRule[0].Protocol)
@@ -6961,18 +7167,6 @@ func TestBuildLocalNetPolSubjRulesEgressMultipleNamedPorts(t *testing.T) {
 	cont.run()
 	defer cont.stop()
 
-	np := netpol("testns", "np1", &metav1.LabelSelector{},
-		nil, []v1net.NetworkPolicyEgressRule{
-			egressRule([]v1net.NetworkPolicyPort{
-				{Protocol: func() *v1.Protocol { a := v1.ProtocolTCP; return &a }(),
-					Port: &intstr.IntOrString{Type: intstr.String, StrVal: "http"},
-				},
-				{Protocol: func() *v1.Protocol { a := v1.ProtocolTCP; return &a }(),
-					Port: &intstr.IntOrString{Type: intstr.String, StrVal: "https"},
-				},
-			}, nil),
-		}, allPolicyTypes)
-
 	// Simulate the result of resolveNetPolPeersAndPorts: "http" resolved to ports
 	// 80 and 8080 (two pods), "https" to port 443. Each entry is portScoped.
 	resolved := &resolvedPeerPorts{
@@ -6984,7 +7178,7 @@ func TestBuildLocalNetPolSubjRulesEgressMultipleNamedPorts(t *testing.T) {
 	}
 
 	subj := &hppv1.HostprotSubj{}
-	cont.buildLocalNetPolSubjRules("0", subj, "egress", resolved, np)
+	cont.buildLocalNetPolSubjRules("0", subj, "egress", resolved)
 
 	// Expect 3 rules: http→80, http→8080, https→443
 	assert.Equal(t, 3, len(subj.HostprotRule),
@@ -7093,7 +7287,7 @@ func TestBuildLocalNetPolSubjRulesIngressNamedPort(t *testing.T) {
 	}
 
 	subj := &hppv1.HostprotSubj{}
-	cont.buildLocalNetPolSubjRules("0", subj, "ingress", resolved, np)
+	cont.buildLocalNetPolSubjRules("0", subj, "ingress", resolved)
 
 	assert.Equal(t, 1, len(subj.HostprotRule), "Should have exactly 1 rule for named port")
 	assert.Equal(t, "ingress", subj.HostprotRule[0].Direction)
@@ -7193,16 +7387,6 @@ func TestBuildLocalNetPolSubjRulesEgressIPBlockNamedPort(t *testing.T) {
 	cont.run()
 	defer cont.stop()
 
-	np := &v1net.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "np1",
-			Namespace: "testns",
-		},
-		Spec: v1net.NetworkPolicySpec{
-			PodSelector: metav1.LabelSelector{},
-		},
-	}
-
 	// Simulate resolved egress state: one port-scoped entry (from named port)
 	// with pod IPs, plus ipBlockSubs from an IPBlock peer in the same rule.
 	resolved := &resolvedPeerPorts{
@@ -7222,7 +7406,7 @@ func TestBuildLocalNetPolSubjRulesEgressIPBlockNamedPort(t *testing.T) {
 	}
 
 	subj := &hppv1.HostprotSubj{}
-	cont.buildLocalNetPolSubjRules("0", subj, "egress", resolved, np)
+	cont.buildLocalNetPolSubjRules("0", subj, "egress", resolved)
 
 	// With the new behavior, port-scoped egress rules should NOT include
 	// the IPBlock CIDRs (1.1.1.0/24). Pod-level filtering is handled by

--- a/pkg/controller/pods.go
+++ b/pkg/controller/pods.go
@@ -371,7 +371,7 @@ func (cont *AciController) deleteCtrNmPortForPod(pod *v1.Pod, podkey string) {
 							delete(ctrNmpEntry.ctrNmpToPods, key)
 							portkey := portProto(&ctrportspec.Protocol) + "-name-" + ctrportspec.Name
 							if entry, exists := cont.targetPortIndex[portkey]; exists {
-								delete(entry.port.ports, int(ctrportspec.ContainerPort))
+								delete(entry.portMapping.portServiceMap, int(ctrportspec.ContainerPort))
 							}
 						}
 					}

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -2175,7 +2175,7 @@ func (cont *AciController) processServiceTargetPorts(service *v1.Service, svcKey
 	ports := make(map[string]targetPort)
 	for _, port := range service.Spec.Ports {
 		var key string
-		portnums := make(map[int]bool)
+		portnums := make(map[int]map[string]bool)
 
 		if port.TargetPort.Type == intstr.String {
 			entry, exists := cont.namedPortServiceIndex[svcKey]
@@ -2206,12 +2206,12 @@ func (cont *AciController) processServiceTargetPorts(service *v1.Service, svcKey
 				portNum = int(port.Port)
 			}
 			key = portProto(&port.Protocol) + "-num-" + strconv.Itoa(portNum)
-			portnums[portNum] = true
+			portnums[portNum] = map[string]bool{svcKey: true}
 		}
 
 		ports[key] = targetPort{
-			proto: port.Protocol,
-			ports: portnums,
+			proto:          port.Protocol,
+			portServiceMap: portnums,
 		}
 	}
 	return ports
@@ -2353,48 +2353,143 @@ func (cont *AciController) processDelayedEpSlices() {
 	}
 }
 
-func (cont *AciController) resolveServiceNamedPortFromEpSlice(epSlice *discovery.EndpointSlice, serviceKey string, old bool) {
-	indexEntry, ok := cont.namedPortServiceIndex[serviceKey]
-	if !ok {
-		return
-	}
-	for _, port := range epSlice.Ports {
-		if port.Name == nil || port.Port == nil {
-			continue
-		}
-		if portEntry, ok := (*indexEntry)[*port.Name]; ok && portEntry != nil {
-			portNum := int(*port.Port)
-			if old {
-				delete(portEntry.resolvedPorts, portNum)
-				cont.log.Debugf("Deleting port: %d from service %s resolved target port. Resolved ports: %v", portNum, serviceKey, portEntry.resolvedPorts)
-			} else {
-				portEntry.resolvedPorts[portNum] = true
-				cont.log.Debugf("Adding port: %d to service %s resolved target port. Resolved ports: %v", portNum, serviceKey, portEntry.resolvedPorts)
-			}
-			key := portProto(port.Protocol) + "-num-" + strconv.Itoa(portNum)
-			targetPortIndexEntry := cont.targetPortIndex[key]
-			if targetPortIndexEntry == nil && len(portEntry.resolvedPorts) == 1 {
-				targetPortIndexEntry = &portIndexEntry{
-					port: targetPort{
-						proto: *port.Protocol,
-						ports: make(map[int]bool),
-					},
-					serviceKeys:       make(map[string]bool),
-					networkPolicyKeys: make(map[string]bool),
-				}
-				targetPortIndexEntry.port.ports[portNum] = true
-				cont.targetPortIndex[key] = targetPortIndexEntry
-			}
-			if targetPortIndexEntry != nil {
-				if len(portEntry.resolvedPorts) == 1 {
-					targetPortIndexEntry.serviceKeys[serviceKey] = true
-				} else {
-					delete(targetPortIndexEntry.serviceKeys, serviceKey)
+func (cont *AciController) updateTargetPortIndexEpSlice(key string, port discovery.EndpointPort, serviceKey string, old bool) {
+	portNum := int(*port.Port)
+
+	if old {
+		entry := cont.targetPortIndex[key]
+		if entry != nil {
+			if svcKeys := entry.portMapping.portServiceMap[portNum]; svcKeys != nil {
+				delete(svcKeys, serviceKey)
+				if len(svcKeys) == 0 {
+					delete(entry.portMapping.portServiceMap, portNum)
 				}
 			}
+			if !entry.hasServiceKeys() && len(entry.networkPolicyKeys) == 0 {
+				delete(cont.targetPortIndex, key)
+			}
 		}
+	} else {
+		entry := cont.targetPortIndex[key]
+		if entry == nil {
+			proto := v1.ProtocolTCP
+			if port.Protocol != nil {
+				proto = *port.Protocol
+			}
+			entry = &portIndexEntry{
+				portMapping: targetPort{
+					proto:          proto,
+					portServiceMap: make(map[int]map[string]bool),
+				},
+				networkPolicyKeys: make(map[string]bool),
+			}
+			cont.targetPortIndex[key] = entry
+		}
+		if entry.portMapping.portServiceMap[portNum] == nil {
+			entry.portMapping.portServiceMap[portNum] = make(map[string]bool)
+		}
+		entry.portMapping.portServiceMap[portNum][serviceKey] = true
 	}
 }
+
+// epSlicePortInfo captures per-key metadata needed for diffing old vs new
+// endpoint slice port entries in resolveServiceNamedPortFromEpSlice.
+type epSlicePortInfo struct {
+	port        discovery.EndpointPort
+	portNum     int
+	svcPortName string // non-empty when the entry tracks a named service port in namedPortServiceIndex
+}
+
+// getEpSlicePortKeys computes the set of targetPortIndex keys that an
+// endpoint slice would produce, keyed by targetPortIndex key string.
+func (cont *AciController) getEpSlicePortKeys(epSlice *discovery.EndpointSlice, serviceKey string, hasIndex bool) map[string]*epSlicePortInfo {
+	if epSlice == nil {
+		return nil
+	}
+	result := make(map[string]*epSlicePortInfo)
+
+	var containerPortNames map[int]string
+	for i := range epSlice.Endpoints {
+		ep := &epSlice.Endpoints[i]
+		if ep.TargetRef != nil && ep.TargetRef.Kind == "Pod" {
+			podObj, exists, err := cont.podIndexer.GetByKey(
+				ep.TargetRef.Namespace + "/" + ep.TargetRef.Name)
+			if exists && err == nil {
+				pod := podObj.(*v1.Pod)
+				containerPortNames = make(map[int]string)
+				for ci := range pod.Spec.Containers {
+					for _, cp := range pod.Spec.Containers[ci].Ports {
+						if cp.Name != "" {
+							containerPortNames[int(cp.ContainerPort)] = cp.Name
+						}
+					}
+				}
+				break
+			}
+		}
+	}
+
+	for _, port := range epSlice.Ports {
+		if port.Port == nil {
+			continue
+		}
+		portNum := int(*port.Port)
+
+		if hasIndex && port.Name != nil {
+			key := portProto(port.Protocol) + "-num-" + strconv.Itoa(portNum)
+			result[key] = &epSlicePortInfo{
+				port:        port,
+				portNum:     portNum,
+				svcPortName: *port.Name,
+			}
+		}
+
+		if cpName, found := containerPortNames[portNum]; found {
+			key := portProto(port.Protocol) + "-name-" + cpName
+			result[key] = &epSlicePortInfo{
+				port:    port,
+				portNum: portNum,
+			}
+		}
+	}
+	return result
+}
+
+func (cont *AciController) resolveServiceNamedPortFromEpSlice(oldEpSlice, newEpSlice *discovery.EndpointSlice, serviceKey string) {
+	indexEntry, hasIndex := cont.namedPortServiceIndex[serviceKey]
+
+	oldKeys := cont.getEpSlicePortKeys(oldEpSlice, serviceKey, hasIndex)
+	newKeys := cont.getEpSlicePortKeys(newEpSlice, serviceKey, hasIndex)
+
+	// Remove entries present in old but not in new
+	for key, info := range oldKeys {
+		if _, ok := newKeys[key]; ok {
+			continue
+		}
+		if hasIndex && info.svcPortName != "" {
+			if portEntry, ok := (*indexEntry)[info.svcPortName]; ok && portEntry != nil {
+				delete(portEntry.resolvedPorts, info.portNum)
+				cont.log.Debugf("Deleting port: %d from service %s resolved target port. Resolved ports: %v", info.portNum, serviceKey, portEntry.resolvedPorts)
+			}
+		}
+		cont.updateTargetPortIndexEpSlice(key, info.port, serviceKey, true)
+	}
+
+	// Add entries present in new but not in old
+	for key, info := range newKeys {
+		if _, ok := oldKeys[key]; ok {
+			continue
+		}
+		if hasIndex && info.svcPortName != "" {
+			if portEntry, ok := (*indexEntry)[info.svcPortName]; ok && portEntry != nil {
+				portEntry.resolvedPorts[info.portNum] = true
+				cont.log.Debugf("Adding port: %d to service %s resolved target port. Resolved ports: %v", info.portNum, serviceKey, portEntry.resolvedPorts)
+			}
+		}
+		cont.updateTargetPortIndexEpSlice(key, info.port, serviceKey, false)
+	}
+}
+
 func (cont *AciController) endpointSliceAdded(obj interface{}) {
 	endpointslice, ok := obj.(*discovery.EndpointSlice)
 	if !ok {
@@ -2408,7 +2503,7 @@ func (cont *AciController) endpointSliceAdded(obj interface{}) {
 	ips := cont.getEndpointSliceIps(endpointslice)
 	cont.indexMutex.Lock()
 	cont.updateIpIndex(cont.endpointsIpIndex, nil, ips, servicekey)
-	cont.resolveServiceNamedPortFromEpSlice(endpointslice, servicekey, false)
+	cont.resolveServiceNamedPortFromEpSlice(nil, endpointslice, servicekey)
 	cont.queueIPNetPolUpdates(ips)
 	cont.indexMutex.Unlock()
 
@@ -2439,7 +2534,7 @@ func (cont *AciController) endpointSliceDeleted(obj interface{}) {
 	ips := cont.getEndpointSliceIps(endpointslice)
 	cont.indexMutex.Lock()
 	cont.updateIpIndex(cont.endpointsIpIndex, ips, nil, servicekey)
-	cont.resolveServiceNamedPortFromEpSlice(endpointslice, servicekey, true)
+	cont.resolveServiceNamedPortFromEpSlice(endpointslice, nil, servicekey)
 	cont.queueIPNetPolUpdates(ips)
 	cont.indexMutex.Unlock()
 	cont.queueEndpointSliceNetPolUpdates(endpointslice)
@@ -2559,8 +2654,7 @@ func (cont *AciController) doendpointSliceUpdated(oldendpointslice *discovery.En
 	newIps := cont.getEndpointSliceIps(newendpointslice)
 	if !reflect.DeepEqual(oldIps, newIps) {
 		cont.indexMutex.Lock()
-		cont.resolveServiceNamedPortFromEpSlice(oldendpointslice, servicekey, true)
-		cont.resolveServiceNamedPortFromEpSlice(newendpointslice, servicekey, false)
+		cont.resolveServiceNamedPortFromEpSlice(oldendpointslice, newendpointslice, servicekey)
 		cont.queueIPNetPolUpdates(oldIps)
 		cont.updateIpIndex(cont.endpointsIpIndex, oldIps, newIps, servicekey)
 		cont.queueIPNetPolUpdates(newIps)

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -946,7 +946,7 @@ func TestServiceNamedTargetPortBasic(t *testing.T) {
 		"web-service")
 
 	cont.indexMutex.Lock()
-	cont.resolveServiceNamedPortFromEpSlice(epSlice, svcKey, false)
+	cont.resolveServiceNamedPortFromEpSlice(nil, epSlice, svcKey)
 	cont.indexMutex.Unlock()
 
 	// Verify resolvedPorts is now populated
@@ -1016,8 +1016,8 @@ func TestServiceNamedTargetPortMultiplePods(t *testing.T) {
 
 	// Step 4: Call resolveServiceNamedPortFromEpSlice for both slices
 	cont.indexMutex.Lock()
-	cont.resolveServiceNamedPortFromEpSlice(epSlice1, svcKey, false)
-	cont.resolveServiceNamedPortFromEpSlice(epSlice2, svcKey, false)
+	cont.resolveServiceNamedPortFromEpSlice(nil, epSlice1, svcKey)
+	cont.resolveServiceNamedPortFromEpSlice(nil, epSlice2, svcKey)
 	cont.indexMutex.Unlock()
 
 	// Verify both ports are resolved
@@ -1168,7 +1168,7 @@ func TestServiceNamedTargetPortEndpointSliceDeletion(t *testing.T) {
 		"web-service")
 
 	cont.indexMutex.Lock()
-	cont.resolveServiceNamedPortFromEpSlice(epSlice, svcKey, false)
+	cont.resolveServiceNamedPortFromEpSlice(nil, epSlice, svcKey)
 	cont.indexMutex.Unlock()
 
 	// Verify port is resolved
@@ -1183,7 +1183,7 @@ func TestServiceNamedTargetPortEndpointSliceDeletion(t *testing.T) {
 
 	// Step 3: Delete EndpointSlice (old=true)
 	cont.indexMutex.Lock()
-	cont.resolveServiceNamedPortFromEpSlice(epSlice, svcKey, true)
+	cont.resolveServiceNamedPortFromEpSlice(epSlice, nil, svcKey)
 	cont.indexMutex.Unlock()
 
 	// Verify port is removed from resolvedPorts


### PR DESCRIPTION
Named ports in NetworkPolicies were resolved too broadly, creating a
security gap where traffic to unintended ports was allowed.

When a named port (e.g., "http") resolved to different container port
numbers on different pods (e.g., 9090 on pod A, 8080 on pod B), the
generated rules allowed traffic to ALL resolved port numbers on ALL
matching pods — even when only a specific pod defined the named port
at that number. This meant any pod defining the same port name at a
different number would widen the policy for every other pod.

The service augment path had a related issue where it did not verify
that the service owning a target port mapping was the one matched by
the policy, further contributing to over-matching.

Changes:
- Unified peer and port resolution into a single per-pod pass so each
  rule carries only the IPs of pods that resolve the named port to a
  specific number (per-destination-IP scoping)
- Added support for ingress named ports with empty PodSelectors, which
  were previously skipped with a warning
- Guarded service augment port matching against the service key that
  registered the port mapping
- Moved pod informer startup before endpointSlice informer in
  PrepareRun so that podIndexer is populated when epSlice List fires
  during controller startup, preventing named-port resolution misses
- Removed redundant HasSynced entries from the final WaitForCacheSync
  (namespace and pod informers already synced earlier in the sequence)

Test changes:
- Added waitForPodIndexed helper to enforce the real K8s invariant
  (pods exist before their EndpointSlices) in npfirst test loops
- Reordered npfirst loops to add pods before services (post-run),
  matching the production event sequence
- Kept podsfirst loops with original pre-run ordering (pods + services
  before cont.run) to test the initial-sync path
- Test coverage added for getServiceAugmentByPort (port-range iteration,
  namedPortServiceIndex multi-resolution, single numeric port path) and
  networkPolicyChanged (HppOptimization/EnableHppDirect spec-change,
  PolicyTypes change branches)