### PR TITLE
[mmr-6.1.1] Fix: Pods missing EPG update when deployment annotation changes

### DIFF
--- a/pkg/hostagent/pod_relatives.go
+++ b/pkg/hostagent/pod_relatives.go
@@ -406,8 +406,9 @@ func (agent *HostAgent) deploymentChanged(oldobj interface{},
 				Error("Could not create key: ", err)
 			return
 		}
-		for ix := range agent.depPods.GetPodForObj(depkey) {
-			agent.podChanged(&agent.depPods.GetPodForObj(depkey)[ix])
+		podkeys := agent.depPods.GetPodForObj(depkey)
+		for ix := range podkeys {
+			agent.podChanged(&podkeys[ix])
 		}
 	}
 	if !reflect.DeepEqual(olddep.ObjectMeta.Labels,
@@ -523,8 +524,9 @@ func (agent *HostAgent) rcChanged(oldobj interface{},
 				Error("Could not create key: ", err)
 			return
 		}
-		for ix := range agent.rcPods.GetPodForObj(rckey) {
-			agent.podChanged(&agent.rcPods.GetPodForObj(rckey)[ix])
+		podkeys := agent.rcPods.GetPodForObj(rckey)
+		for ix := range podkeys {
+			agent.podChanged(&podkeys[ix])
 		}
 	}
 }


### PR DESCRIPTION
When changing a deployment's EPG annotation, some pods were not updated due to non-deterministic Go map iteration order in the pod processing loop.

Store GetPodForObj() result before iterating to ensure consistent processing.

(cherry picked from commit 824bc7eb595946fcbb13e5b4751e570296343a07)