### PR TITLE
[mmr-6.1.1] Support SCTP in HPP-direct NetworkPolicy path

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -310,6 +310,7 @@ func (cont *AciController) validateHppCr(hpp *hppv1.HostprotPol) bool {
 	allowedProtocols := map[string]bool{
 		"tcp":         true,
 		"udp":         true,
+		"sctp":        true,
 		"icmp":        true,
 		"icmpv6":      true,
 		"unspecified": true,

--- a/pkg/hostagent/hpp_lib.go
+++ b/pkg/hostagent/hpp_lib.go
@@ -607,6 +607,8 @@ func protocolNameToNumber(protocol string) int {
 		return 6
 	case "icmpv6":
 		return 58
+	case "sctp":
+		return 132
 	default:
 		return 0
 	}

--- a/pkg/hostagent/hpp_lib_test.go
+++ b/pkg/hostagent/hpp_lib_test.go
@@ -30,11 +30,13 @@ func TestProtocolNameToNumber(t *testing.T) {
 		{"udp lowercase", "udp", 17},
 		{"icmp lowercase", "icmp", 1},
 		{"icmpv6 lowercase", "icmpv6", 58},
+		{"sctp lowercase", "sctp", 132},
 		{"tcp uppercase", "TCP", 6},
 		{"udp uppercase", "UDP", 17},
 		{"icmp mixed case", "IcMp", 1},
 		{"icmpv6 mixed case", "ICMPv6", 58},
-		{"unknown protocol", "sctp", 0},
+		{"sctp uppercase", "SCTP", 132},
+		{"unknown protocol", "foo", 0},
 		{"empty string", "", 0},
 	}
 


### PR DESCRIPTION
NetworkPolicy rules using protocol: SCTP were silently dropped in HPP-direct mode. The controller's HostprotPol CR validator did not include "sctp" in its allowlist, so validateHppCr() rejected the CR before it was ever created. Even if the CR had been written, the host-agent's protocolNameToNumber() had no case for "sctp" and would have emitted prot=0 (HOPOPT) in the .netpol file consumed by opflex-agent, resulting in no matching OVS flow.

(cherry picked from commit 26dd136ec83fe94a2f621a97553b2451d68f19e5)