### PR TITLE
[mmr-6.1.1] Remove enable_endpointslice option as we no longer use it

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -252,9 +252,6 @@ type ControllerConfig struct {
 	// Install Istio ControlPlane components
 	InstallIstio bool `json:"install-istio,omitempty"`
 
-	// enable EndpointSlice
-	EnabledEndpointSlice bool `json:"enable_endpointslice,omitempty"`
-
 	// Cluster Flavour
 	Flavor string `json:"flavor,omitempty"`
 

--- a/pkg/controller/config_test.go
+++ b/pkg/controller/config_test.go
@@ -79,7 +79,6 @@ func TestInitFlags(t *testing.T) {
 		EnableOpflexAgentReconnect:        false,
 		OpflexDeviceReconnectWaitTimeout:  0,
 		InstallIstio:                      false,
-		EnabledEndpointSlice:              false,
 		Flavor:                            "",
 		EnableVmmInjectedLabels:           false,
 		OpflexDeviceDeleteTimeout:         0,

--- a/pkg/hostagent/config.go
+++ b/pkg/hostagent/config.go
@@ -254,8 +254,6 @@ type HostAgentConfig struct {
 	// Delay between dhcp release and renew in seconds
 	DhcpDelay int `json:"dhcp-delay,omitempty"`
 
-	// enable EndpointSlice
-	EnabledEndpointSlice bool `json:"enable_endpointslice,omitempty"`
 	// Cluster Flavour
 	Flavor string `json:"flavor,omitempty"`
 	// Installer lb Ip provisioned for Openshift on Esx


### PR DESCRIPTION
(cherry picked from commit 9af09d65e07b44a02a8542db5e73d02af4946e8b)