### PR TITLE
Fix HPP Direct IPv6 policy enforcement for NetworkPolicies

### DIFF
--- a/pkg/hostagent/hpp_lib.go
+++ b/pkg/hostagent/hpp_lib.go
@@ -530,15 +530,7 @@ func (hsc *HpSubjChild) Make(ruleMo *gbpCommonMo, subjName, npName string) error
 		cfMo.AddProperty(propConnTrack, ct)
 	}
 
-	var prot int
-	switch hsc.Attributes["protocol"] {
-	case "udp":
-		prot = 17
-	case "icmp":
-		prot = 1
-	case "tcp":
-		prot = 6
-	}
+	prot := protocolNameToNumber(hsc.Attributes["protocol"])
 	if prot != 0 {
 		cfMo.AddProperty(propProt, prot)
 	}
@@ -589,9 +581,7 @@ func (hsc *HpSubjChild) Make(ruleMo *gbpCommonMo, subjName, npName string) error
 	cfMo.Make(cname, uri)
 	ss.Make(cname, ssUri)
 	for _, addr := range ipSet {
-		if len(strings.Split(addr, "/")) == 1 {
-			addr += "/32"
-		}
+		addr = normalizeRemoteAddr(addr)
 		s := &GBPSubnet{}
 		sUri := fmt.Sprintf("%sGbpLocalSubnet/%s/", ssUri, escapeName(strings.Split(addr, "/")[0], false))
 		s.Make(addr, sUri)
@@ -605,6 +595,35 @@ func (hsc *HpSubjChild) Make(ruleMo *gbpCommonMo, subjName, npName string) error
 	linkParentChild(ruleMo, &ssRef.gbpCommonMo)
 
 	return nil
+}
+
+func protocolNameToNumber(protocol string) int {
+	switch strings.ToLower(protocol) {
+	case "udp":
+		return 17
+	case "icmp":
+		return 1
+	case "tcp":
+		return 6
+	case "icmpv6":
+		return 58
+	default:
+		return 0
+	}
+}
+
+func normalizeRemoteAddr(addr string) string {
+	if strings.Contains(addr, "/") {
+		return addr
+	}
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		return addr
+	}
+	if ip.To4() != nil {
+		return addr + "/32"
+	}
+	return addr + "/128"
 }
 
 func (hsc *HpSubjChild) getRemoteIPs() []string {

--- a/pkg/hostagent/hpp_lib_test.go
+++ b/pkg/hostagent/hpp_lib_test.go
@@ -1,0 +1,50 @@
+package hostagent
+
+import "testing"
+
+func TestNormalizeRemoteAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "ipv4 bare", in: "10.1.2.3", want: "10.1.2.3/32"},
+		{name: "ipv6 bare", in: "2001:db8::10", want: "2001:db8::10/128"},
+		{name: "ipv4 cidr unchanged", in: "10.1.2.0/24", want: "10.1.2.0/24"},
+		{name: "ipv6 cidr unchanged", in: "2001:db8::/64", want: "2001:db8::/64"},
+		{name: "invalid unchanged", in: "not-an-ip", want: "not-an-ip"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeRemoteAddr(tt.in)
+			if got != tt.want {
+				t.Fatalf("normalizeRemoteAddr(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProtocolNameToNumber(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{name: "udp", in: "udp", want: 17},
+		{name: "icmp", in: "icmp", want: 1},
+		{name: "tcp", in: "tcp", want: 6},
+		{name: "icmpv6", in: "icmpv6", want: 58},
+		{name: "case insensitive", in: "ICMPV6", want: 58},
+		{name: "unknown", in: "sctp", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := protocolNameToNumber(tt.in)
+			if got != tt.want {
+				t.Fatalf("protocolNameToNumber(%q) = %d, want %d", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/hostagent/pods.go
+++ b/pkg/hostagent/pods.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -155,19 +156,22 @@ func (agent *HostAgent) NodeEPRegAdd(nodePodIfEPs map[string]*opflexEndpoint) bo
 
 	var podifs []nodepodif.PodIF
 	for _, ep := range nodePodIfEPs {
-		ipRemEP := strings.Split(ep.IpAddress[0], "/")[0] + "/32"
-		opflexEpLogger(agent.log, ep).Debug("ipRemEP")
-		var podif nodepodif.PodIF
-		podif.PodNS = ep.Attributes["namespace"]
-		podif.PodName = ep.Attributes["vm-name"]
-		podif.ContainerID = ep.Uuid
-		podif.MacAddr = ep.MacAddress
-		podif.IPAddr = ipRemEP
-		// could change
-		podif.EPG = ep.EndpointGroup
-		podif.VTEP = agent.vtepIP
-		podif.IFName = ep.IfaceName
-		podifs = append(podifs, podif)
+		// Register all pod IPs (IPv4 and IPv6 for dual-stack)
+		for _, ipAddr := range ep.IpAddress {
+			ipRemEP := normalizeRemoteAddrForEP(strings.Split(ipAddr, "/")[0])
+			opflexEpLogger(agent.log, ep).Debug("ipRemEP: " + ipRemEP)
+			var podif nodepodif.PodIF
+			podif.PodNS = ep.Attributes["namespace"]
+			podif.PodName = ep.Attributes["vm-name"]
+			podif.ContainerID = ep.Uuid
+			podif.MacAddr = ep.MacAddress
+			podif.IPAddr = ipRemEP
+			// could change
+			podif.EPG = ep.EndpointGroup
+			podif.VTEP = agent.vtepIP
+			podif.IFName = ep.IfaceName
+			podifs = append(podifs, podif)
+		}
 	}
 
 	nodePodif, err := agent.nodePodIFClient.NodePodIFs("kube-system").Get(context.TODO(), agent.getNodePodIFName(agent.config.NodeName), metav1.GetOptions{})
@@ -341,6 +345,28 @@ func writeEp(epfile string, ep *opflexEndpoint) (bool, error) {
 	}
 	err = os.WriteFile(epfile, newdata, 0644)
 	return true, err
+}
+
+// normalizeRemoteAddrForEP adds the appropriate prefix length for IPv4 and IPv6 addresses
+// IPv4 bare addresses get /32, IPv6 bare addresses get /128
+func normalizeRemoteAddrForEP(addr string) string {
+	// If address is empty or already has a prefix, return as-is
+	if addr == "" || strings.Contains(addr, "/") {
+		return addr
+	}
+
+	// Parse the IP to determine family
+	ip := net.ParseIP(addr)
+	if ip == nil {
+		// Invalid IP, return with /32 as fallback
+		return addr + "/32"
+	}
+
+	// IPv4 addresses get /32, IPv6 get /128
+	if ip.To4() != nil {
+		return addr + "/32"
+	}
+	return addr + "/128"
 }
 
 func podLogger(log *logrus.Logger, pod *v1.Pod) *logrus.Entry {


### PR DESCRIPTION
1. Protocol-to-number translation did not exist for IPv6 rules. Added protocolNameToNumber() to map protocol names to their IP protocol numbers. Without this, "icmpv6" had no mapping, so the L24 classifier for the static-discovery ICMPv6/NDP allow rule was generated with no protocol constraint, matching all IPv6 traffic (ethertype=ipv6, any protocol). This gave every IPv6 packet a free pass through the whitelist, bypassing deny rules entirely. Fixed by adding the function with "icmpv6" mapped to protocol 58.

2. Remote IP normalization did not exist for IPv6 subnet classifiers. Added normalizeRemoteAddr() in hpp_lib.go to append the correct prefix length to bare IP addresses. Without this, bare IPv6 addresses were used as-is, causing wrong or no match in the GBP subnet classifier. Fixed by appending /32 for IPv4 and /128 for IPv6.
3. NodeEPRegAdd() in pods.go hardcoded /32 for all pod IPs including IPv6, resulting in wrong prefix length in NodePodIF entries for dual-stack nodes. Fixed by adding normalizeRemoteAddrForEP() which applies /32 for IPv4 and /128 for IPv6.