### PR TITLE
Add flag to enable/disable rate-limiting APIC requests

### DIFF
--- a/pkg/apicapi/apic_types.go
+++ b/pkg/apicapi/apic_types.go
@@ -124,6 +124,7 @@ type ApicConnection struct {
 	ReconnectRetryLimit   int
 	RequestRetryDelayBase int
 	EnableRequestRetry    bool
+	DisableRateLimit      bool
 	VmmDomain             string
 	Flavor                string
 	FilterOpflexDevice    bool

--- a/pkg/apicapi/apicapi.go
+++ b/pkg/apicapi/apicapi.go
@@ -251,7 +251,7 @@ func New(log *logrus.Logger, apic []string, user string,
 }
 
 func (conn *ApicConnection) addToQueue(queue workqueue.RateLimitingInterface, item interface{}) {
-	if conn.cnoEnabled {
+	if conn.cnoEnabled || conn.DisableRateLimit {
 		queue.Add(item)
 	} else {
 		queue.AddRateLimited(item)
@@ -1224,7 +1224,7 @@ func (conn *ApicConnection) getSubtreeDn(dn string, respClasses []string,
 func (conn *ApicConnection) queuePriorityDn(dn string) {
 	conn.indexMutex.Lock()
 	if conn.priorityQueue != nil {
-		conn.priorityQueue.AddRateLimited(dn)
+		conn.addToQueue(conn.priorityQueue, dn)
 	}
 	conn.indexMutex.Unlock()
 }
@@ -1232,7 +1232,7 @@ func (conn *ApicConnection) queuePriorityDn(dn string) {
 func (conn *ApicConnection) queueDn(dn string) {
 	conn.indexMutex.Lock()
 	if conn.deltaQueue != nil {
-		conn.deltaQueue.AddRateLimited(dn)
+		conn.addToQueue(conn.deltaQueue, dn)
 	}
 	conn.indexMutex.Unlock()
 }

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -316,6 +316,9 @@ type ControllerConfig struct {
 	// Enable retying request to APIC when a 503 error is encountered
 	EnableApicRequestRetry bool `json:"enable-apic-request-retry-delay,omitempty"`
 
+	// Disable rate-limiting APIC requests; default false means rate limiting is enabled
+	DisableApicRateLimit bool `json:"disable-apic-rate-limit,omitempty"`
+
 	// Disable hpp rendering if set to true
 	DisableHppRendering bool `json:"disable-hpp-rendering,omitempty"`
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -871,6 +871,7 @@ func (cont *AciController) Run(stopCh <-chan struct{}) {
 	cont.apicConn.ReconnectRetryLimit = cont.config.ApicConnectionRetryLimit
 	cont.apicConn.RequestRetryDelayBase = cont.config.ApicRequestRetryDelayBase
 	cont.apicConn.EnableRequestRetry = cont.config.EnableApicRequestRetry
+	cont.apicConn.DisableRateLimit = cont.config.DisableApicRateLimit
 
 	if len(cont.config.ApicHosts) != 0 {
 	APIC_SWITCH:


### PR DESCRIPTION
Introduce disable-apic-rate-limit config option (default: false) to control whether APIC request queues use AddRateLimited or Add for enqueuing items.