### PR TITLE
fix(controller): handle protocol-only NetworkPolicy ports without panic

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -1700,18 +1700,23 @@ func portProto(protocol *v1.Protocol) string {
 }
 
 func portKey(p *v1net.NetworkPolicyPort) string {
+	if p == nil {
+		return ""
+	}
+
+	if p.Port == nil {
+		return portProto(p.Protocol) + "-none-"
+	}
+
 	portType := ""
 	port := ""
-	if p != nil && p.Port != nil {
-		if p.Port.Type == intstr.Int {
-			portType = "num"
-		} else {
-			portType = "name"
-		}
-		port = p.Port.String()
-		return portProto(p.Protocol) + "-" + portType + "-" + port
+	if p.Port.Type == intstr.Int {
+		portType = "num"
+	} else {
+		portType = "name"
 	}
-	return ""
+	port = p.Port.String()
+	return portProto(p.Protocol) + "-" + portType + "-" + port
 }
 
 func checkEndpointslices(subnetIndex cidranger.Ranger,
@@ -2878,7 +2883,7 @@ func (seps *serviceEndpointSlice) SetNpServiceAugmentForService(servicekey strin
 func isNamedPortPresenInNp(np *v1net.NetworkPolicy) bool {
 	for _, egress := range np.Spec.Egress {
 		for _, p := range egress.Ports {
-			if p.Port.Type == intstr.String {
+			if p.Port != nil && p.Port.Type == intstr.String {
 				return true
 			}
 		}
@@ -2900,7 +2905,7 @@ func (cont *AciController) checkPodNmpMatchesNp(npkey, podkey string) bool {
 		np := npobj.(*v1net.NetworkPolicy)
 		for _, egress := range np.Spec.Egress {
 			for _, p := range egress.Ports {
-				if p.Port.Type == intstr.String {
+				if p.Port != nil && p.Port.Type == intstr.String {
 					_, err := k8util.LookupContainerPortNumberByName(*pod, p.Port.String())
 					if err == nil {
 						return true

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -7727,3 +7727,147 @@ func TestNetworkPolicyChangedHppOptimization(t *testing.T) {
 		cont.networkPolicyChanged(np, npNew)
 	})
 }
+
+func TestIsNamedPortPresenInNpNilPort(t *testing.T) {
+	udpProto := v1.ProtocolUDP
+	np := &v1net.NetworkPolicy{
+		Spec: v1net.NetworkPolicySpec{
+			Egress: []v1net.NetworkPolicyEgressRule{
+				{
+					Ports: []v1net.NetworkPolicyPort{
+						{Protocol: &udpProto},
+					},
+				},
+			},
+		},
+	}
+
+	assert.NotPanics(t, func() {
+		assert.False(t, isNamedPortPresenInNp(np))
+	})
+
+	named := intstr.FromString("dns")
+	np.Spec.Egress[0].Ports = []v1net.NetworkPolicyPort{{
+		Protocol: &udpProto,
+		Port:     &named,
+	}}
+	assert.True(t, isNamedPortPresenInNp(np))
+}
+
+func TestNetworkPolicyAddDeleteProtocolOnlyNoPanic(t *testing.T) {
+	cont := testController()
+	cont.fakeNamespaceSource.Add(namespaceLabel("testns", map[string]string{}))
+	cont.run()
+	defer cont.stop()
+
+	protos := []v1.Protocol{v1.ProtocolUDP, v1.ProtocolTCP, v1.ProtocolSCTP}
+	for _, proto := range protos {
+		proto := proto
+		t.Run(strings.ToLower(string(proto)), func(t *testing.T) {
+			np := netpol("testns", "np-proto-only-"+strings.ToLower(string(proto)),
+				&metav1.LabelSelector{}, nil,
+				[]v1net.NetworkPolicyEgressRule{
+					egressRule([]v1net.NetworkPolicyPort{{Protocol: &proto}}, nil),
+				},
+				[]v1net.PolicyType{v1net.PolicyTypeEgress})
+
+			assert.NotPanics(t, func() {
+				cont.networkPolicyAdded(np)
+			})
+			assert.NotPanics(t, func() {
+				cont.networkPolicyDeleted(np)
+			})
+		})
+	}
+}
+
+func TestHppDirectProtocolOnlyRulesUnspecifiedPorts(t *testing.T) {
+	cont := getContWithEnabledLocalHpp()
+	cont.run()
+	defer cont.stop()
+
+	subj := &hppv1.HostprotSubj{}
+	peers := []v1net.NetworkPolicyPeer{{
+		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "peer"}},
+	}}
+	resolved := &resolvedPeerPorts{
+		entries: []resolvedPortEntry{
+			{proto: "udp", ipsV4: []string{"192.168.1.10"}},
+			{proto: "tcp", ipsV4: []string{"192.168.1.10"}},
+			{proto: "sctp", ipsV4: []string{"192.168.1.10"}},
+		},
+	}
+
+	cont.buildLocalNetPolSubjRules(subj, "egress", resolved, peers, "testns", make(map[string]bool))
+
+	assert.Len(t, subj.HostprotRule, 3)
+	seen := map[string]bool{}
+	for _, rule := range subj.HostprotRule {
+		seen[rule.Protocol] = true
+		assert.Equal(t, "egress", rule.Direction)
+		assert.Equal(t, "ipv4", rule.Ethertype)
+		assert.Equal(t, "unspecified", rule.FromPort)
+		assert.Equal(t, "unspecified", rule.ToPort)
+	}
+	assert.True(t, seen["udp"])
+	assert.True(t, seen["tcp"])
+	assert.True(t, seen["sctp"])
+}
+
+func TestResolveNetPolPeersAndPortsMultipleProtocolOnlyRules(t *testing.T) {
+	cont := getContWithEnabledLocalHpp()
+	cont.run()
+	defer cont.stop()
+
+	udpProto := v1.ProtocolUDP
+	tcpProto := v1.ProtocolTCP
+	sctpProto := v1.ProtocolSCTP
+	np := &v1net.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "np-multi-proto-only", Namespace: "testns"},
+		Spec: v1net.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			Egress: []v1net.NetworkPolicyEgressRule{
+				{
+					Ports: []v1net.NetworkPolicyPort{
+						{Protocol: &udpProto},
+						{Protocol: &tcpProto},
+						{Protocol: &sctpProto},
+					},
+				},
+			},
+		},
+	}
+
+	logger := logrus.New().WithField("test", "resolve-protocol-only")
+	resolved := cont.resolveNetPolPeersAndPorts("egress", nil, np.Spec.Egress[0].Ports, nil, nil, np, logger)
+
+	assert.Len(t, resolved.entries, 3)
+	seen := map[string]bool{}
+	for _, entry := range resolved.entries {
+		seen[entry.proto] = true
+		assert.Empty(t, entry.fromPort)
+		assert.Empty(t, entry.toPort)
+	}
+	assert.True(t, seen["udp"])
+	assert.True(t, seen["tcp"])
+	assert.True(t, seen["sctp"])
+}
+
+func TestPortKeyProtocolOnlyDistinct(t *testing.T) {
+	udpProto := v1.ProtocolUDP
+	tcpProto := v1.ProtocolTCP
+	sctpProto := v1.ProtocolSCTP
+
+	udpKey := portKey(&v1net.NetworkPolicyPort{Protocol: &udpProto})
+	tcpKey := portKey(&v1net.NetworkPolicyPort{Protocol: &tcpProto})
+	sctpKey := portKey(&v1net.NetworkPolicyPort{Protocol: &sctpProto})
+
+	assert.Equal(t, "udp-none-", udpKey)
+	assert.Equal(t, "tcp-none-", tcpKey)
+	assert.Equal(t, "sctp-none-", sctpKey)
+	assert.NotEqual(t, udpKey, tcpKey)
+	assert.NotEqual(t, udpKey, sctpKey)
+	assert.NotEqual(t, tcpKey, sctpKey)
+
+	assert.Equal(t, "", portKey(nil))
+}


### PR DESCRIPTION
Root cause:
Controller code assumed every egress NetworkPolicyPort had a non-nil port field and dereferenced Port.Type directly. For valid protocol-only policies (for example UDP with no port value), Port is nil, causing a nil pointer dereference during add/delete reconciliation and leading to controller restarts.

Fix:

Add nil guards before checking Port.Type in named-port detection paths. Treat nil port as non-named (expected behavior for protocol-only rules). Keep numeric and named-port behavior unchanged.

Regression coverage:

Helper behavior when Port == nil.
NetworkPolicy add/delete with protocol-only UDP/TCP/SCTP entries. HPP-direct output for protocol-only rules keeps protocol set and fromPort/toPort as unspecified. Multiple protocol-only entries in a single egress rule are handled correctly.