### PR TITLE
Fix missing return in handleRemIpContUpdate

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -1897,6 +1897,7 @@ func (cont *AciController) handleRemIpContUpdate(ns string) bool {
 			cont.log.Error("Couldn't find the ns in nsRemoteIpCont cache: ", ns)
 			return false
 		}
+		return false
 	}
 
 	aobj.Spec.HostprotRemoteIp = buildHostprotRemoteIpList(remIpCont)


### PR DESCRIPTION
Fixes a bug where after deleting a HostprotRemoteIpContainer CR (when not found in nsRemoteIpCont cache), the code continued to attempt updating the deleted CR, causing 'UID field not found' errors.