### PR TITLE
[mmr-6.1.1] Remove stale Endpoints API code

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -851,19 +852,19 @@ func findNodeByIP(kubeClient kubernetes.Interface, ip string) (string, error) {
 }
 
 func findEndpoint(kubeClient kubernetes.Interface, ip string, tcp_port int, svc *v1.Service) (*v1.Pod, error) {
-	var pod *v1.Pod
-	endpoints, err := kubeClient.CoreV1().Endpoints(svc.Namespace).Get(kubecontext.TODO(), svc.Name, metav1.GetOptions{})
+	slices, err := kubeClient.DiscoveryV1().EndpointSlices(svc.Namespace).List(kubecontext.TODO(), metav1.ListOptions{
+		LabelSelector: discoveryv1.LabelServiceName + "=" + svc.Name,
+	})
 	if err != nil {
-		fmt.Printf("Error getting endpoints: %s\n", err.Error())
+		fmt.Printf("Error getting endpoint slices: %s\n", err.Error())
 		return nil, err
 	}
-	for _, subset := range endpoints.Subsets {
-		for _, address := range subset.Addresses {
-			if address.TargetRef != nil {
-				if address.IP == ip {
-					pod, err = kubeClient.CoreV1().Pods(address.TargetRef.Namespace).Get(kubecontext.TODO(), address.TargetRef.Name, metav1.GetOptions{})
+	for _, slice := range slices.Items {
+		for _, endpoint := range slice.Endpoints {
+			for _, addr := range endpoint.Addresses {
+				if addr == ip && endpoint.TargetRef != nil {
+					pod, err := kubeClient.CoreV1().Pods(endpoint.TargetRef.Namespace).Get(kubecontext.TODO(), endpoint.TargetRef.Name, metav1.GetOptions{})
 					if err != nil {
-						//fmt.Printf("Error getting pod details: %s\n", err.Error())
 						return nil, err
 					}
 					return pod, nil
@@ -871,13 +872,12 @@ func findEndpoint(kubeClient kubernetes.Interface, ip string, tcp_port int, svc 
 			}
 		}
 	}
-	pod, err = findPodByIPAndTargetPort(kubeClient, ip, tcp_port, svc)
+	pod, err := findPodByIPAndTargetPort(kubeClient, ip, tcp_port, svc)
 	if err != nil {
 		return nil, err
 	}
 
 	return pod, nil
-
 }
 
 func findPodByIPAndTargetPort(kubeClient kubernetes.Interface, ip string, tcp_port int, svc *v1.Service) (*v1.Pod, error) {

--- a/pkg/controller/common_test.go
+++ b/pkg/controller/common_test.go
@@ -15,8 +15,6 @@
 package controller
 
 import (
-	"strconv"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	v1net "k8s.io/api/networking/v1"
@@ -38,7 +36,6 @@ type testAciController struct {
 
 	fakeNamespaceSource       *framework.FakeControllerSource
 	fakePodSource             *framework.FakeControllerSource
-	fakeEndpointsSource       *framework.FakeControllerSource
 	fakeEndpointSliceSource   *framework.FakeControllerSource
 	fakeServiceSource         *framework.FakeControllerSource
 	fakeNodeSource            *framework.FakeControllerSource
@@ -66,8 +63,8 @@ type testAciController struct {
 func (cont *testAciController) InitController() {
 	cont.env.(*K8sEnvironment).cont = &cont.AciController
 	cont.env.(*K8sEnvironment).hppClient = fake.NewSimpleClientset()
-	cont.serviceEndPoints = &serviceEndpoint{}
-	cont.serviceEndPoints.(*serviceEndpoint).cont = &cont.AciController
+	cont.serviceEndPoints = &serviceEndpointSlice{}
+	cont.serviceEndPoints.(*serviceEndpointSlice).cont = &cont.AciController
 	cont.fakeNamespaceSource = framework.NewFakeControllerSource()
 	cont.initNamespaceInformerBase(
 		&cache.ListWatch{
@@ -82,12 +79,6 @@ func (cont *testAciController) InitController() {
 			WatchFunc: cont.fakePodSource.Watch,
 		})
 
-	cont.fakeEndpointsSource = framework.NewFakeControllerSource()
-	cont.initEndpointsInformerBase(
-		&cache.ListWatch{
-			ListFunc:  cont.fakeEndpointsSource.List,
-			WatchFunc: cont.fakeEndpointsSource.Watch,
-		})
 	cont.fakeEndpointSliceSource = framework.NewFakeControllerSource()
 	cont.initEndpointSliceInformerBase(
 		&cache.ListWatch{
@@ -432,43 +423,6 @@ func v6service(namespace, name, lbIP string) *v1.Service {
 			Type:           v1.ServiceTypeLoadBalancer,
 			ClusterIP:      "2001::f",
 			LoadBalancerIP: lbIP,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Annotations: map[string]string{},
-		},
-	}
-}
-
-// nodes ands addrs must have same length if present, but are
-// optional.
-func endpoints(namespace, name string,
-	nodes, addrs []string, ports []v1.EndpointPort) *v1.Endpoints {
-	var eaddrs []v1.EndpointAddress
-	if len(nodes) == 0 {
-		for i := 0; i < len(addrs); i++ {
-			nodes = append(nodes, "node"+strconv.Itoa(i))
-		}
-	}
-	for i, n := range nodes {
-		ncopy := n
-		ip := "42.42.42.42"
-		if addrs != nil {
-			ip = addrs[i]
-		}
-		eaddrs = append(eaddrs, v1.EndpointAddress{
-			IP:       ip,
-			NodeName: &ncopy,
-		})
-	}
-
-	return &v1.Endpoints{
-		Subsets: []v1.EndpointSubset{
-			{
-				Addresses: eaddrs,
-				Ports:     ports,
-			},
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   namespace,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -91,8 +91,6 @@ type AciController struct {
 	namespaceInformer                    cache.Controller
 	podIndexer                           cache.Indexer
 	podInformer                          cache.Controller
-	endpointsIndexer                     cache.Indexer
-	endpointsInformer                    cache.Controller
 	serviceIndexer                       cache.Indexer
 	serviceInformer                      cache.Controller
 	replicaSetIndexer                    cache.Indexer
@@ -421,9 +419,6 @@ type ServiceEndPointType interface {
 		portAugments map[string]*portServiceAugment, subnetIndex cidranger.Ranger, logger *logrus.Entry)
 }
 
-type serviceEndpoint struct {
-	cont *AciController
-}
 type serviceEndpointSlice struct {
 	cont *AciController
 }
@@ -440,26 +435,12 @@ type EpgVlanMap struct {
 	encapVlan int
 }
 
-func (sep *serviceEndpoint) InitClientInformer(kubeClient *kubernetes.Clientset) {
-	sep.cont.initEndpointsInformerFromClient(kubeClient)
-}
-
 func (seps *serviceEndpointSlice) InitClientInformer(kubeClient *kubernetes.Clientset) {
 	seps.cont.initEndpointSliceInformerFromClient(kubeClient)
 }
 
-func (sep *serviceEndpoint) Run(stopCh <-chan struct{}) {
-	go sep.cont.endpointsInformer.Run(stopCh)
-}
-
 func (seps *serviceEndpointSlice) Run(stopCh <-chan struct{}) {
 	go seps.cont.endpointSliceInformer.Run(stopCh)
-}
-
-func (sep *serviceEndpoint) Wait(stopCh <-chan struct{}) {
-	cache.WaitForCacheSync(stopCh,
-		sep.cont.endpointsInformer.HasSynced,
-		sep.cont.serviceInformer.HasSynced)
 }
 
 func (seps *serviceEndpointSlice) Wait(stopCh <-chan struct{}) {

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -1482,21 +1482,6 @@ func portKey(p *v1net.NetworkPolicyPort) string {
 	return ""
 }
 
-func checkEndpoints(subnetIndex cidranger.Ranger,
-	addresses []v1.EndpointAddress) bool {
-	for _, addr := range addresses {
-		ip := net.ParseIP(addr.IP)
-		if ip == nil {
-			return false
-		}
-		contains, err := subnetIndex.Contains(ip)
-		if err != nil || !contains {
-			return false
-		}
-	}
-
-	return true
-}
 func checkEndpointslices(subnetIndex cidranger.Ranger,
 	addresses []string) bool {
 	for _, addr := range addresses {
@@ -2695,65 +2680,6 @@ func (cont *AciController) networkPolicyDeleted(obj interface{}) {
 	}
 	if cont.config.EnableHppDirect {
 		cont.deleteHppCr(np)
-	}
-}
-
-func (sep *serviceEndpoint) SetNpServiceAugmentForService(servicekey string, service *v1.Service, prs *portRemoteSubnet,
-	portAugments map[string]*portServiceAugment, subnetIndex cidranger.Ranger, logger *logrus.Entry) {
-	cont := sep.cont
-	endpointsobj, _, err := cont.endpointsIndexer.GetByKey(servicekey)
-	if err != nil {
-		logger.Error("Could not lookup endpoints for "+
-			servicekey+": ", err.Error())
-		return
-	}
-	if endpointsobj == nil {
-		return
-	}
-	endpoints := endpointsobj.(*v1.Endpoints)
-	npTargetPortsMap := cont.getPortNums(prs.port)
-	for _, svcPort := range service.Spec.Ports {
-		_, ok := npTargetPortsMap[svcPort.TargetPort.IntValue()]
-		if prs.port != nil &&
-			(svcPort.Protocol != *prs.port.Protocol || !ok) {
-			// egress rule does not match service target port
-			continue
-		}
-		for _, subset := range endpoints.Subsets {
-			var foundEpPort *v1.EndpointPort
-			for ix := range subset.Ports {
-				if subset.Ports[ix].Name == svcPort.Name ||
-					(len(service.Spec.Ports) == 1 &&
-						subset.Ports[ix].Name == "") {
-					foundEpPort = &subset.Ports[ix]
-					break
-				}
-			}
-			if foundEpPort == nil {
-				continue
-			}
-
-			incomplete := false
-			incomplete = incomplete ||
-				!checkEndpoints(subnetIndex, subset.Addresses)
-			incomplete = incomplete || !checkEndpoints(subnetIndex,
-				subset.NotReadyAddresses)
-
-			if incomplete {
-				continue
-			}
-
-			proto := portProto(&foundEpPort.Protocol)
-			port := strconv.Itoa(int(svcPort.Port))
-			updateServiceAugmentForService(portAugments,
-				proto, port, service)
-
-			logger.WithFields(logrus.Fields{
-				"proto":   proto,
-				"port":    port,
-				"service": servicekey,
-			}).Debug("Allowing egress for service by subnet match")
-		}
 	}
 }
 

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -99,13 +99,6 @@ func servicePortNamed(name string, proto v1.Protocol, port int32, targetPortName
 	}
 }
 
-func endpointPort(proto v1.Protocol, port int32, name string) v1.EndpointPort {
-	return v1.EndpointPort{
-		Name:     name,
-		Protocol: proto,
-		Port:     port,
-	}
-}
 func endpointSlicePort(proto v1.Protocol, port int32, name string) discovery.EndpointPort {
 	return discovery.EndpointPort{
 		Name:     func() *string { a := name; return &a }(),
@@ -179,7 +172,6 @@ func npservice(namespace string, name string,
 }
 
 type npTestAugment struct {
-	endpoints      []*v1.Endpoints
 	services       []*v1.Service
 	endpointslices []*discovery.EndpointSlice
 }
@@ -229,9 +221,6 @@ func addServices(cont *testAciController, augment *npTestAugment) {
 	for _, s := range augment.services {
 		cont.fakeServiceSource.Add(s)
 	}
-	for _, e := range augment.endpoints {
-		cont.fakeEndpointsSource.Add(e)
-	}
 	for _, e := range augment.endpointslices {
 		cont.fakeEndpointSliceSource.Add(e)
 	}
@@ -255,24 +244,6 @@ func makeNp(ingress apicapi.ApicSlice,
 	return np1
 }
 
-func makeEps(namespace string, name string,
-	addrs []v1.EndpointAddress, ports []v1.EndpointPort) *v1.Endpoints {
-	return &v1.Endpoints{
-		Subsets: []v1.EndpointSubset{
-			{
-				Addresses: addrs,
-				Ports:     ports,
-			},
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:   namespace,
-			Name:        name,
-			Annotations: map[string]string{},
-		},
-	}
-}
-
-// endpointslice.
 func makeEpSlice(namespace string, name string, endpoints []discovery.Endpoint,
 	ports []discovery.EndpointPort, servicename string) *discovery.EndpointSlice {
 	return &discovery.EndpointSlice{
@@ -712,58 +683,6 @@ func TestNetworkPolicy(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_11_0, rule_11_s}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2.2.2.2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service3",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-							{
-								IP: "2.2.2.2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -778,7 +697,58 @@ func TestNetworkPolicy(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 80),
 						}), // should not match (incomplete IPs)
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2.2.2.2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service2"),
+					makeEpSlice("testns", "service3-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+							{
+								Addresses: []string{"2.2.2.2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service3"),
+				},
 			}, "egress-allow-http-augment"},
 		{netpol("testns", "np1", &metav1.LabelSelector{},
 			nil, []v1net.NetworkPolicyEgressRule{
@@ -795,36 +765,6 @@ func TestNetworkPolicy(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_11_0, rule_11_s}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2.2.2.2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -835,7 +775,36 @@ func TestNetworkPolicy(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 80),
 						}), // should not match (no matching IPs)
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2.2.2.2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service2"),
+				},
 			}, "egress-allow-http-augment-namedport"},
 		{netpol("testns", "np1", &metav1.LabelSelector{},
 			nil, []v1net.NetworkPolicyEgressRule{
@@ -844,36 +813,6 @@ func TestNetworkPolicy(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_14_0, rule_14_s}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2.2.2.2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 81, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -884,7 +823,36 @@ func TestNetworkPolicy(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 81),
 						}), // should not match (port wrong)
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2.2.2.2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 81, ""),
+						}, "service2"),
+				},
 			}, "egress-allow-http-all-augment"},
 		{netpol("testns", "np1", &metav1.LabelSelector{},
 			nil, []v1net.NetworkPolicyEgressRule{
@@ -896,39 +864,6 @@ func TestNetworkPolicy(t *testing.T) {
 			makeNp(nil,
 				apicapi.ApicSlice{rule_12_0, rule_12_s_0, rule_12_s_1}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.3",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns1",
-									Name:      "pod3",
-								},
-							},
-							{
-								IP: "1.1.1.4",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns1",
-									Name:      "pod4",
-								},
-							},
-							{
-								IP: "1.1.1.5",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns2",
-									Name:      "pod5",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, "http"),
-							endpointPort(v1.ProtocolTCP, 443, "https"),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.44",
 						[]v1.ServicePort{
@@ -936,7 +871,39 @@ func TestNetworkPolicy(t *testing.T) {
 							servicePort("https", v1.ProtocolTCP, 8443, 443),
 						}),
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.3"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns1",
+									Name:      "pod3",
+								},
+							},
+							{
+								Addresses: []string{"1.1.1.4"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns1",
+									Name:      "pod4",
+								},
+							},
+							{
+								Addresses: []string{"1.1.1.5"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns2",
+									Name:      "pod5",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, "http"),
+							endpointSlicePort(v1.ProtocolTCP, 443, "https"),
+						}, "service1"),
+				},
 			}, "egress-allow-subnet-augment"},
 		{netpol("testns", "np1", &metav1.LabelSelector{},
 			nil, []v1net.NetworkPolicyEgressRule{
@@ -944,11 +911,17 @@ func TestNetworkPolicy(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_13_0}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
+				[]*v1.Service{
+					npservice("testns", "service1", "9.0.0.42",
+						[]v1.ServicePort{
+							servicePort("", v1.ProtocolTCP, 8080, 80),
+						}),
+				},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "1.1.1.1",
+								Addresses: []string{"1.1.1.1"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
 									Namespace: "testns",
@@ -956,17 +929,10 @@ func TestNetworkPolicy(t *testing.T) {
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
 				},
-				[]*v1.Service{
-					npservice("testns", "service1", "9.0.0.42",
-						[]v1.ServicePort{
-							servicePort("", v1.ProtocolTCP, 8080, 80),
-						}),
-				},
-				[]*discovery.EndpointSlice{},
 			}, "egress-allow-all-augment"},
 		{netpol("testns", "np1", &metav1.LabelSelector{},
 			nil, []v1net.NetworkPolicyEgressRule{
@@ -979,36 +945,6 @@ func TestNetworkPolicy(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_11_0_portrange, rule_11_s_portrange}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2.2.2.2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -1019,7 +955,36 @@ func TestNetworkPolicy(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 80),
 						}), // should not match (no matching IPs)
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2.2.2.2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service2"),
+				},
 			}, "egress-allow-http-portrange-augment"},
 	}
 	initCont := func() *testAciController {
@@ -1639,58 +1604,6 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 		{test16_np,
 			makeNp(nil, apicapi.ApicSlice{test16_rule1, test16_rule2}, test16_np_name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2.2.2.2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service3",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-							{
-								IP: "2.2.2.2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -1705,16 +1618,11 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 80),
 						}), // should not match (incomplete IPs)
 				},
-				[]*discovery.EndpointSlice{},
-			}, "egress-allow-http-augment"},
-		{test17_np,
-			makeNp(nil, apicapi.ApicSlice{test17_rule1, test17_rule2}, test17_np_name),
-			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "1.1.1.1",
+								Addresses: []string{"1.1.1.1"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
 									Namespace: "testns",
@@ -1722,13 +1630,13 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "2.2.2.2",
+								Addresses: []string{"2.2.2.2"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
 									Namespace: "testns",
@@ -1736,10 +1644,36 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service2"),
+					makeEpSlice("testns", "service3-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+							{
+								Addresses: []string{"2.2.2.2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service3"),
 				},
+			}, "egress-allow-http-augment"},
+		{test17_np,
+			makeNp(nil, apicapi.ApicSlice{test17_rule1, test17_rule2}, test17_np_name),
+			&npTestAugment{
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -1750,16 +1684,11 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 80),
 						}), // should not match (no matching IPs)
 				},
-				[]*discovery.EndpointSlice{},
-			}, "egress-allow-http-augment-namedport"},
-		{test18_np,
-			makeNp(nil, apicapi.ApicSlice{test18_rule1, test18_rule2}, test18_np_name),
-			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "1.1.1.1",
+								Addresses: []string{"1.1.1.1"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
 									Namespace: "testns",
@@ -1767,13 +1696,13 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "2.2.2.2",
+								Addresses: []string{"2.2.2.2"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
 									Namespace: "testns",
@@ -1781,10 +1710,14 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 81, ""),
-						}),
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service2"),
 				},
+			}, "egress-allow-http-augment-namedport"},
+		{test18_np,
+			makeNp(nil, apicapi.ApicSlice{test18_rule1, test18_rule2}, test18_np_name),
+			&npTestAugment{
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -1795,62 +1728,11 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 81),
 						}), // should not match (port wrong)
 				},
-				[]*discovery.EndpointSlice{},
-			}, "egress-allow-http-all-augment"},
-		{test19_np,
-			makeNp(nil,
-				apicapi.ApicSlice{test19_rule1, test19_rule2, test19_rule3}, test19_np_name),
-			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "1.1.1.3",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns1",
-									Name:      "pod3",
-								},
-							},
-							{
-								IP: "1.1.1.4",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns1",
-									Name:      "pod4",
-								},
-							},
-							{
-								IP: "1.1.1.5",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns2",
-									Name:      "pod5",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, "http"),
-							endpointPort(v1.ProtocolTCP, 443, "https"),
-						}),
-				},
-				[]*v1.Service{
-					npservice("testns", "service1", "9.0.0.44",
-						[]v1.ServicePort{
-							servicePort("http", v1.ProtocolTCP, 8080, 80),
-							servicePort("https", v1.ProtocolTCP, 8443, 443),
-						}),
-				},
-				[]*discovery.EndpointSlice{},
-			}, "egress-allow-subnet-augment"},
-		{test20_np,
-			makeNp(nil, apicapi.ApicSlice{test20_rule}, test20_np_name),
-			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
+								Addresses: []string{"1.1.1.1"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
 									Namespace: "testns",
@@ -1858,43 +1740,13 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-				},
-				[]*v1.Service{
-					npservice("testns", "service1", "9.0.0.42",
-						[]v1.ServicePort{
-							servicePort("", v1.ProtocolTCP, 8080, 80),
-						}),
-				},
-				[]*discovery.EndpointSlice{},
-			}, "egress-allow-all-augment"},
-		{test21_np,
-			makeNp(nil, apicapi.ApicSlice{test21_rule}, test21_np_name),
-			nil, "egress-allow-http-portrange"},
-		{test22_np,
-			makeNp(nil, apicapi.ApicSlice{test22_rule1, test22_rule2}, test22_np_name),
-			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2.2.2.2",
+								Addresses: []string{"2.2.2.2"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
 									Namespace: "testns",
@@ -1902,10 +1754,88 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 81, ""),
+						}, "service2"),
+				},
+			}, "egress-allow-http-all-augment"},
+		{test19_np,
+			makeNp(nil,
+				apicapi.ApicSlice{test19_rule1, test19_rule2, test19_rule3}, test19_np_name),
+			&npTestAugment{
+				[]*v1.Service{
+					npservice("testns", "service1", "9.0.0.44",
+						[]v1.ServicePort{
+							servicePort("http", v1.ProtocolTCP, 8080, 80),
+							servicePort("https", v1.ProtocolTCP, 8443, 443),
 						}),
 				},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.3"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns1",
+									Name:      "pod3",
+								},
+							},
+							{
+								Addresses: []string{"1.1.1.4"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns1",
+									Name:      "pod4",
+								},
+							},
+							{
+								Addresses: []string{"1.1.1.5"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns2",
+									Name:      "pod5",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, "http"),
+							endpointSlicePort(v1.ProtocolTCP, 443, "https"),
+						}, "service1"),
+				},
+			}, "egress-allow-subnet-augment"},
+		{test20_np,
+			makeNp(nil, apicapi.ApicSlice{test20_rule}, test20_np_name),
+			&npTestAugment{
+				[]*v1.Service{
+					npservice("testns", "service1", "9.0.0.42",
+						[]v1.ServicePort{
+							servicePort("", v1.ProtocolTCP, 8080, 80),
+						}),
+				},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+				},
+			}, "egress-allow-all-augment"},
+		{test21_np,
+			makeNp(nil, apicapi.ApicSlice{test21_rule}, test21_np_name),
+			nil, "egress-allow-http-portrange"},
+		{test22_np,
+			makeNp(nil, apicapi.ApicSlice{test22_rule1, test22_rule2}, test22_np_name),
+			&npTestAugment{
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -1916,7 +1846,36 @@ func TestNetworkPolicyHppOptimize(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 80),
 						}), // should not match (no matching IPs)
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2.2.2.2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service2"),
+				},
 			}, "egress-allow-http-portrange-augment"},
 	}
 	initCont := func() *testAciController {
@@ -2312,58 +2271,6 @@ func TestNetworkPolicyv6(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_11_0_v6, rule_11_s_v6}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testnsv6", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "2001::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testnsv6",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testnsv6", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2002:2::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testnsv6",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testnsv6", "service3",
-						[]v1.EndpointAddress{
-							{
-								IP: "2001::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testnsv6",
-									Name:      "pod1",
-								},
-							},
-							{
-								IP: "2002:2::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testnsv6",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testnsv6", "service1", "fd00::1234",
 						[]v1.ServicePort{
@@ -2378,7 +2285,58 @@ func TestNetworkPolicyv6(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 80),
 						}), // should not match (incomplete IPs)
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testnsv6", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2001::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testnsv6",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testnsv6", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2002:2::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testnsv6",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service2"),
+					makeEpSlice("testnsv6", "service3-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2001::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testnsv6",
+									Name:      "pod1",
+								},
+							},
+							{
+								Addresses: []string{"2002:2::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testnsv6",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service3"),
+				},
 			}, "egress-allow-http-augment"},
 		{netpol("testnsv6", "npv6", &metav1.LabelSelector{},
 			nil, []v1net.NetworkPolicyEgressRule{
@@ -2387,36 +2345,6 @@ func TestNetworkPolicyv6(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_14_0_v6, rule_14_s_v6}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testnsv6", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "2001::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2002::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 81, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testns", "service1", "fd00::1234",
 						[]v1.ServicePort{
@@ -2427,7 +2355,36 @@ func TestNetworkPolicyv6(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 81),
 						}), // should not match (port wrong)
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testnsv6", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2001::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2002::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 81, ""),
+						}, "service2"),
+				},
 			}, "egress-allow-http-all-augment"},
 		{netpol("testnsv6", "npv6", &metav1.LabelSelector{},
 			nil, []v1net.NetworkPolicyEgressRule{
@@ -2439,39 +2396,6 @@ func TestNetworkPolicyv6(t *testing.T) {
 			makeNp(nil,
 				apicapi.ApicSlice{rule_12_0_v6, rule_12_s_0_v6, rule_12_s_1_v6}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testnsv6", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "2001::4",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns1",
-									Name:      "pod3",
-								},
-							},
-							{
-								IP: "2001::5",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns1",
-									Name:      "pod4",
-								},
-							},
-							{
-								IP: "2001::6",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns2",
-									Name:      "pod5",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, "http"),
-							endpointPort(v1.ProtocolTCP, 443, "https"),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testnsv6", "service1", "fd00::1236",
 						[]v1.ServicePort{
@@ -2479,7 +2403,39 @@ func TestNetworkPolicyv6(t *testing.T) {
 							servicePort("https", v1.ProtocolTCP, 8443, 443),
 						}),
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testnsv6", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2001::4"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns1",
+									Name:      "pod3",
+								},
+							},
+							{
+								Addresses: []string{"2001::5"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns1",
+									Name:      "pod4",
+								},
+							},
+							{
+								Addresses: []string{"2001::6"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns2",
+									Name:      "pod5",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, "http"),
+							endpointSlicePort(v1.ProtocolTCP, 443, "https"),
+						}, "service1"),
+				},
 			}, "egress-allow-subnet-augment"},
 		{netpol("testnsv6", "npv6", &metav1.LabelSelector{},
 			nil, []v1net.NetworkPolicyEgressRule{
@@ -2487,11 +2443,17 @@ func TestNetworkPolicyv6(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_13_0_v6}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
+				[]*v1.Service{
+					npservice("testns", "service1", "fd00::1234",
+						[]v1.ServicePort{
+							servicePort("", v1.ProtocolTCP, 8080, 80),
+						}),
+				},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "2001::2",
+								Addresses: []string{"2001::2"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
 									Namespace: "testns",
@@ -2499,17 +2461,10 @@ func TestNetworkPolicyv6(t *testing.T) {
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
 				},
-				[]*v1.Service{
-					npservice("testns", "service1", "fd00::1234",
-						[]v1.ServicePort{
-							servicePort("", v1.ProtocolTCP, 8080, 80),
-						}),
-				},
-				[]*discovery.EndpointSlice{},
 			}, "egress-allow-all-augment"},
 	}
 
@@ -2891,58 +2846,6 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 		{test14_np_v6,
 			makeNp(nil, apicapi.ApicSlice{test14_rule1_v6, test14_rule2_v6}, test14_np_name_v6),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testnsv6", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "2001::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testnsv6",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testnsv6", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2002:2::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testnsv6",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testnsv6", "service3",
-						[]v1.EndpointAddress{
-							{
-								IP: "2001::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testnsv6",
-									Name:      "pod1",
-								},
-							},
-							{
-								IP: "2002:2::2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testnsv6",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testnsv6", "service1", "fd00::1234",
 						[]v1.ServicePort{
@@ -2957,41 +2860,62 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 80),
 						}), // should not match (incomplete IPs)
 				},
-				[]*discovery.EndpointSlice{},
-			}, "egress-allow-http-augment"},
-		{test15_np_v6,
-			makeNp(nil, apicapi.ApicSlice{test15_rule1_v6, test15_rule2_v6}, test15_np_name_v6),
-			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testnsv6", "service1",
-						[]v1.EndpointAddress{
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testnsv6", "service1-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "2001::2",
+								Addresses: []string{"2001::2"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
-									Namespace: "testns",
+									Namespace: "testnsv6",
 									Name:      "pod1",
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testnsv6", "service2-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "2002::2",
+								Addresses: []string{"2002:2::2"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
-									Namespace: "testns",
+									Namespace: "testnsv6",
 									Name:      "pod2",
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 81, ""),
-						}),
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service2"),
+					makeEpSlice("testnsv6", "service3-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2001::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testnsv6",
+									Name:      "pod1",
+								},
+							},
+							{
+								Addresses: []string{"2002:2::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testnsv6",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service3"),
 				},
+			}, "egress-allow-http-augment"},
+		{test15_np_v6,
+			makeNp(nil, apicapi.ApicSlice{test15_rule1_v6, test15_rule2_v6}, test15_np_name_v6),
+			&npTestAugment{
 				[]*v1.Service{
 					npservice("testns", "service1", "fd00::1234",
 						[]v1.ServicePort{
@@ -3002,62 +2926,11 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8080, 81),
 						}), // should not match (port wrong)
 				},
-				[]*discovery.EndpointSlice{},
-			}, "egress-allow-http-all-augment"},
-		{test16_np_v6,
-			makeNp(nil,
-				apicapi.ApicSlice{test16_rule1_v6, test16_rule2_v6, test16_rule3_v6}, test16_np_name_v6),
-			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testnsv6", "service1",
-						[]v1.EndpointAddress{
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testnsv6", "service1-eps",
+						[]discovery.Endpoint{
 							{
-								IP: "2001::4",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns1",
-									Name:      "pod3",
-								},
-							},
-							{
-								IP: "2001::5",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns1",
-									Name:      "pod4",
-								},
-							},
-							{
-								IP: "2001::6",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "ns2",
-									Name:      "pod5",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, "http"),
-							endpointPort(v1.ProtocolTCP, 443, "https"),
-						}),
-				},
-				[]*v1.Service{
-					npservice("testnsv6", "service1", "fd00::1236",
-						[]v1.ServicePort{
-							servicePort("http", v1.ProtocolTCP, 8080, 80),
-							servicePort("https", v1.ProtocolTCP, 8443, 443),
-						}),
-				},
-				[]*discovery.EndpointSlice{},
-			}, "egress-allow-subnet-augment"},
-		{test17_np_v6,
-			makeNp(nil, apicapi.ApicSlice{test17_rule_v6}, test17_np_name_v6),
-			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "2001::2",
+								Addresses: []string{"2001::2"},
 								TargetRef: &v1.ObjectReference{
 									Kind:      "Pod",
 									Namespace: "testns",
@@ -3065,17 +2938,95 @@ func TestNetworkPolicyv6HppOptimize(t *testing.T) {
 								},
 							},
 						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2002::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 81, ""),
+						}, "service2"),
+				},
+			}, "egress-allow-http-all-augment"},
+		{test16_np_v6,
+			makeNp(nil,
+				apicapi.ApicSlice{test16_rule1_v6, test16_rule2_v6, test16_rule3_v6}, test16_np_name_v6),
+			&npTestAugment{
+				[]*v1.Service{
+					npservice("testnsv6", "service1", "fd00::1236",
+						[]v1.ServicePort{
+							servicePort("http", v1.ProtocolTCP, 8080, 80),
+							servicePort("https", v1.ProtocolTCP, 8443, 443),
 						}),
 				},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testnsv6", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2001::4"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns1",
+									Name:      "pod3",
+								},
+							},
+							{
+								Addresses: []string{"2001::5"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns1",
+									Name:      "pod4",
+								},
+							},
+							{
+								Addresses: []string{"2001::6"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "ns2",
+									Name:      "pod5",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, "http"),
+							endpointSlicePort(v1.ProtocolTCP, 443, "https"),
+						}, "service1"),
+				},
+			}, "egress-allow-subnet-augment"},
+		{test17_np_v6,
+			makeNp(nil, apicapi.ApicSlice{test17_rule_v6}, test17_np_name_v6),
+			&npTestAugment{
 				[]*v1.Service{
 					npservice("testns", "service1", "fd00::1234",
 						[]v1.ServicePort{
 							servicePort("", v1.ProtocolTCP, 8080, 80),
 						}),
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2001::2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+				},
 			}, "egress-allow-all-augment"},
 	}
 
@@ -3225,7 +3176,6 @@ func TestNetworkPolicyWithEndPointSlice(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_11_0, rule_11_s}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -3343,7 +3293,6 @@ func TestNetworkPolicyWithEndPointSlice(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_11_0, rule_11_s}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -3398,7 +3347,6 @@ func TestNetworkPolicyWithEndPointSlice(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_14_0, rule_14_s}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -3452,7 +3400,6 @@ func TestNetworkPolicyWithEndPointSlice(t *testing.T) {
 			makeNp(nil,
 				apicapi.ApicSlice{rule_12_0, rule_12_s_0, rule_12_s_1}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.44",
 						[]v1.ServicePort{
@@ -3506,7 +3453,6 @@ func TestNetworkPolicyWithEndPointSlice(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_13_0}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -3702,7 +3648,6 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		{test16_np,
 			makeNp(nil, apicapi.ApicSlice{test16_rule1, test16_rule2}, test16_np_name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -3778,7 +3723,6 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		{test17_np,
 			makeNp(nil, apicapi.ApicSlice{test17_rule1, test17_rule2}, test17_np_name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -3829,7 +3773,6 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		{test18_np,
 			makeNp(nil, apicapi.ApicSlice{test18_rule1, test18_rule2}, test18_np_name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -3877,7 +3820,6 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 			makeNp(nil,
 				apicapi.ApicSlice{test19_rule1, test19_rule2, test19_rule3}, test19_np_name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.44",
 						[]v1.ServicePort{
@@ -3928,7 +3870,6 @@ func TestNetworkPolicyWithEndPointSliceHppOptimize(t *testing.T) {
 		{test20_np,
 			makeNp(nil, apicapi.ApicSlice{test20_rule}, test20_np_name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -4053,36 +3994,6 @@ func TestNetworkPolicyEgressNmPort(t *testing.T) {
 			}, allPolicyTypes),
 			makeNp(nil, apicapi.ApicSlice{rule_1_0, rule_1_s}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2.2.2.2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 81, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -4093,7 +4004,36 @@ func TestNetworkPolicyEgressNmPort(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8081, 81),
 						}),
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2.2.2.2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 81, ""),
+						}, "service2"),
+				},
 			}, "egress-allow-http-all-augment-namedport-mathing-diffrent-ports"},
 	}
 	initCont := func() *testAciController {
@@ -4206,36 +4146,6 @@ func TestNetworkPolicyEgressNmPortHppOptimize(t *testing.T) {
 		{test1_np,
 			makeNp(nil, apicapi.ApicSlice{test1_rule1, test1_rule2}, test1_np_name),
 			&npTestAugment{
-				[]*v1.Endpoints{
-					makeEps("testns", "service1",
-						[]v1.EndpointAddress{
-							{
-								IP: "1.1.1.1",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod1",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 80, ""),
-						}),
-					makeEps("testns", "service2",
-						[]v1.EndpointAddress{
-							{
-								IP: "2.2.2.2",
-								TargetRef: &v1.ObjectReference{
-									Kind:      "Pod",
-									Namespace: "testns",
-									Name:      "pod2",
-								},
-							},
-						},
-						[]v1.EndpointPort{
-							endpointPort(v1.ProtocolTCP, 81, ""),
-						}),
-				},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -4246,7 +4156,36 @@ func TestNetworkPolicyEgressNmPortHppOptimize(t *testing.T) {
 							servicePort("", v1.ProtocolTCP, 8081, 81),
 						}),
 				},
-				[]*discovery.EndpointSlice{},
+				[]*discovery.EndpointSlice{
+					makeEpSlice("testns", "service1-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"1.1.1.1"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod1",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 80, ""),
+						}, "service1"),
+					makeEpSlice("testns", "service2-eps",
+						[]discovery.Endpoint{
+							{
+								Addresses: []string{"2.2.2.2"},
+								TargetRef: &v1.ObjectReference{
+									Kind:      "Pod",
+									Namespace: "testns",
+									Name:      "pod2",
+								},
+							},
+						},
+						[]discovery.EndpointPort{
+							endpointSlicePort(v1.ProtocolTCP, 81, ""),
+						}, "service2"),
+				},
 			}, "egress-allow-http-all-augment-namedport-mathing-diffrent-ports"},
 	}
 	initCont := func() *testAciController {
@@ -5934,7 +5873,6 @@ func TestNetworkPolicyEgressNamedPortWithPodSelector(t *testing.T) {
 		{test_np,
 			makeNp(nil, apicapi.ApicSlice{rule_1_0, rule_1_s}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -6310,7 +6248,6 @@ func TestNetworkPolicyNamedPortMultipleEndpoints(t *testing.T) {
 		{test_np,
 			makeNp(nil, apicapi.ApicSlice{rule_80, rule_svc}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -6440,7 +6377,6 @@ func TestNetworkPolicyEgressEmptyToWithNamedPort(t *testing.T) {
 		{test_np,
 			makeNp(nil, apicapi.ApicSlice{rule_1_0, rule_1_s}, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{
 					npservice("testns", "service1", "9.0.0.42",
 						[]v1.ServicePort{
@@ -6561,7 +6497,6 @@ func TestNetworkPolicyIngressNamedPort(t *testing.T) {
 		{test_np,
 			makeNp(apicapi.ApicSlice{rule_1_0}, nil, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{},
 				[]*discovery.EndpointSlice{},
 			}, "ingress-named-port"},
@@ -6674,7 +6609,6 @@ func TestNetworkPolicyIngressMultipleNamedPorts(t *testing.T) {
 		{test_np,
 			makeNp(apicapi.ApicSlice{rule_1_0, rule_1_1}, nil, name),
 			&npTestAugment{
-				[]*v1.Endpoints{},
 				[]*v1.Service{},
 				[]*discovery.EndpointSlice{},
 			}, "ingress-multiple-named-ports"},

--- a/pkg/controller/qos_test.go
+++ b/pkg/controller/qos_test.go
@@ -35,8 +35,7 @@ import (
 )
 
 type qrTestAugment struct {
-	endpoints []*v1.Endpoints
-	services  []*v1.Service
+	services []*v1.Service
 }
 
 type qrTest struct {
@@ -52,9 +51,6 @@ func addQosServices(cont *testAciController, augment *qrTestAugment) {
 	}
 	for _, s := range augment.services {
 		cont.fakeServiceSource.Add(s)
-	}
-	for _, e := range augment.endpoints {
-		cont.fakeEndpointsSource.Add(e)
 	}
 }
 

--- a/pkg/controller/services.go
+++ b/pkg/controller/services.go
@@ -45,14 +45,6 @@ const DefaultServiceContractScope = "context"
 // Default service ext subnet scope - enable shared security
 const DefaultServiceExtSubNetShared = false
 
-func (cont *AciController) initEndpointsInformerFromClient(
-	kubeClient kubernetes.Interface) {
-	cont.initEndpointsInformerBase(
-		cache.NewListWatchFromClient(
-			kubeClient.CoreV1().RESTClient(), "endpoints",
-			metav1.NamespaceAll, fields.Everything()))
-}
-
 func (cont *AciController) initEndpointSliceInformerFromClient(
 	kubeClient kubernetes.Interface) {
 	cont.initEndpointSliceInformerBase(
@@ -73,24 +65,6 @@ func (cont *AciController) initEndpointSliceInformerBase(listWatch *cache.ListWa
 			},
 			DeleteFunc: func(obj interface{}) {
 				cont.endpointSliceDeleted(obj)
-			},
-		},
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-	)
-}
-
-func (cont *AciController) initEndpointsInformerBase(listWatch *cache.ListWatch) {
-	cont.endpointsIndexer, cont.endpointsInformer = cache.NewIndexerInformer(
-		listWatch, &v1.Endpoints{}, 0,
-		cache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				cont.endpointsAdded(obj)
-			},
-			UpdateFunc: func(old interface{}, new interface{}) {
-				cont.endpointsUpdated(old, new)
-			},
-			DeleteFunc: func(obj interface{}) {
-				cont.endpointsDeleted(obj)
 			},
 		},
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
@@ -162,25 +136,6 @@ func (cont *AciController) queuePortNetPolUpdates(ports map[string]targetPort) {
 	}
 }
 
-func (cont *AciController) queueNetPolForEpAddrs(addrs []v1.EndpointAddress) {
-	for _, addr := range addrs {
-		if addr.TargetRef == nil || addr.TargetRef.Kind != "Pod" ||
-			addr.TargetRef.Namespace == "" || addr.TargetRef.Name == "" {
-			continue
-		}
-		podkey := addr.TargetRef.Namespace + "/" + addr.TargetRef.Name
-		npkeys := cont.netPolEgressPods.GetObjForPod(podkey)
-		ps := make(map[string]bool)
-		for _, npkey := range npkeys {
-			cont.queueNetPolUpdateByKey(npkey)
-			ps[npkey] = true
-		}
-		// Process if the  any matching namedport wildcard policy is present
-		// ignore np already processed policies
-		cont.queueMatchingNamedNp(ps, podkey)
-	}
-}
-
 func (cont *AciController) queueMatchingNamedNp(served map[string]bool, podkey string) {
 	cont.indexMutex.Lock()
 	for npkey := range cont.nmPortNp {
@@ -191,12 +146,6 @@ func (cont *AciController) queueMatchingNamedNp(served map[string]bool, podkey s
 		}
 	}
 	cont.indexMutex.Unlock()
-}
-func (cont *AciController) queueEndpointsNetPolUpdates(endpoints *v1.Endpoints) {
-	for _, subset := range endpoints.Subsets {
-		cont.queueNetPolForEpAddrs(subset.Addresses)
-		cont.queueNetPolForEpAddrs(subset.NotReadyAddresses)
-	}
 }
 
 func (cont *AciController) returnServiceIps(ips []net.IP) {
@@ -2204,19 +2153,6 @@ func (cont *AciController) clearLbService(servicekey string) {
 	cont.apicConn.ClearApicObjects(cont.aciNameForKey("svc", servicekey))
 }
 
-func getEndpointsIps(endpoints *v1.Endpoints) map[string]bool {
-	ips := make(map[string]bool)
-	for _, subset := range endpoints.Subsets {
-		for _, addr := range subset.Addresses {
-			ips[addr.IP] = true
-		}
-		for _, addr := range subset.NotReadyAddresses {
-			ips[addr.IP] = true
-		}
-	}
-	return ips
-}
-
 func (cont *AciController) processServiceTargetPorts(service *v1.Service, svcKey string, old bool) map[string]targetPort {
 	ports := make(map[string]targetPort)
 	for _, port := range service.Spec.Ports {
@@ -2261,83 +2197,6 @@ func (cont *AciController) processServiceTargetPorts(service *v1.Service, svcKey
 		}
 	}
 	return ports
-}
-
-func (cont *AciController) endpointsAdded(obj interface{}) {
-	endpoints := obj.(*v1.Endpoints)
-	servicekey, err := cache.MetaNamespaceKeyFunc(obj.(*v1.Endpoints))
-	if err != nil {
-		cont.log.Error("Could not create service key: ", err)
-		return
-	}
-
-	ips := getEndpointsIps(endpoints)
-	cont.indexMutex.Lock()
-	cont.updateIpIndex(cont.endpointsIpIndex, nil, ips, servicekey)
-	cont.queueIPNetPolUpdates(ips)
-	cont.indexMutex.Unlock()
-
-	cont.queueEndpointsNetPolUpdates(endpoints)
-
-	cont.queueServiceUpdateByKey(servicekey)
-}
-
-func (cont *AciController) endpointsDeleted(obj interface{}) {
-	endpoints, isEndpoints := obj.(*v1.Endpoints)
-	if !isEndpoints {
-		deletedState, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			cont.log.Error("Received unexpected object: ", obj)
-			return
-		}
-		endpoints, ok = deletedState.Obj.(*v1.Endpoints)
-		if !ok {
-			cont.log.Error("DeletedFinalStateUnknown contained non-Endpoints object: ", deletedState.Obj)
-			return
-		}
-	}
-	servicekey, err := cache.MetaNamespaceKeyFunc(endpoints)
-	if err != nil {
-		cont.log.Error("Could not create service key: ", err)
-		return
-	}
-
-	ips := getEndpointsIps(endpoints)
-	cont.indexMutex.Lock()
-	cont.updateIpIndex(cont.endpointsIpIndex, ips, nil, servicekey)
-	cont.queueIPNetPolUpdates(ips)
-	cont.indexMutex.Unlock()
-
-	cont.queueEndpointsNetPolUpdates(endpoints)
-
-	cont.queueServiceUpdateByKey(servicekey)
-}
-
-func (cont *AciController) endpointsUpdated(oldEps, newEps interface{}) {
-	oldendpoints := oldEps.(*v1.Endpoints)
-	newendpoints := newEps.(*v1.Endpoints)
-	servicekey, err := cache.MetaNamespaceKeyFunc(newendpoints)
-	if err != nil {
-		cont.log.Error("Could not create service key: ", err)
-		return
-	}
-
-	oldIps := getEndpointsIps(oldendpoints)
-	newIps := getEndpointsIps(newendpoints)
-	if !reflect.DeepEqual(oldIps, newIps) {
-		cont.indexMutex.Lock()
-		cont.queueIPNetPolUpdates(oldIps)
-		cont.updateIpIndex(cont.endpointsIpIndex, oldIps, newIps, servicekey)
-		cont.queueIPNetPolUpdates(newIps)
-		cont.indexMutex.Unlock()
-	}
-
-	if !reflect.DeepEqual(oldendpoints.Subsets, newendpoints.Subsets) {
-		cont.queueEndpointsNetPolUpdates(oldendpoints)
-		cont.queueEndpointsNetPolUpdates(newendpoints)
-	}
-
-	cont.queueServiceUpdateByKey(servicekey)
 }
 
 func (cont *AciController) serviceAdded(obj interface{}) {
@@ -2736,29 +2595,6 @@ func getServiceNameAndNs(endPointSlice *discovery.EndpointSlice) (string, string
 	return serviceName, endPointSlice.ObjectMeta.Namespace, true
 }
 
-// can be called with index lock
-func (sep *serviceEndpoint) UpdateServicesForNode(nodename string) {
-	cont := sep.cont
-	cache.ListAll(cont.endpointsIndexer, labels.Everything(),
-		func(endpointsobj interface{}) {
-			endpoints := endpointsobj.(*v1.Endpoints)
-			for _, subset := range endpoints.Subsets {
-				for _, addr := range subset.Addresses {
-					if addr.NodeName != nil && *addr.NodeName == nodename {
-						servicekey, err :=
-							cache.MetaNamespaceKeyFunc(endpointsobj.(*v1.Endpoints))
-						if err != nil {
-							cont.log.Error("Could not create endpoints key: ", err)
-							return
-						}
-						cont.queueServiceUpdateByKey(servicekey)
-						return
-					}
-				}
-			}
-		})
-}
-
 func (seps *serviceEndpointSlice) UpdateServicesForNode(nodename string) {
 	// 1. List all the endpointslice and check for matching nodename
 	// 2. if it matches trigger the Service update and mark it visited
@@ -2846,28 +2682,6 @@ func (cont *AciController) setNodeMapDelay(nodeMap map[string]*metadata.ServiceE
 	}
 }
 
-func (sep *serviceEndpoint) GetnodesMetadata(key string,
-	service *v1.Service, nodeMap map[string]*metadata.ServiceEndpoint) {
-	cont := sep.cont
-	endpointsobj, exists, err := cont.endpointsIndexer.GetByKey(key)
-	if err != nil {
-		cont.log.Error("Could not lookup endpoints for " +
-			key + ": " + err.Error())
-	}
-	if exists && endpointsobj != nil {
-		endpoints := endpointsobj.(*v1.Endpoints)
-		for _, subset := range endpoints.Subsets {
-			for _, addr := range subset.Addresses {
-				if addr.NodeName == nil {
-					continue
-				}
-				cont.setNodeMap(nodeMap, *addr.NodeName)
-			}
-		}
-	}
-	cont.log.Info("NodeMap: ", nodeMap)
-}
-
 func (seps *serviceEndpointSlice) GetnodesMetadata(key string,
 	service *v1.Service, nodeMap map[string]*metadata.ServiceEndpoint) {
 	cont := seps.cont
@@ -2890,34 +2704,6 @@ func (seps *serviceEndpointSlice) GetnodesMetadata(key string,
 			}
 		})
 	cont.log.Debug("NodeMap: ", nodeMap)
-}
-
-func (sep *serviceEndpoint) SetServiceApicObject(aobj apicapi.ApicObject, service *v1.Service) bool {
-	cont := sep.cont
-	key, err := cache.MetaNamespaceKeyFunc(service)
-	if err != nil {
-		serviceLogger(cont.log, service).
-			Error("Could not create service key: ", err)
-		return false
-	}
-	endpointsobj, _, err := cont.endpointsIndexer.GetByKey(key)
-	if err != nil {
-		cont.log.Error("Could not lookup endpoints for " +
-			key + ": " + err.Error())
-		return false
-	}
-	if endpointsobj != nil {
-		for _, subset := range endpointsobj.(*v1.Endpoints).Subsets {
-			for _, addr := range subset.Addresses {
-				if addr.TargetRef == nil || addr.TargetRef.Kind != "Pod" {
-					continue
-				}
-				aobj.AddChild(apicapi.NewVmmInjectedSvcEp(aobj.GetDn(),
-					addr.TargetRef.Name))
-			}
-		}
-	}
-	return true
 }
 
 func (seps *serviceEndpointSlice) SetServiceApicObject(aobj apicapi.ApicObject, service *v1.Service) bool {

--- a/pkg/controller/services_test.go
+++ b/pkg/controller/services_test.go
@@ -408,8 +408,15 @@ func TestServiceAnnotation(t *testing.T) {
 	}
 	s1Dcc := apicDevCtx(name, "common", graphName, graphName,
 		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn(), false)
-	endpoints1 := endpoints("testns", "service1",
-		[]string{"node1", "node2"}, nil, nil)
+	ready := true
+	node1name := "node1"
+	node2name := "node2"
+	epSlice1 := endpointslice("testns", "service1-eps", []discovery.Endpoint{
+		{Addresses: []string{"42.42.42.42"}, NodeName: &node1name,
+			Conditions: discovery.EndpointConditions{Ready: &ready}},
+		{Addresses: []string{"42.42.42.43"}, NodeName: &node2name,
+			Conditions: discovery.EndpointConditions{Ready: &ready}},
+	}, "service1")
 	service1 := service("testns", "service1", "10.4.2.2")
 	service1.Spec.Ports = []v1.ServicePort{
 		{
@@ -471,7 +478,7 @@ func TestServiceAnnotation(t *testing.T) {
 	cont.opflexDeviceChanged(opflexDevice0)
 	cont.opflexDeviceChanged(opflexDevice1)
 	cont.opflexDeviceChanged(opflexDevice2)
-	cont.fakeEndpointsSource.Add(endpoints1)
+	cont.fakeEndpointSliceSource.Add(epSlice1)
 
 	//Function to check if an object is present in the apic connection at a specific key
 	sgPresentObject := func(t *testing.T, desc string, cont *testAciController,
@@ -600,8 +607,15 @@ func TestServiceGraph(t *testing.T) {
 	s1Dcc := apicDevCtx(name, "common", graphName, graphName,
 		"kube_bd_kubernetes-service", oneNodeRedirect.GetDn(), false)
 
-	endpoints1 := endpoints("testns", "service1",
-		[]string{"node1", "node2"}, nil, nil)
+	ready := true
+	node1name := "node1"
+	node2name := "node2"
+	epSlice1 := endpointslice("testns", "service1-eps", []discovery.Endpoint{
+		{Addresses: []string{"42.42.42.42"}, NodeName: &node1name,
+			Conditions: discovery.EndpointConditions{Ready: &ready}},
+		{Addresses: []string{"42.42.42.43"}, NodeName: &node2name,
+			Conditions: discovery.EndpointConditions{Ready: &ready}},
+	}, "service1")
 	service1 := service("testns", "service1", "10.4.2.2")
 	service1.Spec.Ports = []v1.ServicePort{
 		{
@@ -706,7 +720,7 @@ func TestServiceGraph(t *testing.T) {
 
 	sgWait(t, "non-lb", cont, expectedNoService)
 	cont.serviceUpdates = nil
-	cont.fakeEndpointsSource.Add(endpoints1)
+	cont.fakeEndpointSliceSource.Add(epSlice1)
 	cont.fakeServiceSource.Add(service1)
 
 	sgWait(t, "create", cont, expected)
@@ -733,11 +747,11 @@ func TestServiceGraph(t *testing.T) {
 	cont.opflexDeviceChanged(opflexDevice2)
 	sgWait(t, "restore device", cont, expected)
 
-	cont.fakeEndpointsSource.Delete(endpoints1)
+	cont.fakeEndpointSliceSource.Delete(epSlice1)
 	sgWait(t, "delete eps", cont,
 		map[string]apicapi.ApicSlice{name: nil})
 
-	cont.fakeEndpointsSource.Add(endpoints1)
+	cont.fakeEndpointSliceSource.Add(epSlice1)
 	sgWait(t, "add eps", cont, expected)
 
 	cont.fakeNodeSource.Delete(node1)
@@ -759,64 +773,6 @@ func TestServiceGraph(t *testing.T) {
 		map[string]apicapi.ApicSlice{name: nil})
 
 	cont.stop()
-}
-
-func TestEndpointsIpIndex(t *testing.T) {
-	eps1 := endpoints("ns1", "name1", nil, []string{"1.1.1.1", "1.1.1.2"}, nil)
-
-	cont := testController()
-	cont.fakeEndpointsSource.Add(eps1)
-	cont.run()
-
-	tu.WaitForComp(t, "add", 500*time.Millisecond,
-		func() bool {
-			c1, _ := cont.endpointsIpIndex.Contains(net.ParseIP("1.1.1.1"))
-			c2, _ := cont.endpointsIpIndex.Contains(net.ParseIP("1.1.1.2"))
-			return (c1 && c2)
-		})
-
-	eps1 = endpoints("ns1", "name1", nil, []string{"1.1.1.1"}, nil)
-	cont.log.Info("updating")
-	cont.fakeEndpointsSource.Add(eps1)
-
-	tu.WaitForComp(t, "update", 500*time.Millisecond,
-		func() bool {
-			c1, _ := cont.endpointsIpIndex.Contains(net.ParseIP("1.1.1.1"))
-			c2, _ := cont.endpointsIpIndex.Contains(net.ParseIP("1.1.1.2"))
-			return (c1 && !c2)
-		})
-
-	cont.log.Info("adding new")
-	eps2 := endpoints("ns1", "name2", nil, []string{"1.1.1.1", "1.1.1.3"}, nil)
-	cont.fakeEndpointsSource.Add(eps2)
-
-	tu.WaitForComp(t, "new", 500*time.Millisecond,
-		func() bool {
-			c1, _ := cont.endpointsIpIndex.Contains(net.ParseIP("1.1.1.3"))
-			return c1
-		})
-
-	cont.log.Info("ipv6")
-	eps3 := endpoints("ns1", "name2", nil, []string{"2001::1"}, nil)
-	cont.fakeEndpointsSource.Add(eps3)
-
-	tu.WaitForComp(t, "ipv6", 500*time.Millisecond,
-		func() bool {
-			c1, _ := cont.endpointsIpIndex.Contains(net.ParseIP("2001::1"))
-			return c1
-		})
-
-	cont.log.Info("deleting")
-	cont.fakeEndpointsSource.Delete(eps1)
-	cont.fakeEndpointsSource.Delete(eps2)
-
-	tu.WaitForComp(t, "delete", 500*time.Millisecond,
-		func() bool {
-			c1, _ := cont.endpointsIpIndex.Contains(net.ParseIP("1.1.1.1"))
-			c2, _ := cont.endpointsIpIndex.Contains(net.ParseIP("1.1.1.2"))
-			c3, _ := cont.endpointsIpIndex.Contains(net.ParseIP("1.1.1.3"))
-			return (!c1 && !c2 && !c3)
-		})
 }
 
 func TestEndpointsliceIpIndex(t *testing.T) {

--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -81,7 +81,6 @@ type HostAgent struct {
 	nodePodIFClient        nodepodifv1.AciV1Interface
 	fabAttClient           fabattv1.AciV1Interface
 	podInformer            cache.SharedIndexInformer
-	endpointsInformer      cache.SharedIndexInformer
 	serviceInformer        cache.SharedIndexInformer
 	nodeInformer           cache.SharedIndexInformer
 	nsInformer             cache.SharedIndexInformer
@@ -163,24 +162,12 @@ type ServiceEndPointType interface {
 		external bool, key string, sp *v1.ServicePort) bool
 }
 
-type serviceEndpoint struct {
-	agent *HostAgent
-}
 type serviceEndpointSlice struct {
 	agent *HostAgent
 }
 
-func (sep *serviceEndpoint) InitClientInformer(kubeClient *kubernetes.Clientset) {
-	sep.agent.initEndpointsInformerFromClient(kubeClient)
-}
-
 func (seps *serviceEndpointSlice) InitClientInformer(kubeClient *kubernetes.Clientset) {
 	seps.agent.initEndpointSliceInformerFromClient(kubeClient)
-}
-
-func (sep *serviceEndpoint) Run(stopCh <-chan struct{}) {
-	go sep.agent.endpointsInformer.Run(stopCh)
-	cache.WaitForCacheSync(stopCh, sep.agent.endpointsInformer.HasSynced)
 }
 
 func (seps *serviceEndpointSlice) Run(stopCh <-chan struct{}) {

--- a/pkg/hostagent/common_test.go
+++ b/pkg/hostagent/common_test.go
@@ -41,7 +41,6 @@ type testHostAgent struct {
 
 	fakeNodeSource           *framework.FakeControllerSource
 	fakePodSource            *framework.FakeControllerSource
-	fakeEndpointsSource      *framework.FakeControllerSource
 	fakeEndpointSliceSource  *framework.FakeControllerSource
 	fakeServiceSource        *framework.FakeControllerSource
 	fakeNamespaceSource      *framework.FakeControllerSource
@@ -99,8 +98,8 @@ func testAgentWithConf(hcf *HostAgentConfig) *testHostAgent {
 
 func testAgentInit(agent *testHostAgent) *testHostAgent {
 	agent.env.(*K8sEnvironment).agent = agent.HostAgent
-	agent.serviceEndPoints = &serviceEndpoint{}
-	agent.serviceEndPoints.(*serviceEndpoint).agent = agent.HostAgent
+	agent.serviceEndPoints = &serviceEndpointSlice{}
+	agent.serviceEndPoints.(*serviceEndpointSlice).agent = agent.HostAgent
 	agent.fakeNodeSource = framework.NewFakeControllerSource()
 	agent.config.OvsDbSock = ""
 	agent.initNodeInformerBase(
@@ -122,12 +121,6 @@ func testAgentInit(agent *testHostAgent) *testHostAgent {
 			WatchFunc: agent.fakePodSource.Watch,
 		})
 
-	agent.fakeEndpointsSource = framework.NewFakeControllerSource()
-	agent.initEndpointsInformerBase(
-		&cache.ListWatch{
-			ListFunc:  agent.fakeEndpointsSource.List,
-			WatchFunc: agent.fakeEndpointsSource.Watch,
-		})
 	agent.fakeEndpointSliceSource = framework.NewFakeControllerSource()
 	agent.initEndpointSliceInformerBase(
 		&cache.ListWatch{

--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -58,7 +58,6 @@ type K8sEnvironment struct {
 	snatLocalInfoClient *snatlocalinfoclset.Clientset
 	agent               *HostAgent
 	podInformer         cache.SharedIndexInformer
-	endpointsInformer   cache.SharedIndexInformer
 	serviceInformer     cache.SharedIndexInformer
 	nodeInformer        cache.SharedIndexInformer
 	netClient           *netClientSet.Clientset

--- a/pkg/hostagent/services.go
+++ b/pkg/hostagent/services.go
@@ -158,47 +158,6 @@ var Version = map[string]bool{
 	"openshift-4.20-agent-based-esx":       true,
 }
 
-func (agent *HostAgent) initEndpointsInformerFromClient(
-	kubeClient *kubernetes.Clientset) {
-	agent.initEndpointsInformerBase(
-		&cache.ListWatch{
-			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-				obj, err := kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).List(context.TODO(), options)
-				if err != nil {
-					agent.log.Fatalf("Failed to list Endpoints during initialization of EndpointsInformer: %s", err)
-				}
-				return obj, err
-			},
-			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-				obj, err := kubeClient.CoreV1().Endpoints(metav1.NamespaceAll).Watch(context.TODO(), options)
-				if err != nil {
-					agent.log.Fatalf("Failed to watch Endpoints during initialization of EndpointsInformer: %s", err)
-				}
-				return obj, err
-			},
-		})
-}
-
-func (agent *HostAgent) initEndpointsInformerBase(listWatch *cache.ListWatch) {
-	agent.endpointsInformer = cache.NewSharedIndexInformer(
-		listWatch,
-		&v1.Endpoints{},
-		controller.NoResyncPeriodFunc(),
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
-	)
-	agent.endpointsInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			agent.endpointsChanged(obj)
-		},
-		UpdateFunc: func(_ interface{}, obj interface{}) {
-			agent.endpointsChanged(obj)
-		},
-		DeleteFunc: func(obj interface{}) {
-			agent.endpointsChanged(obj)
-		},
-	})
-}
-
 func (agent *HostAgent) initEndpointSliceInformerFromClient(
 	kubeClient *kubernetes.Clientset) {
 	agent.initEndpointSliceInformerBase(
@@ -481,21 +440,6 @@ func (agent *HostAgent) doUpdateService(key string) {
 	}
 }
 
-func (agent *HostAgent) endpointsChanged(obj interface{}) {
-	agent.indexMutex.Lock()
-	defer agent.indexMutex.Unlock()
-
-	endpoints := obj.(*v1.Endpoints)
-	agent.log.Debugf("Endpoint changed: name=%s namespace=%s",
-		endpoints.ObjectMeta.Name, endpoints.ObjectMeta.Namespace)
-
-	key, err := cache.MetaNamespaceKeyFunc(endpoints)
-	if err != nil {
-		agent.log.Error("Could not create key:" + err.Error())
-		return
-	}
-	agent.doUpdateService(key)
-}
 func getServiceKey(endPointSlice *discovery.EndpointSlice) (string, bool) {
 	serviceName, ok := endPointSlice.Labels[discovery.LabelServiceName]
 	if !ok {
@@ -669,102 +613,6 @@ func (agent *HostAgent) setOpenShfitService(as *v1.Service, external bool, ofas 
 			}
 		}
 	}
-}
-
-func (sep *serviceEndpoint) SetOpflexService(ofas *opflexService, as *v1.Service,
-	external bool, key string, sp *v1.ServicePort) bool {
-	agent := sep.agent
-	endpointsobj, exists, err :=
-		agent.endpointsInformer.GetStore().GetByKey(key)
-	if err != nil {
-		agent.log.Error("Could not lookup endpoints for " +
-			key + ": " + err.Error())
-		return false
-	}
-	if !exists || endpointsobj == nil {
-		agent.log.Debugf("no endpoints for service %s/%s", as.Namespace, as.Name)
-		return false
-	}
-	endpoints := endpointsobj.(*v1.Endpoints)
-	hasValidMapping := false
-
-	type void struct{}
-	var ipexists void
-	clusterIPs := make(map[string]void)
-	clusterIPs[as.Spec.ClusterIP] = ipexists
-	clusterIPsField := reflect.ValueOf(as.Spec).FieldByName("ClusterIPs")
-	if clusterIPsField.IsValid() {
-		for _, ip := range as.Spec.ClusterIPs {
-			clusterIPs[ip] = ipexists
-		}
-	}
-
-	for clusterIP := range clusterIPs {
-		for _, e := range endpoints.Subsets {
-			if len(e.Addresses) == 0 {
-				continue
-			}
-			parsedClusterIp := net.ParseIP(clusterIP)
-			parsedPodIp := net.ParseIP(e.Addresses[0].IP)
-
-			if parsedClusterIp == nil || parsedPodIp == nil {
-				agent.log.Info("Not a valid IP address..", parsedClusterIp, parsedPodIp)
-				continue
-			}
-			if parsedClusterIp.To4() != nil && parsedPodIp.To4() != nil {
-				agent.log.Info("Both are IPv4 addresses..", parsedClusterIp, parsedPodIp, "Adding to map..")
-			} else if parsedClusterIp.To4() == nil && parsedPodIp.To4() == nil {
-				agent.log.Info("Both are IPv6 addresses..", parsedClusterIp, parsedPodIp, "Adding to map..")
-			} else {
-				continue
-			}
-			for _, p := range e.Ports {
-				if p.Protocol != sp.Protocol {
-					continue
-				}
-				if p.Name != sp.Name {
-					continue
-				}
-
-				sm := &opflexServiceMapping{
-					ServicePort:  uint16(sp.Port),
-					ServiceProto: strings.ToLower(string(sp.Protocol)),
-					NextHopIps:   make([]string, 0),
-					NextHopPort:  uint16(p.Port),
-					Conntrack:    true,
-					NodePort:     uint16(sp.NodePort),
-				}
-
-				if external {
-					if as.Spec.Type == v1.ServiceTypeLoadBalancer &&
-						len(as.Status.LoadBalancer.Ingress) > 0 {
-						for _, ip := range as.Status.LoadBalancer.Ingress {
-							LBIp := net.ParseIP(ip.IP)
-							if (LBIp.To4() != nil) == (parsedPodIp.To4() != nil) {
-								sm.ServiceIp = ip.IP
-								break
-							}
-						}
-					}
-				} else {
-					sm.ServiceIp = clusterIP
-				}
-				sm.setServiceAffinityConfig(as)
-				for _, a := range e.Addresses {
-					if !external ||
-						(a.NodeName != nil && *a.NodeName == agent.config.NodeName) {
-						sm.NextHopIps = append(sm.NextHopIps, a.IP)
-					}
-				}
-				if sm.ServiceIp != "" && len(sm.NextHopIps) > 0 {
-					hasValidMapping = true
-				}
-
-				ofas.ServiceMappings = append(ofas.ServiceMappings, *sm)
-			}
-		}
-	}
-	return hasValidMapping
 }
 
 func (sm *opflexServiceMapping) setServiceAffinityConfig(as *v1.Service) {

--- a/pkg/hostagent/services_test.go
+++ b/pkg/hostagent/services_test.go
@@ -73,36 +73,6 @@ func service(uuid string, namespace string, name string,
 	return s
 }
 
-func endpoints(namespace string, name string,
-	nextHopIps []string, ports []int32) *v1.Endpoints {
-	e := &v1.Endpoints{
-		Subsets: []v1.EndpointSubset{{}},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-	}
-
-	nn := "test-node"
-	for _, ip := range nextHopIps {
-		e.Subsets[0].Addresses =
-			append(e.Subsets[0].Addresses, v1.EndpointAddress{
-				IP:       ip,
-				NodeName: &nn,
-			})
-	}
-
-	for _, port := range ports {
-		e.Subsets[0].Ports =
-			append(e.Subsets[0].Ports, v1.EndpointPort{
-				Port:     port,
-				Protocol: "TCP",
-			})
-	}
-
-	return e
-}
-
 func endpointslice(namespace string, name string,
 	nextHopIps []string, ports []int32, nodename string) *discovery.EndpointSlice {
 	e := &discovery.EndpointSlice{
@@ -303,9 +273,9 @@ func TestServiceSync(t *testing.T) {
 		}
 		service := service(st.uuid, st.namespace, st.name,
 			st.clusterIp, st.externalIp, st.ports)
-		endpoints := endpoints(st.namespace, st.name, st.nextHopIps, st.ports)
+		epSlice := endpointslice(st.namespace, st.name, st.nextHopIps, st.ports, "test-node")
 		agent.fakeServiceSource.Add(service)
-		agent.fakeEndpointsSource.Add(endpoints)
+		agent.fakeEndpointSliceSource.Add(epSlice)
 		agent.doTestService(t, tempdir, &serviceTests[i], "create")
 	}
 
@@ -554,9 +524,9 @@ func TestServiceEptoSerMap(t *testing.T) {
 	service := service(st.uuid, st.namespace, st.name,
 		st.clusterIp, st.externalIp, st.ports)
 	service.Spec.Selector = map[string]string{"app": "tier"}
-	endpoints := endpoints(st.namespace, st.name, st.nextHopIps, st.ports)
+	epSlice := endpointslice(st.namespace, st.name, st.nextHopIps, st.ports, "test-node")
 	agent.fakeServiceSource.Add(service)
-	agent.fakeEndpointsSource.Add(endpoints)
+	agent.fakeEndpointSliceSource.Add(epSlice)
 	time.Sleep(10 * time.Millisecond)
 	clusterIp := agent.getServiceIPs("poduid")
 	assert.Equal(t, clusterIp, []string{"100.1.1.1"}, "Updated", "ClusterIp")
@@ -615,9 +585,9 @@ func TestSingleStackIPv6ServiceEptoSerMap(t *testing.T) {
 	service := service(st.uuid, st.namespace, st.name,
 		st.clusterIp, st.externalIp, st.ports)
 	service.Spec.Selector = map[string]string{"app": "tier"}
-	endpoints := endpoints(st.namespace, st.name, st.nextHopIps, st.ports)
+	epSlice := endpointslice(st.namespace, st.name, st.nextHopIps, st.ports, "test-node")
 	agent.fakeServiceSource.Add(service)
-	agent.fakeEndpointsSource.Add(endpoints)
+	agent.fakeEndpointSliceSource.Add(epSlice)
 	time.Sleep(10 * time.Millisecond)
 	clusterIp := agent.getServiceIPs("poduid")
 	assert.Equal(t, clusterIp, []string{"2001:1db8:42::8664"}, "Updated", "ClusterIp")
@@ -679,9 +649,9 @@ func TestDualStackServiceEptoSerMap(t *testing.T) {
 	service := service(st.uuid, st.namespace, st.name,
 		st.clusterIp, st.externalIp, st.ports)
 	service.Spec.Selector = map[string]string{"app": "tier"}
-	endpoints := endpoints(st.namespace, st.name, st.nextHopIps, st.ports)
+	epSlice := endpointslice(st.namespace, st.name, st.nextHopIps, st.ports, "test-node")
 	agent.fakeServiceSource.Add(service)
-	agent.fakeEndpointsSource.Add(endpoints)
+	agent.fakeEndpointSliceSource.Add(epSlice)
 	time.Sleep(10 * time.Millisecond)
 	clusterIp := agent.getServiceIPs("poduid")
 	assert.Equal(t, clusterIp, []string{"2001:1db8:42::8664"}, "Updated", "ClusterIp")


### PR DESCRIPTION
The Kubernetes Endpoints API support was recently removed. This cleanup removes all leftover stale code that was only reachable through the old Endpoints path.

Removed:
- serviceEndpoint struct and all its methods from both controller and hostagent packages
- Endpoints informer setup, event handlers, and related helpers
- makeEps test helper and endpointPort; all test call sites now use makeEpSlice with native EndpointSlice types directly
- Stale test infrastructure (fakeEndpointsSource, endpoints fields in test augment structs)

(cherry picked from commit 49e5d9fb8c66660a7bba6970533e13da811034b7)