### PR TITLE
[mmr-6.1.1] tests(hostagent): avoid stale OpFlex config artifacts

### DIFF
--- a/pkg/hostagent/opflex_test.go
+++ b/pkg/hostagent/opflex_test.go
@@ -76,6 +76,7 @@ func TestDiscoverUpdateOverlayConfig(t *testing.T) {
 
 	agent := testAgent()
 	agent.config.OpflexMode = "overlay"
+	agent.config.OpFlexConfigPath = tempdir
 	config := agent.discoverHostConfig()
 	assert.NotNil(t, config, "Host config is nil")
 	agent.config.HostAgentNodeConfig.VxlanIface = "eth1.4093"


### PR DESCRIPTION
A hostagent unit test could leave generated OpFlex config files behind after the test run, which pollutes the source tree and shows up during check runs.

Ensure the test writes its generated config into temporary test state instead of leaving stale files in pkg/hostagent.

(cherry picked from commit ae7c3be3363d12692bb622210ebd92c44f8556b1)