### PR TITLE
Prevent HostprotPol and HostprotRemoteIpContainer hash collisions

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -939,6 +939,7 @@ type resolvedPeerPorts struct {
 // resolvedPortEntry is a single port (or port range) with its associated remote IPs.
 type resolvedPortEntry struct {
 	proto    string
+	portName string
 	fromPort string
 	toPort   string
 	// ipsV4/ipsV6 contain the remote IPs for this entry split by address family.
@@ -1291,6 +1292,7 @@ func (cont *AciController) resolveNetPolPeersAndPorts(
 			sort.Strings(ipsV6)
 			result.entries = append(result.entries, resolvedPortEntry{
 				proto:      proto,
+				portName:   portName,
 				fromPort:   strconv.Itoa(portNum),
 				ipsV4:      ipsV4,
 				ipsV6:      ipsV6,
@@ -1522,10 +1524,6 @@ func (cont *AciController) buildLocalNetPolSubjRules(
 	hasV4 := !cont.configuredPodNetworkIps.V4.Empty()
 	hasV6 := !cont.configuredPodNetworkIps.V6.Empty()
 	for _, entry := range resolved.entries {
-		ricSuffix := ""
-		if entry.portScoped {
-			ricSuffix = entry.fromPort
-		}
 		entryName := "unspecified"
 		if entry.proto != "" {
 			entryName = protoPortKey(entry.proto, entry.fromPort)
@@ -1540,6 +1538,16 @@ func (cont *AciController) buildLocalNetPolSubjRules(
 		// itself has no From/To (see resolveNetPolPeersAndPorts).
 		noRic := resolved.noPeers && !entry.portScoped
 
+		var ricHash string
+		if !noRic {
+			if entry.portScoped {
+				ricHash = util.CreateHashFromNetPolPeersWithNamedPort(peers,
+					netPolNs, entry.proto, entry.portName, entry.fromPort)
+			} else {
+				ricHash = util.CreateHashFromNetPolPeers(peers, netPolNs)
+			}
+		}
+
 		if hasV4 {
 			namePrefix := "ipv4"
 			var ricNameV4 string
@@ -1550,7 +1558,7 @@ func (cont *AciController) buildLocalNetPolSubjRules(
 				} else {
 					ricIpsV4 = entry.ipsV4
 				}
-				ricNameV4 = util.CreateHashFromNetPolPeers(peers, netPolNs, ricSuffix) + "-ipv4"
+				ricNameV4 = ricHash + "-ipv4"
 				namePrefix = ricNameV4
 				cont.hppMutex.Lock()
 				cont.remoteIpCache[ricNameV4] = ricIpsV4
@@ -1577,7 +1585,7 @@ func (cont *AciController) buildLocalNetPolSubjRules(
 				} else {
 					ricIpsV6 = entry.ipsV6
 				}
-				ricNameV6 = util.CreateHashFromNetPolPeers(peers, netPolNs, ricSuffix) + "-ipv6"
+				ricNameV6 = ricHash + "-ipv6"
 				namePrefix = ricNameV6
 				cont.hppMutex.Lock()
 				cont.remoteIpCache[ricNameV6] = ricIpsV6

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -4474,7 +4474,7 @@ func TestNetworkPolicyMultipleNPsSharedHPPNamedPortsDirect(t *testing.T) {
 	cont.fakeNetworkPolicySource.Add(np1)
 	cont.fakeNetworkPolicySource.Add(np2)
 
-	hash, _ := util.CreateHashFromNetPol(np1)
+	hash, _ := util.CreateCanonicalHashFromNetPol(np1)
 	labelKey := cont.aciNameForKey("np", hash)
 	hppName := strings.ReplaceAll(labelKey, "_", "-")
 	ns := os.Getenv("SYSTEM_NAMESPACE")
@@ -4790,7 +4790,7 @@ func TestBuildLocalNetPolSubjRules(t *testing.T) {
 		entries: []resolvedPortEntry{{proto: "tcp", fromPort: "8080", ipsV4: []string{"192.168.0.1"}}},
 	}, peers, "test-namespace", make(map[string]bool))
 
-	expectedRicName := util.CreateHashFromNetPolPeers(peers, "test-namespace", "")
+	expectedRicName := util.CreateHashFromNetPolPeers(peers, "test-namespace")
 	assert.Equal(t, 1, len(subj.HostprotRule))
 	assert.Equal(t, expectedRicName+"-ipv4__tcp-8080", subj.HostprotRule[0].Name)
 	assert.Equal(t, "ingress", subj.HostprotRule[0].Direction)
@@ -5539,7 +5539,7 @@ func TestHandleNetPolUpdate(t *testing.T) {
 	}
 
 	cont.handleNetPolUpdate(np)
-	hash, _ := util.CreateHashFromNetPol(np)
+	hash, _ := util.CreateCanonicalHashFromNetPol(np)
 	labelKey := cont.aciNameForKey("np", hash)
 	hppName := strings.ReplaceAll(labelKey, "_", "-")
 
@@ -6906,20 +6906,108 @@ func TestBuildLocalNetPolSubjRulesEgressNamedPort(t *testing.T) {
 	// named port "http" resolved to port 80 (portScoped since IPs are per-pod).
 	resolved := &resolvedPeerPorts{
 		entries: []resolvedPortEntry{
-			{proto: "tcp", fromPort: "80", portScoped: true},
+			{proto: "tcp", portName: "http", fromPort: "80", portScoped: true},
 		},
 	}
 
 	subj := &hppv1.HostprotSubj{}
 	cont.buildLocalNetPolSubjRules(subj, "egress", resolved, nil, "", make(map[string]bool))
 
-	expectedRicName := util.CreateHashFromNetPolPeers(nil, "", "80")
+	expectedRicName := util.CreateHashFromNetPolPeersWithNamedPort(
+		nil, "", "tcp", "http", "80")
 	assert.Equal(t, 1, len(subj.HostprotRule), "Should have 1 rule for resolved named port")
 	assert.Equal(t, expectedRicName+"-ipv4__tcp-80", subj.HostprotRule[0].Name)
 	assert.Equal(t, "egress", subj.HostprotRule[0].Direction)
 	assert.Equal(t, "ipv4", subj.HostprotRule[0].Ethertype)
 	assert.Equal(t, "tcp", subj.HostprotRule[0].Protocol)
 	assert.Equal(t, "80", subj.HostprotRule[0].FromPort)
+}
+
+func TestBuildLocalNetPolSubjRulesDistinguishesNamedPortsAtSameNumber(t *testing.T) {
+	cont := getContWithEnabledLocalHpp()
+	proto := v1.ProtocolTCP
+	http := intstr.FromString("http")
+	metrics := intstr.FromString("metrics")
+	peers := []v1net.NetworkPolicyPeer{{
+		PodSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"app": "backend"},
+		},
+	}}
+	ports := []v1net.NetworkPolicyPort{
+		{Protocol: &proto, Port: &http},
+		{Protocol: &proto, Port: &metrics},
+	}
+	peerPods := []*v1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "testns",
+				Name:      "http-pod",
+				Labels:    map[string]string{"app": "backend"},
+			},
+			Spec: v1.PodSpec{Containers: []v1.Container{{
+				Ports: []v1.ContainerPort{{Name: "http", ContainerPort: 8080}},
+			}}},
+			Status: v1.PodStatus{
+				PodIP:  "10.1.1.10",
+				PodIPs: []v1.PodIP{{IP: "10.1.1.10"}},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "testns",
+				Name:      "metrics-pod",
+				Labels:    map[string]string{"app": "backend"},
+			},
+			Spec: v1.PodSpec{Containers: []v1.Container{{
+				Ports: []v1.ContainerPort{{Name: "metrics", ContainerPort: 8080}},
+			}}},
+			Status: v1.PodStatus{
+				PodIP:  "10.1.1.11",
+				PodIPs: []v1.PodIP{{IP: "10.1.1.11"}},
+			},
+		},
+	}
+	peerNs := map[string]*v1.Namespace{
+		"testns": {ObjectMeta: metav1.ObjectMeta{Name: "testns"}},
+	}
+	np := &v1net.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-np", Namespace: "testns"},
+	}
+
+	resolved := cont.resolveNetPolPeersAndPorts("egress", peers, ports,
+		peerPods, peerNs, np, logrus.New().WithField("test", t.Name()))
+	assert.Len(t, resolved.entries, 2)
+
+	entriesByName := make(map[string]resolvedPortEntry)
+	for _, entry := range resolved.entries {
+		entriesByName[entry.portName] = entry
+	}
+	assert.Equal(t, "8080", entriesByName["http"].fromPort)
+	assert.Equal(t, []string{"10.1.1.10"}, entriesByName["http"].ipsV4)
+	assert.Equal(t, "8080", entriesByName["metrics"].fromPort)
+	assert.Equal(t, []string{"10.1.1.11"}, entriesByName["metrics"].ipsV4)
+
+	subj := &hppv1.HostprotSubj{}
+	rics := make(map[string]bool)
+	cont.buildLocalNetPolSubjRules(subj, "egress", resolved, peers, "testns", rics)
+
+	httpRic := util.CreateHashFromNetPolPeersWithNamedPort(
+		peers, "testns", "tcp", "http", "8080") + "-ipv4"
+	metricsRic := util.CreateHashFromNetPolPeersWithNamedPort(
+		peers, "testns", "tcp", "metrics", "8080") + "-ipv4"
+	assert.NotEqual(t, httpRic, metricsRic)
+	assert.Equal(t, []string{"10.1.1.10"}, cont.remoteIpCache[httpRic])
+	assert.Equal(t, []string{"10.1.1.11"}, cont.remoteIpCache[metricsRic])
+	assert.True(t, rics[httpRic])
+	assert.True(t, rics[metricsRic])
+	assert.Len(t, subj.HostprotRule, 2)
+
+	ruleRics := make(map[string]bool)
+	for _, rule := range subj.HostprotRule {
+		ruleRics[rule.RsRemoteIpContainer] = true
+	}
+	assert.True(t, ruleRics[httpRic])
+	assert.True(t, ruleRics[metricsRic])
 }
 
 // TestBuildLocalNetPolSubjRulesEgressMultipleNamedPorts tests that
@@ -6935,9 +7023,9 @@ func TestBuildLocalNetPolSubjRulesEgressMultipleNamedPorts(t *testing.T) {
 	// 80 and 8080 (two pods), "https" to port 443. Each entry is portScoped.
 	resolved := &resolvedPeerPorts{
 		entries: []resolvedPortEntry{
-			{proto: "tcp", fromPort: "80", portScoped: true},
-			{proto: "tcp", fromPort: "8080", portScoped: true},
-			{proto: "tcp", fromPort: "443", portScoped: true},
+			{proto: "tcp", portName: "http", fromPort: "80", portScoped: true},
+			{proto: "tcp", portName: "http", fromPort: "8080", portScoped: true},
+			{proto: "tcp", portName: "https", fromPort: "443", portScoped: true},
 		},
 	}
 
@@ -7150,6 +7238,7 @@ func TestBuildLocalNetPolSubjRulesEgressIPBlockNamedPort(t *testing.T) {
 		entries: []resolvedPortEntry{
 			{
 				proto:      "tcp",
+				portName:   "http",
 				fromPort:   "80",
 				ipsV4:      []string{"10.0.0.1", "10.0.0.2"},
 				portScoped: true,

--- a/pkg/util/nwpolicy.go
+++ b/pkg/util/nwpolicy.go
@@ -20,6 +20,7 @@ package util
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	v1net "k8s.io/api/networking/v1"
@@ -208,117 +209,107 @@ func labelSelectorToStr(labelsel *metav1.LabelSelector) string {
 
 // --- Canonical variants (HPP-direct mode only) ---
 //
-// These are added alongside the originals so that existing HPP-optimisation
-// deployments are not affected. Used only in HPP-direct mode; the originals
-// can be removed once HPP-direct is the only supported mode.
+// Added alongside the originals so existing HPP-optimisation deployments are
+// unaffected; used only in HPP-direct mode.
+//
+// The pre-image is a bracket/separator grammar: records "{f1;f2;...}" and lists
+// "[e1,e2,...]". Kubernetes forbids the structural characters { } [ ] , ; in
+// every NetworkPolicy field value, so raw values are embedded verbatim and
+// cannot forge a delimiter; an absent optional field is left empty. Only
+// encoding collisions are handled here; the semantic normalisations in section
+// 4a of docs/hpp-canonical-hash-spec.md are deferred.
 
 func CreateCanonicalHashFromNetPol(np *v1net.NetworkPolicy) (string, error) {
 	_, err := cache.MetaNamespaceKeyFunc(np)
 	if err != nil {
 		return "", err
 	}
-
-	var in, e, pt string
-	if np.Spec.Ingress != nil && len(np.Spec.Ingress) > 0 {
-		in = canonicalIngressStrSorted(np)
-	}
-	if np.Spec.Egress != nil && len(np.Spec.Egress) > 0 {
-		e = canonicalEgressStrSorted(np)
-	}
-	key := in + e
-	if np.Spec.PolicyTypes != nil && len(np.Spec.PolicyTypes) > 0 {
-		for _, policyType := range sortPolicyTypes(np.Spec.PolicyTypes) {
-			pt += policyType
-		}
-	}
-
-	key += pt
-
-	return Hash(key), nil
+	in := canonicalIngressStrSorted(np)
+	e := canonicalEgressStrSorted(np)
+	pt := "[" + strings.Join(sortPolicyTypes(np.Spec.PolicyTypes), ",") + "]"
+	return Hash("{" + in + ";" + e + ";" + pt + "}"), nil
 }
 
-func CreateHashFromNetPolPeers(peers []v1net.NetworkPolicyPeer, namespace string, suffix string) string {
-	return Hash(canonicalSelectorsToStr(peers, namespace) + canonicalPeersToStr(peers) + suffix)
+func CreateHashFromNetPolPeers(peers []v1net.NetworkPolicyPeer, namespace string) string {
+	return createHashFromNetPolPeers(peers, namespace, "")
+}
+
+func createHashFromNetPolPeers(peers []v1net.NetworkPolicyPeer,
+	namespace, portScope string) string {
+	return Hash("{" + canonicalSelectorsToStr(peers, namespace) + ";" +
+		canonicalPeersToStr(peers) + ";" + portScope + "}")
+}
+
+// CreateHashFromNetPolPeersWithNamedPort returns the RIC identity for an
+// egress named-port scope. The original name is part of the identity because
+// two names can resolve to the same number on different sets of peer pods.
+func CreateHashFromNetPolPeersWithNamedPort(peers []v1net.NetworkPolicyPeer,
+	namespace, protocol, portName, portNumber string) string {
+	portScope := "{" + protocol + ";" + portName + ";" + portNumber + "}"
+	return createHashFromNetPolPeers(peers, namespace, portScope)
 }
 
 func canonicalPeersToStr(peers []v1net.NetworkPolicyPeer) string {
 	var blocks []string
 	for _, p := range peers {
 		if p.IPBlock != nil {
-			b := p.IPBlock.CIDR
-			if len(p.IPBlock.Except) != 0 {
-				excepts := make([]string, len(p.IPBlock.Except))
-				copy(excepts, p.IPBlock.Except)
-				sort.Strings(excepts)
-				b += "[except"
-				for _, e := range excepts {
-					b += fmt.Sprintf("-%s", e)
-				}
-				b += "]"
-			}
-			blocks = append(blocks, b)
+			excepts := make([]string, len(p.IPBlock.Except))
+			copy(excepts, p.IPBlock.Except)
+			sort.Strings(excepts)
+			blocks = append(blocks, "{"+p.IPBlock.CIDR+";["+strings.Join(excepts, ",")+"]}")
 		}
 	}
 	sort.Strings(blocks)
-	return "[" + strings.Join(blocks, "+") + "]"
+	return "[" + strings.Join(blocks, ",") + "]"
 }
 
 func canonicalPortsToStr(ports []v1net.NetworkPolicyPort) string {
 	var portStrs []string
 	for _, p := range ports {
-		s := ""
+		proto := ""
 		if p.Protocol != nil {
-			s += string(*p.Protocol)
+			proto = string(*p.Protocol)
 		}
+		port := ""
 		if p.Port != nil {
-			s += ":" + p.Port.String()
+			port = p.Port.String()
 		}
-		portStrs = append(portStrs, s)
+		endPort := ""
+		if p.EndPort != nil {
+			endPort = strconv.Itoa(int(*p.EndPort))
+		}
+		portStrs = append(portStrs, "{"+proto+";"+port+";"+endPort+"}")
 	}
 	sort.Strings(portStrs)
-	return "[" + strings.Join(portStrs, "+") + "]"
+	return "[" + strings.Join(portStrs, ",") + "]"
 }
 
 func canonicalEgressStrSorted(np *v1net.NetworkPolicy) string {
 	var rules []string
 	for _, rule := range np.Spec.Egress {
-		eStr := ""
-		eStr += canonicalSelectorsToStr(rule.To, np.Namespace)
-		eStr += canonicalPeersToStr(rule.To)
-		eStr += canonicalPortsToStr(rule.Ports)
-		rules = append(rules, eStr)
+		rules = append(rules, "{"+
+			canonicalSelectorsToStr(rule.To, np.Namespace)+";"+
+			canonicalPeersToStr(rule.To)+";"+
+			canonicalPortsToStr(rule.Ports)+"}")
 	}
 	sort.Slice(rules, func(i, j int) bool {
 		return rules[i] < rules[j]
 	})
-	eStr := ""
-	for _, rule := range rules {
-		eStr += rule
-		eStr += "+"
-	}
-	eStr = strings.TrimSuffix(eStr, "+")
-	return eStr
+	return "[" + strings.Join(rules, ",") + "]"
 }
 
 func canonicalIngressStrSorted(np *v1net.NetworkPolicy) string {
 	var rules []string
 	for _, rule := range np.Spec.Ingress {
-		iStr := ""
-		iStr += canonicalSelectorsToStr(rule.From, np.Namespace)
-		iStr += canonicalPeersToStr(rule.From)
-		iStr += canonicalPortsToStr(rule.Ports)
-		rules = append(rules, iStr)
+		rules = append(rules, "{"+
+			canonicalSelectorsToStr(rule.From, np.Namespace)+";"+
+			canonicalPeersToStr(rule.From)+";"+
+			canonicalPortsToStr(rule.Ports)+"}")
 	}
 	sort.Slice(rules, func(i, j int) bool {
 		return rules[i] < rules[j]
 	})
-	iStr := ""
-	for _, rule := range rules {
-		iStr += rule
-		iStr += "+"
-	}
-	iStr = strings.TrimSuffix(iStr, "+")
-	return iStr
+	return "[" + strings.Join(rules, ",") + "]"
 }
 
 func canonicalSelectorsToStr(peers []v1net.NetworkPolicyPeer, ns string) string {
@@ -326,53 +317,52 @@ func canonicalSelectorsToStr(peers []v1net.NetworkPolicyPeer, ns string) string 
 	for _, p := range peers {
 		podSel := canonicalLabelSelectorToStr(p.PodSelector)
 		nsSel := canonicalLabelSelectorToStr(p.NamespaceSelector)
-		if podSel != "" && nsSel == "" {
-			selectors = append(selectors, podSel+ns)
-		} else if podSel != "" || nsSel != "" {
-			selectors = append(selectors, podSel+nsSel)
+		if podSel == "" && nsSel == "" {
+			continue
 		}
+		// A pod-only peer is scoped to the policy namespace (a bare name); a
+		// namespace selector encodes as "{...}", so the two never collide.
+		nsField := nsSel
+		if podSel != "" && nsSel == "" {
+			nsField = ns
+		}
+		selectors = append(selectors, "{"+podSel+";"+nsField+"}")
 	}
 	sort.Strings(selectors)
-	var str string
-	for _, s := range selectors {
-		str += s
-	}
-	return str
+	return "[" + strings.Join(selectors, ",") + "]"
 }
 
 func canonicalLabelSelectorToStr(labelsel *metav1.LabelSelector) string {
-	var str string
-	if labelsel != nil {
-		str = "["
-		matchLKeys := make([]string, 0, len(labelsel.MatchLabels))
-		for k := range labelsel.MatchLabels {
-			matchLKeys = append(matchLKeys, k)
-		}
-		sort.Strings(matchLKeys)
-		for _, key := range matchLKeys {
-			str += key + "=" + labelsel.MatchLabels[key]
-		}
-		exprs := make([]metav1.LabelSelectorRequirement, len(labelsel.MatchExpressions))
-		copy(exprs, labelsel.MatchExpressions)
-		for i := range exprs {
-			vals := make([]string, len(exprs[i].Values))
-			copy(vals, exprs[i].Values)
-			sort.Strings(vals)
-			exprs[i].Values = vals
-		}
-		sort.Slice(exprs, func(i, j int) bool {
-			return lessLabelSelectorRequirement(exprs[i], exprs[j])
-		})
-		for _, expressions := range exprs {
-			str += expressions.Key
-			str += string(expressions.Operator)
-			for _, values := range expressions.Values {
-				str += values
-			}
-		}
-		str += "]"
+	if labelsel == nil {
+		return ""
 	}
-	return str
+	matchLKeys := make([]string, 0, len(labelsel.MatchLabels))
+	for k := range labelsel.MatchLabels {
+		matchLKeys = append(matchLKeys, k)
+	}
+	sort.Strings(matchLKeys)
+	labels := make([]string, 0, len(matchLKeys))
+	for _, key := range matchLKeys {
+		labels = append(labels, "{"+key+";"+labelsel.MatchLabels[key]+"}")
+	}
+	// Copy before sorting so the caller's selector is not mutated.
+	exprs := make([]metav1.LabelSelectorRequirement, len(labelsel.MatchExpressions))
+	copy(exprs, labelsel.MatchExpressions)
+	for i := range exprs {
+		vals := make([]string, len(exprs[i].Values))
+		copy(vals, exprs[i].Values)
+		sort.Strings(vals)
+		exprs[i].Values = vals
+	}
+	sort.Slice(exprs, func(i, j int) bool {
+		return lessLabelSelectorRequirement(exprs[i], exprs[j])
+	})
+	expressions := make([]string, 0, len(exprs))
+	for _, e := range exprs {
+		expressions = append(expressions,
+			"{"+e.Key+";"+string(e.Operator)+";["+strings.Join(e.Values, ",")+"]}")
+	}
+	return "{[" + strings.Join(labels, ",") + "];[" + strings.Join(expressions, ",") + "]}"
 }
 
 func lessLabelSelectorRequirement(a, b metav1.LabelSelectorRequirement) bool {

--- a/pkg/util/nwpolicy_test.go
+++ b/pkg/util/nwpolicy_test.go
@@ -21,6 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	v1net "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func netPolWithIngressPeers(peers []v1net.NetworkPolicyPeer) *v1net.NetworkPolicy {
@@ -140,12 +141,12 @@ func TestCreateHashFromNetPolPeersDistinguishesPeerBoundaries(t *testing.T) {
 	separatePeersHash := CreateHashFromNetPolPeers([]v1net.NetworkPolicyPeer{
 		{PodSelector: podSelector},
 		{NamespaceSelector: namespaceSelector},
-	}, "default", "")
+	}, "default")
 
 	combinedPeerHash := CreateHashFromNetPolPeers([]v1net.NetworkPolicyPeer{{
 		PodSelector:       podSelector,
 		NamespaceSelector: namespaceSelector,
-	}}, "default", "")
+	}}, "default")
 
 	if separatePeersHash == combinedPeerHash {
 		t.Errorf("hash is identical for distinct peer groupings: %q", separatePeersHash)
@@ -220,5 +221,143 @@ func TestCanonicalHashIgnoresPortOrder(t *testing.T) {
 	}
 	if h1 != h2 {
 		t.Errorf("hash differs with port order: %q != %q", h1, h2)
+	}
+}
+
+func int32Ptr(v int32) *int32 { return &v }
+
+// npWithRules builds a policy with the given ingress/egress rules and policyTypes.
+func npWithRules(ingress []v1net.NetworkPolicyIngressRule, egress []v1net.NetworkPolicyEgressRule, pt []v1net.PolicyType) *v1net.NetworkPolicy {
+	return &v1net.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy", Namespace: "default"},
+		Spec: v1net.NetworkPolicySpec{
+			Ingress:     ingress,
+			Egress:      egress,
+			PolicyTypes: pt,
+		},
+	}
+}
+
+// Class 2: an ingress rule and an egress rule with identical peer/port text and
+// identical policyTypes must not collapse onto one HPP.
+func TestCanonicalHashDistinguishesDirection(t *testing.T) {
+	tcp := v1.ProtocolTCP
+	port := intstr.FromInt(32501)
+	rulePorts := []v1net.NetworkPolicyPort{{Protocol: &tcp, Port: &port}}
+	both := []v1net.PolicyType{v1net.PolicyTypeIngress, v1net.PolicyTypeEgress}
+
+	ingressOnly := npWithRules(
+		[]v1net.NetworkPolicyIngressRule{{Ports: rulePorts}}, nil, both)
+	egressOnly := npWithRules(
+		nil, []v1net.NetworkPolicyEgressRule{{Ports: rulePorts}}, both)
+
+	h1, err := CreateCanonicalHashFromNetPol(ingressOnly)
+	if err != nil {
+		t.Fatalf("hash ingress: %v", err)
+	}
+	h2, err := CreateCanonicalHashFromNetPol(egressOnly)
+	if err != nil {
+		t.Fatalf("hash egress: %v", err)
+	}
+	if h1 == h2 {
+		t.Errorf("ingress-only and egress-only policies collapsed to one hash: %q", h1)
+	}
+}
+
+// Class 3: different endPort values (and absent endPort) must differ.
+func TestCanonicalHashDistinguishesEndPort(t *testing.T) {
+	tcp := v1.ProtocolTCP
+	port := intstr.FromInt(32400)
+	mk := func(end *int32) *v1net.NetworkPolicy {
+		return npWithRules([]v1net.NetworkPolicyIngressRule{{
+			Ports: []v1net.NetworkPolicyPort{{Protocol: &tcp, Port: &port, EndPort: end}},
+		}}, nil, nil)
+	}
+	h401, err := CreateCanonicalHashFromNetPol(mk(int32Ptr(32401)))
+	if err != nil {
+		t.Fatalf("hash 401: %v", err)
+	}
+	h402, err := CreateCanonicalHashFromNetPol(mk(int32Ptr(32402)))
+	if err != nil {
+		t.Fatalf("hash 402: %v", err)
+	}
+	hNone, err := CreateCanonicalHashFromNetPol(mk(nil))
+	if err != nil {
+		t.Fatalf("hash none: %v", err)
+	}
+	if h401 == h402 {
+		t.Errorf("32400-32401 and 32400-32402 collapsed: %q", h401)
+	}
+	if h401 == hNone || h402 == hNone {
+		t.Errorf("ranged and unranged ports collapsed: %q / %q / %q", h401, h402, hNone)
+	}
+}
+
+// Selector nil vs empty {}: an absent podSelector must differ from a present
+// empty selector (which matches all pods).
+func TestCanonicalHashDistinguishesNilVsEmptySelector(t *testing.T) {
+	nilSel := CreateHashFromNetPolPeers([]v1net.NetworkPolicyPeer{
+		{NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "x"}}},
+	}, "default")
+	emptyPodSel := CreateHashFromNetPolPeers([]v1net.NetworkPolicyPeer{{
+		PodSelector:       &metav1.LabelSelector{},
+		NamespaceSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"team": "x"}},
+	}}, "default")
+	if nilSel == emptyPodSel {
+		t.Errorf("nil podSelector and empty podSelector collapsed: %q", nilSel)
+	}
+}
+
+// Empty-peer handling (retained original behavior): a fully empty peer is
+// dropped so [{}] equals an empty peer list, but an all-pods peer
+// [{podSelector:{}}] stays distinct.
+func TestCanonicalHashEmptyPeerHandling(t *testing.T) {
+	none := CreateHashFromNetPolPeers(nil, "default")
+	emptyPeer := CreateHashFromNetPolPeers([]v1net.NetworkPolicyPeer{{}}, "default")
+	allPods := CreateHashFromNetPolPeers([]v1net.NetworkPolicyPeer{
+		{PodSelector: &metav1.LabelSelector{}},
+	}, "default")
+	if none != emptyPeer {
+		t.Errorf("fully-empty peer not dropped: %q != %q", none, emptyPeer)
+	}
+	if none == allPods {
+		t.Errorf("all-pods peer collapsed with allow-all: %q", none)
+	}
+}
+
+func TestCreateHashFromNetPolPeersDistinguishesNamedPortScope(t *testing.T) {
+	peers := []v1net.NetworkPolicyPeer{
+		{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}}},
+	}
+	http := CreateHashFromNetPolPeersWithNamedPort(
+		peers, "default", "tcp", "http", "8080")
+	metrics := CreateHashFromNetPolPeersWithNamedPort(
+		peers, "default", "tcp", "metrics", "8080")
+	if http == metrics {
+		t.Errorf("different named ports at the same number collapsed: %q", http)
+	}
+
+	unscoped := CreateHashFromNetPolPeers(peers, "default")
+	if http == unscoped {
+		t.Errorf("named-port-scoped and unscoped RICs collapsed: %q", http)
+	}
+
+	udpHTTP := CreateHashFromNetPolPeersWithNamedPort(
+		peers, "default", "udp", "http", "8080")
+	if http == udpHTTP {
+		t.Errorf("different named-port protocols collapsed: %q", http)
+	}
+
+	http9090 := CreateHashFromNetPolPeersWithNamedPort(
+		peers, "default", "tcp", "http", "9090")
+	if http == http9090 {
+		t.Errorf("different named-port numbers collapsed: %q", http)
+	}
+
+	httpAgain := CreateHashFromNetPolPeersWithNamedPort(
+		peers, "default", "tcp", "http", "8080")
+	if http != httpAgain {
+		t.Errorf("identical named-port scopes produced different hashes: %q != %q",
+			http, httpAgain)
 	}
 }


### PR DESCRIPTION
Canonical NetworkPolicy and peer hashing allowed semantically distinct inputs to share one custom resource identity:

- endPort was omitted from HostprotPol port serialization.
- Ingress and egress rules lacked a structural direction boundary.
- Egress named-port HostprotRemoteIpContainer suffixes used only the resolved port number. Different names resolving to the same number therefore shared an identity.
- Peer selector labels had no field boundaries, so different selectors such as {a=bc,d=e} and {a=b,cd=e} serialized identically.

Encode hash inputs as sorted, structurally delimited records and lists. Scope named-port remote IP identities by protocol, original port name and resolved port number. Add regression coverage for these collision cases.