### PR TITLE
Source OpenSSL/FIPS from UBI, only missing packages from CentOS Stream

### DIFF
--- a/docker/travis/Dockerfile-host
+++ b/docker/travis/Dockerfile-host
@@ -7,16 +7,21 @@ version="v1.1.0" \
 release="1" \
 summary="This is an ACI CNI Host-Agent." \
 description="This will deploy a single instance of ACI CNI Host-Agent."
-RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
-# For some reason this prevents the next RUN from installing the incompat fips module
-RUN microdnf install -y yum yum-utils \
- && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
- && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os
-
-RUN yum update --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os -y --nogpgcheck && rm -rf /var/cache/yum
-RUN yum install --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os dhcp-client curl iptables-nft nftables jq nmstate tar -y --allowerasing --nogpgcheck && rm -rf /var/cache/yum
+RUN microdnf install -y yum yum-utils
 
 RUN yum update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y && rm -rf /var/cache/yum
+
+RUN yum install -y --nogpgcheck --allowerasing \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+    curl iptables-nft nftables jq nmstate tar \
+ && rm -rf /var/cache/yum
+
+RUN yum install -y --nogpgcheck \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+      --repofrompath=centos-baseos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
+      --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
+    dhcp-client \
+ && rm -rf /var/cache/yum
 
 COPY dist-static/iptables-libs.tar.gz dist-static/iptables-bin.tar.gz dist-static/iptables-wrapper-installer.sh /tmp/
 

--- a/docker/travis/Dockerfile-openvswitch
+++ b/docker/travis/Dockerfile-openvswitch
@@ -1,12 +1,21 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
 RUN microdnf install -y yum yum-utils
-RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
-RUN yum install -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
-  logrotate conntrack-tools tcpdump strace ltrace iptables net-tools \
-  libcap vi hostname iproute openssl procps-ng kmod tar \
+
+RUN yum --nogpgcheck update -y \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms
+
+RUN yum install -y --nogpgcheck \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+    logrotate tcpdump strace iptables-nft net-tools \
+    libcap vim-minimal hostname iproute openssl procps-ng kmod tar \
  && yum clean all
-RUN yum --nogpgcheck update -y
+
+RUN yum install -y --nogpgcheck \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+      --repofrompath=centos-baseos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
+      --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
+    conntrack-tools ltrace \
+ && yum clean all
 # Required OpenShift Labels
 LABEL name="ACI CNI Openvswitch" \
 maintainer="Vishal Lella <vlella@cisco.com>" \

--- a/docker/travis/Dockerfile-openvswitch-base
+++ b/docker/travis/Dockerfile-openvswitch-base
@@ -1,23 +1,26 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
-RUN rpm -e --nodeps openssl-fips-provider-so 2>/dev/null || true
-RUN microdnf install -y yum yum-utils \
- && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
- && yum-config-manager --add-repo=https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os
+RUN microdnf install -y yum yum-utils
 
-RUN yum update -y --nogpgcheck --disablerepo=* --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os  --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os && rm -rf /var/cache/yum
+RUN yum --nogpgcheck update -y \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+      --enablerepo=ubi-9-codeready-builder-rpms
 
-RUN yum --nogpgcheck --disablerepo=* install --repofrompath=centos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os -y \
-  libtool pkgconfig autoconf automake make file python3-six \
+RUN yum --nogpgcheck install -y \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+      --enablerepo=ubi-9-codeready-builder-rpms \
+  libtool pkgconf-pkg-config autoconf automake make file python3-six \
   git gcc gcc-c++ diffutils python3-devel \
-  expat-devel wget which curl-devel libcap-devel \
-  logrotate conntrack-tools tcpdump strace ltrace iptables net-tools \
-  hostname vi iproute \
+  expat-devel wget which libcurl-devel libcap-devel openssl-devel \
+  logrotate tcpdump strace iptables-nft net-tools \
+  hostname vim-minimal iproute \
  && yum clean all
 
-RUN yum update --disablerepo=* --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y && rm -rf /var/cache/yum
-
-RUN yum --nogpgcheck --disablerepo=* install --enablerepo=ubi-9-appstream-rpms --enablerepo=ubi-9-baseos-rpms -y \
-  openssl-devel \
+RUN yum --nogpgcheck install -y \
+      --disablerepo=* --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms \
+      --enablerepo=ubi-9-codeready-builder-rpms \
+      --repofrompath=centos-baseos,https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os \
+      --repofrompath=centos-app,https://mirror.stream.centos.org/9-stream/AppStream/x86_64/os \
+    conntrack-tools ltrace \
  && yum clean all
 
 RUN wget https://nlnetlabs.nl/downloads/unbound/unbound-1.17.1.tar.gz \


### PR DESCRIPTION
Install UBI-available packages from UBI and pull only what UBI lacks (dhcp-client, conntrack-tools, ltrace) from Stream.