### PR TITLE
Prevent premature netpol pruning on host-agent restart

### DIFF
--- a/pkg/hostagent/agent.go
+++ b/pkg/hostagent/agent.go
@@ -112,6 +112,7 @@ type HostAgent struct {
 	ricToHpp               map[string]map[string]bool
 	hppQueue               workqueue.RateLimitingInterface
 	hppInformerReg         cache.ResourceEventHandlerRegistration
+	netPolInformerReg      cache.ResourceEventHandlerRegistration
 	hppSyncEnabled         atomic.Bool
 	proactiveConfInformer  cache.SharedIndexInformer
 
@@ -602,17 +603,28 @@ func (agent *HostAgent) processQueue(queue workqueue.RateLimitingInterface, stor
 }
 
 // enableHppSyncAfterCheckpoint defers stale netpol-file pruning until the
-// initial HPP render batch has fully drained: it waits for the hpp informer
-// to sync, then enqueues a sentinel on hppQueue and waits for the render
-// worker to reach it. Only then does hppMoIndex reflect the full initial
-// desired state, so syncLocalHppMo can safely delete files with no backing
-// entry without risking a delete-then-readd churn on restart.
+// initial HPP render batch has fully drained. The prune deletes any on-disk
+// netpol file whose HPP is absent from hppMoIndex, so it is only safe once
+// hppMoIndex holds every locally-relevant HPP. Local relevance is decided by
+// isHppLocallyRelevant, which reads netPolPods. Each NetworkPolicy add handler
+// scans the already-synced, node-local pod informer store while registering the
+// policy's subject selector, populates netPolPods, and synchronously queues
+// every newly local HPP through its pod-callback fan-out. So we wait for the HPP
+// and NetworkPolicy handler registrations to finish their initial delivery,
+// then enqueue a sentinel on hppQueue and wait for the render worker to reach
+// it. Only then does hppMoIndex reflect the full initial desired state and can
+// syncLocalHppMo safely delete files with no backing entry.
 func (agent *HostAgent) enableHppSyncAfterCheckpoint(stopCh <-chan struct{}) {
-	if agent.hppInformerReg == nil {
+	if agent.hppInformerReg == nil || agent.netPolInformerReg == nil {
+		agent.log.Error("Cannot enable stale netpol prune without HPP and NetworkPolicy handler sync")
 		return
 	}
-	if !cache.WaitForCacheSync(stopCh, agent.hppInformerReg.HasSynced) {
-		return
+	for _, reg := range []cache.ResourceEventHandlerRegistration{
+		agent.hppInformerReg, agent.netPolInformerReg,
+	} {
+		if !cache.WaitForCacheSync(stopCh, reg.HasSynced) {
+			return
+		}
 	}
 	done := make(chan struct{})
 	agent.hppQueue.Add(done)

--- a/pkg/hostagent/environment.go
+++ b/pkg/hostagent/environment.go
@@ -283,15 +283,17 @@ func (env *K8sEnvironment) PrepareRun(stopCh <-chan struct{}) (bool, error) {
 
 	if env.agent.hppDirectEnabled() {
 		env.agent.log.Debug("Starting hpp informers")
+		env.agent.log.Debug("Starting hostprotremoteipcontainer informers")
+		go env.agent.hppRemoteIpInformer.Run(stopCh)
 		go env.agent.hppInformer.Run(stopCh)
+		// HPP rendering resolves RIC references from the RIC informer store.
+		// Synchronize that store before starting the HPP worker so every RIC
+		// referenced by an HPP that existed at startup is already available.
+		env.agent.log.Info("Waiting for hostprotremoteipcontainer cache sync")
+		cache.WaitForCacheSync(stopCh, env.agent.hppRemoteIpInformer.HasSynced)
 		env.agent.log.Info("Waiting for hpp cache sync")
 		cache.WaitForCacheSync(stopCh, env.agent.hppInformer.HasSynced)
 		env.agent.log.Info("hpp cache sync successful")
-
-		env.agent.log.Debug("Starting hostprotremoteipcontainer informers")
-		go env.agent.hppRemoteIpInformer.Run(stopCh)
-		env.agent.log.Info("Waiting for hostprotremoteipcontainer cache sync")
-		cache.WaitForCacheSync(stopCh, env.agent.hppRemoteIpInformer.HasSynced)
 		env.agent.log.Info("hostprotremoteipcontainer cache sync successful")
 		env.agent.log.Debug("Starting hpp processing queue")
 		go env.agent.processQueue(env.agent.hppQueue, env.agent.hppInformer.GetStore(), env.agent.handleHppQueueItem, stopCh)

--- a/pkg/hostagent/hpp_test.go
+++ b/pkg/hostagent/hpp_test.go
@@ -17,7 +17,9 @@ package hostagent
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	hppv1 "github.com/noironetworks/aci-containers/pkg/hpp/apis/aci.hpp/v1"
 	"github.com/noironetworks/aci-containers/pkg/util"
@@ -28,6 +30,47 @@ import (
 	"k8s.io/client-go/tools/cache"
 	framework "k8s.io/client-go/tools/cache/testing"
 )
+
+type controlledHandlerRegistration struct {
+	name string
+	done chan struct{}
+}
+
+func newControlledHandlerRegistration(name string, synced bool) *controlledHandlerRegistration {
+	reg := &controlledHandlerRegistration{
+		name: name,
+		done: make(chan struct{}),
+	}
+	if synced {
+		close(reg.done)
+	}
+	return reg
+}
+
+func (r *controlledHandlerRegistration) HasSynced() bool {
+	select {
+	case <-r.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *controlledHandlerRegistration) HasSyncedChecker() cache.DoneChecker {
+	return r
+}
+
+func (r *controlledHandlerRegistration) Name() string {
+	return r.name
+}
+
+func (r *controlledHandlerRegistration) Done() <-chan struct{} {
+	return r.done
+}
+
+func (r *controlledHandlerRegistration) markSynced() {
+	close(r.done)
+}
 
 // testAgentHppDirect builds a testHostAgent with EnableHppDirect enabled and
 // OpFlexNetPolDir pointed at a per-test temp directory.
@@ -92,6 +135,88 @@ func drainHppQueue(t *testing.T, agent *testHostAgent) {
 		agent.hppQueue.Done(item)
 		agent.hppQueue.Forget(item)
 	}
+}
+
+func TestHppCheckpointWaitsForNetworkPolicyHandler(t *testing.T) {
+	agent := testAgentHppDirect(t)
+
+	np := &v1net.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "np-checkpoint"},
+		Spec: v1net.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+		},
+	}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "pod-checkpoint"},
+		Spec:       v1.PodSpec{NodeName: nodename},
+	}
+	specName, err := agent.getHPPDirLabelKey(np)
+	assert.NoError(t, err)
+	hpp := &hppv1.HostprotPol{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: agent.config.AciHppObjsNamespace,
+			Name:      strings.ReplaceAll(specName, "_", "-"),
+		},
+		Spec: hppv1.HostprotPolSpec{
+			Name:            specName,
+			NetworkPolicies: []string{"testns/np-checkpoint"},
+			HostprotSubj:    []hppv1.HostprotSubj{{Name: "subj1"}},
+		},
+	}
+
+	assert.NoError(t, agent.podInformer.GetStore().Add(pod))
+	assert.NoError(t, agent.netPolInformer.GetStore().Add(np))
+	assert.NoError(t, agent.hppInformer.GetStore().Add(hpp))
+
+	filePath := filepath.Join(agent.config.OpFlexNetPolDir, specName+".netpol")
+	assert.NoError(t, os.WriteFile(filePath, []byte("existing netpol"), 0o600))
+
+	hppReg := newControlledHandlerRegistration("hpp", true)
+	netPolReg := newControlledHandlerRegistration("networkpolicy", false)
+	agent.hppInformerReg = hppReg
+	agent.netPolInformerReg = netPolReg
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go agent.processQueue(agent.hppQueue, agent.hppInformer.GetStore(),
+		agent.handleHppQueueItem, stopCh)
+	go agent.processSyncQueue(agent.hppLocalMoSyncQueue, stopCh)
+	go agent.enableHppSyncAfterCheckpoint(stopCh)
+
+	assert.Never(t, agent.hppSyncEnabled.Load, 250*time.Millisecond, 10*time.Millisecond,
+		"stale prune must remain disabled while the NetworkPolicy handler is pending")
+	_, err = os.Stat(filePath)
+	assert.NoError(t, err, "the existing netpol file must not be pruned")
+
+	// Complete the delayed initial NetworkPolicy delivery. The handler scans
+	// the already-populated pod store, reconstructs NP-to-pod locality, and
+	// queues the corresponding HPP before its registration reports synced.
+	agent.networkPolicyAdded(np)
+	netPolReg.markSynced()
+
+	assert.Eventually(t, agent.hppSyncEnabled.Load, 2*time.Second, 10*time.Millisecond,
+		"stale prune should be enabled after the handler and HPP queue drain")
+	assert.Eventually(t, func() bool {
+		agent.hppMutex.Lock()
+		defer agent.hppMutex.Unlock()
+		_, ok := agent.hppMoIndex[specName]
+		return ok
+	}, 2*time.Second, 10*time.Millisecond, "the locally relevant HPP should be rendered")
+	_, err = os.Stat(filePath)
+	assert.NoError(t, err, "the locally relevant netpol file must remain present")
+}
+
+func TestHppCheckpointFailsClosedWithoutNetworkPolicyRegistration(t *testing.T) {
+	agent := testAgentHppDirect(t)
+	agent.hppInformerReg = newControlledHandlerRegistration("hpp", true)
+	agent.netPolInformerReg = nil
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	agent.enableHppSyncAfterCheckpoint(stopCh)
+
+	assert.False(t, agent.hppSyncEnabled.Load())
+	assert.Zero(t, agent.hppQueue.Len())
 }
 
 func TestIsStaticOrNodeHpp(t *testing.T) {

--- a/pkg/hostagent/pod_relatives.go
+++ b/pkg/hostagent/pod_relatives.go
@@ -137,7 +137,7 @@ func (agent *HostAgent) initNetworkPolicyInformerBase(listWatch *cache.ListWatch
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		)
 
-	agent.netPolInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := agent.netPolInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			agent.networkPolicyAdded(obj)
 		},
@@ -149,6 +149,11 @@ func (agent *HostAgent) initNetworkPolicyInformerBase(listWatch *cache.ListWatch
 		},
 	},
 	)
+	if err != nil {
+		agent.log.Errorf("Failed to register network policy event handler: %v", err)
+		return
+	}
+	agent.netPolInformerReg = reg
 }
 
 func (agent *HostAgent) networkPolicyAdded(obj interface{}) {


### PR DESCRIPTION
On restart, the HPP handler could reach its render checkpoint before initial NetworkPolicy callbacks finished rebuilding the node-local policy-to-pod index. Valid HPPs were then treated as non-local, causing their persisted netpol files to be deleted and recreated.

Retain the NetworkPolicy handler registration and wait for it together with the HPP handler before checkpointing the render queue. Synchronize the RIC informer store before rendering pre-existing HPPs, and keep pruning disabled if either handler dependency is unavailable.

Add regression coverage for delayed NetworkPolicy delivery and fail-closed dependency handling.