### PR TITLE
[mmr-6.1.1] Update warn msg for droplog config

### DIFF
--- a/cmd/acikubectl/cmd/debug.go
+++ b/cmd/acikubectl/cmd/debug.go
@@ -71,13 +71,13 @@ func getDropLogFile(kubeClient kubernetes.Interface, systemNamespace string) str
 
 	accProvisionInput, ok := result["acc_provision_input"].(map[string]interface{})
 	if !ok {
-		fmt.Fprintln(os.Stderr, "acc_provision_input not found in configMap")
+		fmt.Fprintln(os.Stderr, "[warn] acc_provision_input is absent in configMap, skipping droplog collection")
 		return ""
 	}
 
 	dropLogConfig, ok := accProvisionInput["drop_log_config"].(map[string]interface{})
 	if !ok {
-		fmt.Fprintln(os.Stderr, "drop_log_config not found in acc_provision_input")
+		fmt.Fprintln(os.Stderr, "[warn] drop_log_config is absent in acc_provision_input, skipping droplog collection")
 		return ""
 	}
 


### PR DESCRIPTION
Replaced keywords like 'not found' from the warn message

(cherry picked from commit 833c586af3331d799b80aeb3d2b7db7ec1c698de)