### PR TITLE
[mmr-6.1.1] Fix incorrect deletion of shared netpols from a node

### DIFF
--- a/pkg/hostagent/hpp.go
+++ b/pkg/hostagent/hpp.go
@@ -403,6 +403,31 @@ func (agent *HostAgent) evictStaleHppForNp(npkey string) {
 		agent.log.Errorf("evictStaleHppForNp: failed to compute HPP label key for NP %s: %v", npkey, err)
 		return
 	}
+
+	// Verify that no other NerworkPolicy selects pods on this node that would keep the HPP relevant. If any do, skip eviction.
+	// This is a safety check to avoid evicting an HPP that is still relevant due to other NPs.
+	hppName := strings.ReplaceAll(specName, "_", "-")
+	hppKey := agent.config.AciHppObjsNamespace + "/" + hppName
+	hppObj, hppExists, err := agent.hppInformer.GetIndexer().GetByKey(hppKey)
+	if err != nil {
+		agent.log.Errorf("evictStaleHppForNp: failed to look up HPP %s: %v", hppKey, err)
+		return
+	}
+	if !hppExists || hppObj == nil {
+		// The HPP delete handler owns cleanup after a CR deletion.  Retaining an
+		// existing local render here is safer than pruning it while the informer
+		// is catching up.
+		return
+	}
+	hpp, ok := hppObj.(*hppv1.HostprotPol)
+	if !ok {
+		agent.log.Errorf("evictStaleHppForNp: HPP %s has unexpected type %T", hppKey, hppObj)
+		return
+	}
+	if agent.isHppLocallyRelevant(hpp) {
+		return
+	}
+
 	agent.hppMutex.Lock()
 	_, present := agent.hppMoIndex[specName]
 	if present {

--- a/pkg/hostagent/pod_relatives.go
+++ b/pkg/hostagent/pod_relatives.go
@@ -221,9 +221,9 @@ func (agent *HostAgent) initNetPolPodIndex() {
 		}
 	})
 	if agent.config.EnableHppDirect {
-		// When an NP's local pod set changes (pod deleted, labels changed, etc.),
-		// evict exactly the HPP derived from that NP if it's no longer locally
-		// relevant.
+		// The callback runs when a NetworkPolicy selector is registered or its
+		// local pod set changes (pod deleted, labels changed, etc.).  Evict the
+		// HPP derived from that NP only when it is no longer locally relevant.
 		agent.netPolPods.SetObjUpdateCallback(func(npkey string) {
 			agent.evictStaleHppForNp(npkey)
 		})

--- a/pkg/hostagent/pod_relatives_hpp_test.go
+++ b/pkg/hostagent/pod_relatives_hpp_test.go
@@ -15,8 +15,10 @@
 package hostagent
 
 import (
+	"strings"
 	"testing"
 
+	hppv1 "github.com/noironetworks/aci-containers/pkg/hpp/apis/aci.hpp/v1"
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	v1net "k8s.io/api/networking/v1"
@@ -50,6 +52,17 @@ func TestEvictStaleHppForNpViaRealPodCallback(t *testing.T) {
 
 	specName, err := agent.getHPPDirLabelKey(np)
 	assert.NoError(t, err)
+	hpp := &hppv1.HostprotPol{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: agent.config.AciHppObjsNamespace,
+			Name:      strings.ReplaceAll(specName, "_", "-"),
+		},
+		Spec: hppv1.HostprotPolSpec{
+			Name:            specName,
+			NetworkPolicies: []string{"testns/np1"},
+		},
+	}
+	assert.NoError(t, agent.hppInformer.GetStore().Add(hpp))
 
 	// Pre-populate hppMoIndex as if this NP's HPP had already been
 	// rendered locally.
@@ -82,6 +95,77 @@ func TestEvictStaleHppForNpViaRealPodCallback(t *testing.T) {
 	assert.Equal(t, "hpp", item)
 	agent.hppLocalMoSyncQueue.Done(item)
 	agent.hppLocalMoSyncQueue.Forget(item)
+}
+
+// TestEvictStaleHppForNpKeepsCanonicalSharedHpp covers the direct-mode
+// canonicalization case: two otherwise identical policies in different
+// namespaces share one HPP CR.  In particular, an ordinary NetworkPolicy-add
+// selector registration for a namespace with no local pod invokes the object
+// update callback.  It must not remove the shared HPP while another referenced
+// policy is still local.
+func TestEvictStaleHppForNpKeepsCanonicalSharedHpp(t *testing.T) {
+	agent := testAgentHppDirect(t)
+
+	localNP := &v1net.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "local-ns", Name: "allow-system"},
+		Spec:       v1net.NetworkPolicySpec{PodSelector: metav1.LabelSelector{}},
+	}
+	staleNP := &v1net.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "stale-ns", Name: "allow-system"},
+		Spec:       v1net.NetworkPolicySpec{PodSelector: metav1.LabelSelector{}},
+	}
+	localPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "local-ns", Name: "pod-local"},
+		Spec:       v1.PodSpec{NodeName: nodename},
+	}
+
+	specName, err := agent.getHPPDirLabelKey(localNP)
+	assert.NoError(t, err)
+	staleSpecName, err := agent.getHPPDirLabelKey(staleNP)
+	assert.NoError(t, err)
+	assert.Equal(t, specName, staleSpecName, "identical policies must share the canonical HPP")
+
+	hpp := &hppv1.HostprotPol{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: agent.config.AciHppObjsNamespace,
+			Name:      strings.ReplaceAll(specName, "_", "-"),
+		},
+		Spec: hppv1.HostprotPolSpec{
+			Name: specName,
+			NetworkPolicies: []string{
+				"local-ns/allow-system",
+				"stale-ns/allow-system",
+			},
+		},
+	}
+	assert.NoError(t, agent.hppInformer.GetStore().Add(hpp))
+	assert.NoError(t, agent.netPolInformer.GetStore().Add(localNP))
+	assert.NoError(t, agent.netPolInformer.GetStore().Add(staleNP))
+	assert.NoError(t, agent.podInformer.GetStore().Add(localPod))
+	// Establish the local member first, as happens while a Bosch profile is
+	// applied.  The second policy has no pod selected on this node.
+	agent.netPolPods.UpdateSelectorObjNoCallback(localNP)
+
+	agent.hppMutex.Lock()
+	agent.hppMoIndex[specName] = []*gbpBaseMo{{}}
+	agent.hppMutex.Unlock()
+
+	// This is the production trigger: networkPolicyAdded calls
+	// UpdateSelectorObj, whose changed empty mapping invokes the callback.
+	// stale-ns has no local selected pod, but local-ns still does.
+	agent.networkPolicyAdded(staleNP)
+	agent.hppMutex.Lock()
+	_, present := agent.hppMoIndex[specName]
+	agent.hppMutex.Unlock()
+	assert.True(t, present, "shared HPP must stay rendered while any referenced policy is local")
+
+	// Once the remaining referenced local policy has no pod either, eviction
+	// is both safe and expected.
+	agent.netPolPods.DeletePod(localPod)
+	agent.hppMutex.Lock()
+	_, present = agent.hppMoIndex[specName]
+	agent.hppMutex.Unlock()
+	assert.False(t, present, "shared HPP must be evicted after every referenced policy is non-local")
 }
 
 // TestEvictStaleHppForNpViaRealPodCallbackNoStaleEntry verifies that when


### PR DESCRIPTION
Host-agent non-local HPP eviction could delete a netpol file without checking whether another NetworkPolicy sharing the HPP remained local to the node. This could remove a required shared netpol and cause traffic outages for the other netpols.

Check the locality of every NetworkPolicy using the HPP before deleting the netpol file.

(cherry picked from commit 71f9d4ead30b4102159ca1f49954d2c95c52a707)