### PR TITLE
[mmr-6.1.1] Bump go version to 1.26.3 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
     - stage: check
       if: tag IS NOT present
       sudo: false
-      go: 1.25.8
+      go: 1.26.3
       before_install:
         - go install github.com/mattn/goveralls@v0.0.12
       install:
@@ -36,7 +36,7 @@ jobs:
         - pip install PyYAML
         - pip install pytz
         - curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
-      go: 1.25.8
+      go: 1.26.3
       go_import_path: github.com/noironetworks/aci-containers
       before_script:
         - export DOCKER_BUILDKIT=1


### PR DESCRIPTION
(cherry picked from commit e7bf1ba4e766613dfb38ec556ff126c2a9065d79)