### PR TITLE
[mmr-6.1.1] Prevent internal customSG attribute from being posted to APIC

### DIFF
--- a/pkg/apicapi/apic_sync.go
+++ b/pkg/apicapi/apic_sync.go
@@ -40,7 +40,7 @@ func (conn *ApicConnection) apicBodyAttrCmp(class string,
 	for p, def := range meta.attributes {
 		if class == "vzRsSubjGraphAtt" && p == "tnVnsAbsGraphName" {
 			_, forceResolveExists := bodyc.Attributes["forceResolve"]
-			_, customSGAnnoExists := bodyd.Attributes["customSG"]
+			_, customSGAnnoExists := bodyd.Hints["customSG"]
 			if forceResolveExists && customSGAnnoExists {
 				bodyd.Attributes["tnVnsAbsGraphName"] = bodyc.Attributes["tnVnsAbsGraphName"]
 				conn.log.Debug("Ignoring comparison of tnVnsAbsGraphName attribute of vzRsSubjGraphAtt class")

--- a/pkg/apicapi/apic_sync_test.go
+++ b/pkg/apicapi/apic_sync_test.go
@@ -83,7 +83,9 @@ func TestApicBodyAttrCmp(t *testing.T) {
 		bodyd := &ApicObjectBody{
 			Attributes: map[string]interface{}{
 				"tnVnsAbsGraphName": "graph2",
-				"customSG":          true,
+			},
+			Hints: map[string]interface{}{
+				"customSG": true,
 			},
 		}
 

--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -30,6 +30,7 @@ import (
 
 type ApicObjectBody struct {
 	HintDn     string                 `json:"-"`
+	Hints      map[string]interface{} `json:"-"`
 	Attributes map[string]interface{} `json:"attributes,omitempty"`
 	Children   ApicSlice              `json:"children,omitempty"`
 }
@@ -1029,7 +1030,7 @@ func NewVzRsSubjGraphAtt(parentDn, tnVnsAbsGraphName string, customSG bool) Apic
 	ret := newApicObject("vzRsSubjGraphAtt")
 	ret["vzRsSubjGraphAtt"].Attributes["tnVnsAbsGraphName"] = tnVnsAbsGraphName
 	if customSG {
-		ret["vzRsSubjGraphAtt"].Attributes["customSG"] = "true"
+		ret["vzRsSubjGraphAtt"].Hints = map[string]interface{}{"customSG": true}
 	}
 	ret["vzRsSubjGraphAtt"].Attributes["dn"] =
 		fmt.Sprintf("%s/rsSubjGraphAtt", parentDn)


### PR DESCRIPTION
When a LoadBalancer service is created with the ServiceGraphName annotation already present, the controller can include customSG on vzRsSubjGraphAtt during the initial APIC post.

customSG is only meant for internal sync handling, but it was being stored as a regular APIC attribute. APIC rejects the post with: unknown attribute 'customSG' in element 'vzRsSubjGraphAtt'

Keep customSG in non-serialized object hints instead, and use that hint only for the existing sync comparison logic.

(cherry picked from commit 4c03d26d6f56d950a7fddf0dffe7765b0ffd6725)