### PR TITLE
[mmr-6.1.1] test: add named port test coverage for network policies and services

### DIFF
--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -249,6 +249,7 @@ func (cont *testAciController) InitController() {
 	cont.initErspanPolPodIndex()
 	cont.endpointsIpIndex = cidranger.NewPCTrieRanger()
 	cont.targetPortIndex = make(map[string]*portIndexEntry)
+	cont.namedPortServiceIndex = make(map[string]*namedPortServiceIndexEntry)
 	cont.netPolSubnetIndex = cidranger.NewPCTrieRanger()
 
 }


### PR DESCRIPTION
Add comprehensive test coverage for named port resolution in network policies and services:

- 12 NetworkPolicy tests covering egress/ingress directions, empty/ non-empty selectors, multiple ports, unique rule naming, and index lifecycle (targetPortIndex and namedPortServiceIndex)
- 5 Service tests for named target port resolution, updates, and EndpointSlice integration
- 4 HppDirect mode tests validating local path behavior

Add servicePortNamed helper and initialize namedPortServiceIndex in test setup. Remove unused convertEndpointsToEndpointSlice helper.

Tests verify named port resolution via targetPortIndex (egress) and pod container ports (ingress), service augmentation, and proper index lifecycle management.

(cherry picked from commit 0c2a016470785a3ffeaf6328dccac8412df3869c)