### PR TITLE
[mmr-6.1.1] Prevent shared ingress named ports from over-allowing

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -302,20 +302,18 @@ type globalVlanConfig struct {
 // hppOptReference is the HPP-optimization (APIC) mode cache entry.
 // Keyed by aciNameForKey("np", CreateHashFromNetPol(np)).
 type hppOptReference struct {
-	RefCount       uint                       `json:"ref-count,omitempty"`
-	Npkeys         []string                   `json:"npkeys,omitempty"`
-	HppObj         apicapi.ApicSlice          `json:"hpp-obj,omitempty"`
-	NpIngressRules map[string]map[string]bool `json:"-"` // npKey → set of ingress rule names
+	RefCount uint              `json:"ref-count,omitempty"`
+	Npkeys   []string          `json:"npkeys,omitempty"`
+	HppObj   apicapi.ApicSlice `json:"hpp-obj,omitempty"`
 }
 
 // hppDirReference is the HPP-Direct (CR) mode cache entry.
 // Keyed by aciNameForKey("np", CreateCanonicalHashFromNetPol(np)).
 type hppDirReference struct {
-	RefCount       uint                       `json:"ref-count,omitempty"`
-	Npkeys         []string                   `json:"npkeys,omitempty"`
-	HppCr          hppv1.HostprotPol          `json:"hpp-cr,omitempty"`
-	NpIngressRules map[string]map[string]bool `json:"-"` // npKey → set of ingress rule names
-	RicNames       map[string]bool            `json:"-"` // set of RIC names referenced by rules
+	RefCount uint              `json:"ref-count,omitempty"`
+	Npkeys   []string          `json:"npkeys,omitempty"`
+	HppCr    hppv1.HostprotPol `json:"hpp-cr,omitempty"`
+	RicNames map[string]bool   `json:"-"` // set of RIC names referenced by rules
 }
 
 type DelayedEpSlice struct {

--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -930,8 +930,6 @@ type resolvedPeerPorts struct {
 	noPeers bool
 	// addPodSubnetAsRemIp is true when the rule allows all namespaces.
 	addPodSubnetAsRemIp bool
-	// hasNamedPort is true when the rule contains at least one named port.
-	hasNamedPort bool
 	// hasIpBlocks is true when there are IPBlock peers in this rule.
 	hasIpBlocks bool
 }
@@ -1226,7 +1224,6 @@ func (cont *AciController) resolveNetPolPeersAndPorts(
 
 		// Named port resolution.
 		portName := ports[j].Port.String()
-		result.hasNamedPort = true
 
 		if direction == "ingress" {
 			var portMap map[int]bool
@@ -2164,7 +2161,6 @@ func (cont *AciController) handleHppUpdate(hppName string) bool {
 	// Read desired state from the NP-derived cache.
 	cont.hppMutex.Lock()
 	ref, desiredExists := cont.hppDirRef[hppName]
-	hasIngressRuleNamedPort := len(ref.NpIngressRules) > 0
 	var desired *hppv1.HostprotPol
 	if desiredExists {
 		desired = ref.HppCr.DeepCopy()
@@ -2201,19 +2197,13 @@ func (cont *AciController) handleHppUpdate(hppName string) bool {
 		if !cont.hppSyncEnabled.Load() {
 
 			if actual.Spec.Name == desired.Spec.Name {
-				if !reflect.DeepEqual(actual.Spec.HostprotSubj, desired.Spec.HostprotSubj) {
-					if hasIngressRuleNamedPort {
-						// For ingress named port netpols with varying named port resolutions across different
-						// netpols, all hashing to the same hpp, even hostprotSubj can have inconsistent
-						// intermediate desired states during the sync.
+				if reflect.DeepEqual(actual.Spec.HostprotSubj, desired.Spec.HostprotSubj) {
+					if !reflect.DeepEqual(actual.Spec.NetworkPolicies, desired.Spec.NetworkPolicies) {
+						// Until the NP sync and HPP cache build is complete, we don't have the full
+						// desired list of network policies to compare against, so we can't determine
+						// if an update is needed.
 						return true // requeue until NP sync completes
 					}
-				} else if !reflect.DeepEqual(actual.Spec.NetworkPolicies, desired.Spec.NetworkPolicies) {
-					// Until the NP sync and HPP cache build is complete, we don't have the full
-					// desired list of network policies to compare against, so we can't determine
-					// if an update is needed.
-					return true // requeue until NP sync completes
-				} else {
 					return false // no-op
 				}
 			}
@@ -2358,8 +2348,6 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 		}
 		hpp := apicapi.NewHostprotPol(cont.config.AciPolicyTenant, labelKey)
 
-		var hasNamedPorts bool
-
 		// Generate ingress policies
 		if np.Spec.PolicyTypes == nil || ptypeset[v1net.PolicyTypeIngress] {
 			subjIngress :=
@@ -2369,27 +2357,6 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 				resolved := cont.resolveNetPolPeersAndPorts("ingress",
 					ingress.From, ingress.Ports, peerPods, peerNs, np, logger)
 				cont.buildNetPolSubjRules(strconv.Itoa(i), subjIngress, "ingress", resolved, np)
-				if resolved.hasNamedPort {
-					hasNamedPorts = true
-				}
-			}
-
-			// Merge sibling NPs' named port resolutions into this subject.
-			// Rule names encode the ingress-rule index + proto-port so siblings
-			// produce identically-named rules. Cache full rule names and pull
-			// missing ones from the previously-written HPP object.
-			if cont.config.HppOptimization && hasNamedPorts {
-				ruleNames := make(map[string]bool)
-				for _, body := range subjIngress {
-					for _, rule := range body.Children {
-						name := rule.GetAttrStr("name")
-						if name != "" {
-							ruleNames[name] = true
-						}
-					}
-				}
-				cont.cacheNpOptIngressRules(labelKey, key, ruleNames)
-				cont.mergeHppOptIngressRules(labelKey, key, ruleNames, subjIngress)
 			}
 			hpp.AddChild(subjIngress)
 		}
@@ -2454,8 +2421,6 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 		}
 		var rics = make(map[string]bool)
 
-		var hasNamedPorts bool
-
 		// Generate ingress policies
 		if np.Spec.PolicyTypes == nil || ptypeset[v1net.PolicyTypeIngress] {
 			subjIngress := &hppv1.HostprotSubj{
@@ -2466,25 +2431,9 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 			for _, ingress := range np.Spec.Ingress {
 				resolved := cont.resolveNetPolPeersAndPorts("ingress",
 					ingress.From, ingress.Ports, peerPods, peerNs, np, logger)
-				if resolved.hasNamedPort {
-					hasNamedPorts = true
-				}
 				if !(!resolved.noPeers && len(resolved.subnetMap) == 0) {
 					cont.buildLocalNetPolSubjRules(subjIngress, "ingress", resolved, ingress.From, np.ObjectMeta.Namespace, rics)
 				}
-			}
-
-			// Merge sibling NPs' named port resolutions into this subject.
-			// Cache full rule names and pull missing ones from the HPP CR.
-			if hasNamedPorts {
-				ruleNames := make(map[string]bool)
-				for _, rule := range subjIngress.HostprotRule {
-					if rule.Name != "" {
-						ruleNames[rule.Name] = true
-					}
-				}
-				cont.cacheNpDirIngressRules(hppName, key, ruleNames)
-				cont.mergeHppDirectIngressRules(hppName, key, ruleNames, subjIngress)
 			}
 			subjIngress.HostprotRule = canonicalizeHppRules(subjIngress.HostprotRule, logger)
 			hpp.Spec.HostprotSubj = append(hpp.Spec.HostprotSubj, *subjIngress)
@@ -2530,129 +2479,6 @@ func (cont *AciController) handleNetPolUpdate(np *v1net.NetworkPolicy) bool {
 		cont.queueHppUpdateByKey(hppName)
 	}
 	return false
-}
-
-// mergeHppOptIngressRules merges missing ingress rules from sibling NPs into
-// the current subject. It compares full rule names (which encode the ingress
-// rule index + proto-port) to avoid false positives from overlapping ports
-// in different ingress rules. Rules present in the HPP object but missing
-// from the current NP are added if claimed by a sibling's cached rule names.
-func (cont *AciController) mergeHppOptIngressRules(labelKey, key string,
-	ruleNames map[string]bool, subjIngress apicapi.ApicObject) {
-	cont.indexMutex.Lock()
-	defer cont.indexMutex.Unlock()
-
-	hppRef, ok := cont.hppOptRef[labelKey]
-	if !ok {
-		return
-	}
-
-	// Collect all rule names claimed by siblings but not in current NP.
-	siblingNames := make(map[string]bool)
-	for _, npKey := range hppRef.Npkeys {
-		if npKey == key {
-			continue
-		}
-		for name := range hppRef.NpIngressRules[npKey] {
-			if !ruleNames[name] {
-				siblingNames[name] = true
-			}
-		}
-	}
-	if len(siblingNames) == 0 {
-		return
-	}
-
-	// Find rules in the HPP object whose names are claimed by siblings.
-	for _, hppObj := range hppRef.HppObj {
-		hppBody, ok := hppObj["hostprotPol"]
-		if !ok || hppBody == nil {
-			continue
-		}
-		for _, child := range hppBody.Children {
-			subj, ok := child["hostprotSubj"]
-			if !ok || subj == nil || subj.Attributes["name"] != "networkpolicy-ingress" {
-				continue
-			}
-			for _, ruleChild := range subj.Children {
-				rule, ok := ruleChild["hostprotRule"]
-				if !ok || rule == nil {
-					continue
-				}
-				name, _ := rule.Attributes["name"].(string)
-				if siblingNames[name] {
-					subjIngress.AddChild(ruleChild)
-					delete(siblingNames, name)
-				}
-			}
-		}
-	}
-}
-
-// mergeHppDirectIngressRules merges missing ingress rules from sibling NPs
-// into the current HPP-Direct subject. Same approach as mergeHppIngressRules
-// but operates on the HPP CR struct instead of the APIC object tree.
-func (cont *AciController) mergeHppDirectIngressRules(labelKey, key string,
-	ruleNames map[string]bool, subjIngress *hppv1.HostprotSubj) {
-	cont.hppMutex.Lock()
-	defer cont.hppMutex.Unlock()
-
-	hppRef, ok := cont.hppDirRef[labelKey]
-	if !ok {
-		return
-	}
-
-	// Collect all rule names claimed by siblings but not in current NP.
-	siblingNames := make(map[string]bool)
-	for _, npKey := range hppRef.Npkeys {
-		if npKey == key {
-			continue
-		}
-		for name := range hppRef.NpIngressRules[npKey] {
-			if !ruleNames[name] {
-				siblingNames[name] = true
-			}
-		}
-	}
-	if len(siblingNames) == 0 {
-		return
-	}
-
-	// Find rules in the HPP CR whose names are claimed by siblings.
-	for i := range hppRef.HppCr.Spec.HostprotSubj {
-		subj := &hppRef.HppCr.Spec.HostprotSubj[i]
-		if subj.Name != "networkpolicy-ingress" {
-			continue
-		}
-		for _, rule := range subj.HostprotRule {
-			if siblingNames[rule.Name] {
-				subjIngress.HostprotRule = append(subjIngress.HostprotRule, rule)
-				delete(siblingNames, rule.Name)
-			}
-		}
-	}
-}
-
-func (cont *AciController) cacheNpOptIngressRules(labelKey, npKey string, names map[string]bool) {
-	cont.indexMutex.Lock()
-	defer cont.indexMutex.Unlock()
-	ref := cont.hppOptRef[labelKey]
-	if ref.NpIngressRules == nil {
-		ref.NpIngressRules = make(map[string]map[string]bool)
-	}
-	ref.NpIngressRules[npKey] = names
-	cont.hppOptRef[labelKey] = ref
-}
-
-func (cont *AciController) cacheNpDirIngressRules(labelKey, npKey string, names map[string]bool) {
-	cont.hppMutex.Lock()
-	defer cont.hppMutex.Unlock()
-	ref := cont.hppDirRef[labelKey]
-	if ref.NpIngressRules == nil {
-		ref.NpIngressRules = make(map[string]map[string]bool)
-	}
-	ref.NpIngressRules[npKey] = names
-	cont.hppDirRef[labelKey] = ref
 }
 
 func (cont *AciController) addToHppOptCache(labelKey, key string, hpp apicapi.ApicSlice) {
@@ -2746,17 +2572,11 @@ func (cont *AciController) removeFromHppDirCache(np *v1net.NetworkPolicy, key st
 			ref.Npkeys = slices.Delete(ref.Npkeys, pos, pos+1)
 			ref.RefCount--
 		}
-		_, hadRuleCache := ref.NpIngressRules[key]
-		delete(ref.NpIngressRules, key)
 		if ref.RefCount > 0 {
 			ref.HppCr.Spec.NetworkPolicies = ref.Npkeys
 			cont.hppDirRef[hppName] = ref
-			if hadRuleCache {
-				cont.queueNetPolUpdateByKey(ref.Npkeys[0])
-			} else {
-				// NetworkPolicies list changed; reconcile the HPP CR.
-				cont.queueHppUpdateByKey(hppName)
-			}
+			// NetworkPolicies list changed; reconcile the HPP CR.
+			cont.queueHppUpdateByKey(hppName)
 		} else {
 			// Clean up RIC reverse index for this HPP.
 			for ric := range ref.RicNames {
@@ -2797,13 +2617,8 @@ func (cont *AciController) removeFromHppOptCache(np *v1net.NetworkPolicy, key st
 				break
 			}
 		}
-		_, hadRuleCache := ref.NpIngressRules[key]
-		delete(ref.NpIngressRules, key)
 		if ref.RefCount > 0 {
 			cont.hppOptRef[labelKey] = ref
-			if hadRuleCache {
-				cont.queueNetPolUpdateByKey(ref.Npkeys[0])
-			}
 		} else {
 			delete(cont.hppOptRef, labelKey)
 			noRef = true

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -4297,11 +4298,9 @@ func TestNetworkPolicyEgressNmPortHppOptimize(t *testing.T) {
 	}
 }
 
-// TestNetworkPolicyMultipleNPsSharedHPPNamedPorts tests the scenario where
-// multiple NetworkPolicies with identical rules but different PodSelectors
-// share the same HPP, and use named ports that resolve to different port numbers
-func TestNetworkPolicyMultipleNPsSharedHPPNamedPorts(t *testing.T) {
-	// Simple test to verify the fix works in hpp-optimization mode
+// TestNetworkPolicyIngressNamedPortsUseDistinctHPPs verifies that ingress
+// named-port policies selecting different target pods do not share an APIC HPP.
+func TestNetworkPolicyIngressNamedPortsUseDistinctHPPs(t *testing.T) {
 	config := NewConfig()
 	config.HppOptimization = true
 	config.AciPolicyTenant = "test-tenant"
@@ -4362,64 +4361,57 @@ func TestNetworkPolicyMultipleNPsSharedHPPNamedPorts(t *testing.T) {
 	cont.fakePodSource.Add(pod1)
 	cont.fakePodSource.Add(pod2)
 	cont.run()
+	waitForPodIndexed(t, cont, "testns/pod1", "testns/pod2")
 	cont.fakeNetworkPolicySource.Add(np1)
 	cont.fakeNetworkPolicySource.Add(np2)
 
-	// Wait for controller to process the network policies
-	hash, _ := util.CreateHashFromNetPol(np1)
-	labelKey := cont.aciNameForKey("np", hash)
+	hash1, err := util.CreateHashFromNetPol(np1)
+	assert.NoError(t, err)
+	hash2, err := util.CreateHashFromNetPol(np2)
+	assert.NoError(t, err)
+	assert.NotEqual(t, hash1, hash2)
+	labelKey1 := cont.aciNameForKey("np", hash1)
+	labelKey2 := cont.aciNameForKey("np", hash2)
 
-	foundNp1Rule := false
-	foundNp2Rule := false
-
-	tu.WaitFor(t, "multiple-nps-shared-hpp-named-ports", 2000*time.Millisecond,
-		func(last bool) (bool, error) {
-			desiredState := cont.apicConn.GetDesiredState(labelKey)
-			if len(desiredState) == 0 {
-				return false, nil
-			}
-
-			// Verify rules exist for both NPs
-			hppObj := desiredState[0]
-			hppMap, ok := hppObj["hostprotPol"]
-			if !ok || hppMap == nil {
-				return false, nil
-			}
-
-			foundNp1Rule = false
-			foundNp2Rule = false
-
-			for _, child := range hppMap.Children {
-				if subj, ok := child["hostprotSubj"]; ok {
-					if subj != nil && subj.Attributes["name"] == "networkpolicy-ingress" {
-						for _, ruleChild := range subj.Children {
-							if rule, ok := ruleChild["hostprotRule"]; ok {
-								if rule != nil {
-									fromPort, _ := rule.Attributes["fromPort"].(string)
-									if fromPort == "http" {
-										foundNp1Rule = true
-									}
-									if fromPort == "8080" {
-										foundNp2Rule = true
-									}
-								}
-							}
+	waitForOnlyIngressPort := func(labelKey, wantPort string) {
+		t.Helper()
+		tu.WaitFor(t, labelKey+"-port-"+wantPort, 2000*time.Millisecond,
+			func(last bool) (bool, error) {
+				desiredState := cont.apicConn.GetDesiredState(labelKey)
+				if len(desiredState) != 1 {
+					return false, nil
+				}
+				hppBody := desiredState[0]["hostprotPol"]
+				if hppBody == nil {
+					return false, nil
+				}
+				var ports []string
+				for _, child := range hppBody.Children {
+					subj := child["hostprotSubj"]
+					if subj == nil || subj.Attributes["name"] != "networkpolicy-ingress" {
+						continue
+					}
+					for _, ruleChild := range subj.Children {
+						rule := ruleChild["hostprotRule"]
+						if rule != nil {
+							ports = append(ports,
+								rule.Attributes["fromPort"].(string))
 						}
 					}
 				}
-			}
+				return len(ports) == 1 && ports[0] == wantPort, nil
+			})
+	}
 
-			return foundNp1Rule && foundNp2Rule, nil
-		})
+	waitForOnlyIngressPort(labelKey1, "http")
+	waitForOnlyIngressPort(labelKey2, "8080")
 
 	cont.stop()
 }
 
-// TestNetworkPolicyMultipleNPsSharedHPPNamedPortsDirect tests the same
-// sibling-NP merge scenario as TestNetworkPolicyMultipleNPsSharedHPPNamedPorts
-// but for the HPP-Direct (EnableHppDirect) code path, verifying that the
-// HostprotPol CRD contains merged ingress rules from both NPs.
-func TestNetworkPolicyMultipleNPsSharedHPPNamedPortsDirect(t *testing.T) {
+// TestNetworkPolicyIngressNamedPortsUseDistinctHPPsDirect verifies the same
+// subject isolation for HPP-direct HostprotPol custom resources.
+func TestNetworkPolicyIngressNamedPortsUseDistinctHPPsDirect(t *testing.T) {
 	cont := getContWithEnabledLocalHpp()
 	os.Setenv("SYSTEM_NAMESPACE", "kube-system")
 	defer os.Unsetenv("SYSTEM_NAMESPACE")
@@ -4471,44 +4463,45 @@ func TestNetworkPolicyMultipleNPsSharedHPPNamedPortsDirect(t *testing.T) {
 	cont.fakePodSource.Add(pod1)
 	cont.fakePodSource.Add(pod2)
 	cont.run()
+	waitForPodIndexed(t, cont, "testns/pod1", "testns/pod2")
 	cont.fakeNetworkPolicySource.Add(np1)
 	cont.fakeNetworkPolicySource.Add(np2)
 
-	hash, _ := util.CreateCanonicalHashFromNetPol(np1)
-	labelKey := cont.aciNameForKey("np", hash)
-	hppName := strings.ReplaceAll(labelKey, "_", "-")
+	hash1, err := util.CreateCanonicalHashFromNetPol(np1)
+	assert.NoError(t, err)
+	hash2, err := util.CreateCanonicalHashFromNetPol(np2)
+	assert.NoError(t, err)
+	assert.NotEqual(t, hash1, hash2)
+	hppName1 := strings.ReplaceAll(cont.aciNameForKey("np", hash1), "_", "-")
+	hppName2 := strings.ReplaceAll(cont.aciNameForKey("np", hash2), "_", "-")
 	ns := os.Getenv("SYSTEM_NAMESPACE")
 
-	tu.WaitFor(t, "multiple-nps-shared-hpp-named-ports-direct", 2000*time.Millisecond,
-		func(last bool) (bool, error) {
-			hpp, err := cont.getHostprotPol(hppName, ns)
-			if err != nil {
-				return false, nil
-			}
-
-			// Find ingress subject
-			var ingressSubj *hppv1.HostprotSubj
-			for i := range hpp.Spec.HostprotSubj {
-				if hpp.Spec.HostprotSubj[i].Name == "networkpolicy-ingress" {
-					ingressSubj = &hpp.Spec.HostprotSubj[i]
-					break
+	waitForOnlyIngressPort := func(hppName, npKey, wantPort string) {
+		t.Helper()
+		tu.WaitFor(t, hppName+"-port-"+wantPort, 2000*time.Millisecond,
+			func(last bool) (bool, error) {
+				hpp, err := cont.getHostprotPol(hppName, ns)
+				if err != nil {
+					return false, nil
 				}
-			}
-			if ingressSubj == nil {
-				return false, nil
-			}
-
-			// Collect all fromPort values from ingress rules
-			ports := make(map[string]bool)
-			for _, rule := range ingressSubj.HostprotRule {
-				if rule.FromPort != "" && rule.FromPort != "unspecified" {
-					ports[rule.FromPort] = true
+				if !reflect.DeepEqual(hpp.Spec.NetworkPolicies, []string{npKey}) {
+					return false, nil
 				}
-			}
+				var ports []string
+				for _, subj := range hpp.Spec.HostprotSubj {
+					if subj.Name != "networkpolicy-ingress" {
+						continue
+					}
+					for _, rule := range subj.HostprotRule {
+						ports = append(ports, rule.FromPort)
+					}
+				}
+				return len(ports) == 1 && ports[0] == wantPort, nil
+			})
+	}
 
-			// Both port 80 (from NP1/pod1) and 8080 (from NP2/pod2) must be present
-			return ports["80"] && ports["8080"], nil
-		})
+	waitForOnlyIngressPort(hppName1, "testns/np1", "80")
+	waitForOnlyIngressPort(hppName2, "testns/np2", "8080")
 
 	cont.stop()
 }

--- a/pkg/util/nwpolicy.go
+++ b/pkg/util/nwpolicy.go
@@ -25,6 +25,7 @@ import (
 
 	v1net "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -68,6 +69,9 @@ func CreateHashFromNetPol(np *v1net.NetworkPolicy) (string, error) {
 	}
 
 	key += pt
+	if subjectHash := ingressNamedPortSubjectHash(np); subjectHash != "" {
+		key += subjectHash
+	}
 
 	return Hash(key), nil
 }
@@ -227,7 +231,32 @@ func CreateCanonicalHashFromNetPol(np *v1net.NetworkPolicy) (string, error) {
 	in := canonicalIngressStrSorted(np)
 	e := canonicalEgressStrSorted(np)
 	pt := "[" + strings.Join(sortPolicyTypes(np.Spec.PolicyTypes), ",") + "]"
-	return Hash("{" + in + ";" + e + ";" + pt + "}"), nil
+	var key string
+	if subjectHash := ingressNamedPortSubjectHash(np); subjectHash != "" {
+		key = "{" + in + ";" + e + ";" + pt + ";" + subjectHash + "}"
+	} else {
+		key = "{" + in + ";" + e + ";" + pt + "}"
+	}
+	return Hash(key), nil
+}
+
+// CreateCanonicalHashFromPodSelector returns the canonical identity of a
+// NetworkPolicy's selected pods. Namespace is part of the identity because a
+// PodSelector only selects pods in the policy's own namespace.
+func CreateCanonicalHashFromPodSelector(podSelector *metav1.LabelSelector,
+	namespace string) string {
+	return Hash("{" + canonicalLabelSelectorToStr(podSelector) + ";" + namespace + "}")
+}
+
+func ingressNamedPortSubjectHash(np *v1net.NetworkPolicy) string {
+	for _, ingress := range np.Spec.Ingress {
+		for _, port := range ingress.Ports {
+			if port.Port != nil && port.Port.Type == intstr.String {
+				return CreateCanonicalHashFromPodSelector(&np.Spec.PodSelector, np.Namespace)
+			}
+		}
+	}
+	return ""
 }
 
 func CreateHashFromNetPolPeers(peers []v1net.NetworkPolicyPeer, namespace string) string {

--- a/pkg/util/nwpolicy_test.go
+++ b/pkg/util/nwpolicy_test.go
@@ -238,6 +238,131 @@ func npWithRules(ingress []v1net.NetworkPolicyIngressRule, egress []v1net.Networ
 	}
 }
 
+func netPolWithIngressPort(namespace string, podSelector metav1.LabelSelector,
+	port intstr.IntOrString) *v1net.NetworkPolicy {
+	tcp := v1.ProtocolTCP
+	return &v1net.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "policy", Namespace: namespace},
+		Spec: v1net.NetworkPolicySpec{
+			PodSelector: podSelector,
+			Ingress: []v1net.NetworkPolicyIngressRule{{
+				Ports: []v1net.NetworkPolicyPort{{Protocol: &tcp, Port: &port}},
+			}},
+			PolicyTypes: []v1net.PolicyType{v1net.PolicyTypeIngress},
+		},
+	}
+}
+
+func TestNetPolHashesScopeIngressNamedPortsBySelectedPods(t *testing.T) {
+	web := metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}}
+	api := metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}}
+	namedPort := intstr.FromString("http")
+
+	webPolicy := netPolWithIngressPort("default", web, namedPort)
+	apiPolicy := netPolWithIngressPort("default", api, namedPort)
+
+	webLegacy, err := CreateHashFromNetPol(webPolicy)
+	if err != nil {
+		t.Fatalf("hash legacy web policy: %v", err)
+	}
+	apiLegacy, err := CreateHashFromNetPol(apiPolicy)
+	if err != nil {
+		t.Fatalf("hash legacy api policy: %v", err)
+	}
+	if webLegacy == apiLegacy {
+		t.Errorf("legacy HPP hash collapsed distinct named-port subject selectors: %q",
+			webLegacy)
+	}
+
+	webCanonical, err := CreateCanonicalHashFromNetPol(webPolicy)
+	if err != nil {
+		t.Fatalf("hash canonical web policy: %v", err)
+	}
+	apiCanonical, err := CreateCanonicalHashFromNetPol(apiPolicy)
+	if err != nil {
+		t.Fatalf("hash canonical api policy: %v", err)
+	}
+	if webCanonical == apiCanonical {
+		t.Errorf("canonical HPP hash collapsed distinct named-port subject selectors: %q",
+			webCanonical)
+	}
+
+	webOtherNamespace := netPolWithIngressPort("other", web, namedPort)
+	otherNamespaceHash, err := CreateCanonicalHashFromNetPol(webOtherNamespace)
+	if err != nil {
+		t.Fatalf("hash policy in other namespace: %v", err)
+	}
+	if webCanonical == otherNamespaceHash {
+		t.Errorf("named-port policies in different namespaces collapsed: %q",
+			webCanonical)
+	}
+}
+
+func TestNetPolHashesContinueSharingNumericIngressPolicies(t *testing.T) {
+	web := metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}}
+	api := metav1.LabelSelector{MatchLabels: map[string]string{"app": "api"}}
+	numericPort := intstr.FromInt(8080)
+
+	webPolicy := netPolWithIngressPort("default", web, numericPort)
+	apiPolicy := netPolWithIngressPort("default", api, numericPort)
+
+	webLegacy, err := CreateHashFromNetPol(webPolicy)
+	if err != nil {
+		t.Fatalf("hash legacy web policy: %v", err)
+	}
+	apiLegacy, err := CreateHashFromNetPol(apiPolicy)
+	if err != nil {
+		t.Fatalf("hash legacy api policy: %v", err)
+	}
+	if webLegacy != apiLegacy {
+		t.Errorf("numeric ingress policies no longer share legacy HPP: %q != %q",
+			webLegacy, apiLegacy)
+	}
+
+	webCanonical, err := CreateCanonicalHashFromNetPol(webPolicy)
+	if err != nil {
+		t.Fatalf("hash canonical web policy: %v", err)
+	}
+	apiCanonical, err := CreateCanonicalHashFromNetPol(apiPolicy)
+	if err != nil {
+		t.Fatalf("hash canonical api policy: %v", err)
+	}
+	if webCanonical != apiCanonical {
+		t.Errorf("numeric ingress policies no longer share canonical HPP: %q != %q",
+			webCanonical, apiCanonical)
+	}
+}
+
+func TestCanonicalPodSelectorHashIsOrderIndependent(t *testing.T) {
+	first := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "api"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "tier",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{"backend", "frontend"},
+		}},
+	}
+	second := &metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": "api"},
+		MatchExpressions: []metav1.LabelSelectorRequirement{{
+			Key:      "tier",
+			Operator: metav1.LabelSelectorOpIn,
+			Values:   []string{"frontend", "backend"},
+		}},
+	}
+
+	firstHash := CreateCanonicalHashFromPodSelector(first, "default")
+	secondHash := CreateCanonicalHashFromPodSelector(second, "default")
+	if firstHash != secondHash {
+		t.Errorf("equivalent pod selectors produced different hashes: %q != %q",
+			firstHash, secondHash)
+	}
+	if firstHash == CreateCanonicalHashFromPodSelector(first, "other") {
+		t.Errorf("same pod selector in different namespaces produced one hash: %q",
+			firstHash)
+	}
+}
+
 // Class 2: an ingress rule and an egress rule with identical peer/port text and
 // identical policyTypes must not collapse onto one HPP.
 func TestCanonicalHashDistinguishesDirection(t *testing.T) {


### PR DESCRIPTION
Ingress NetworkPolicies with identical named-port rules could share a HostprotPol even when their pod selectors resolved the name to different numeric ports. Merging sibling rules then attached the union of resolved ports to every selected destination group.

- Include the policy namespace and canonical pod selector in HostprotPol identity when an ingress rule contains a named port.
- Apply the scoped identity in HPP optimization and HPP direct while retaining sharing for numeric ingress policies.
- Remove sibling named-port rule merging, ownership caches, deletion requeues and the related startup defer path.
- Add regression coverage proving each selected pod group receives only its own resolved port.

(cherry picked from commit 4bfba326c47871949310c5fc29602cfeffa7728c)