### PR TITLE
[mmr-6.1.1] Prevent HPP churn on controller restart

### DIFF
--- a/pkg/controller/network_policy.go
+++ b/pkg/controller/network_policy.go
@@ -35,6 +35,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	v1net "k8s.io/api/networking/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -2203,8 +2204,8 @@ func (cont *AciController) handleHppUpdate(hppName string) bool {
 		if !cont.hppSyncEnabled.Load() {
 
 			if actual.Spec.Name == desired.Spec.Name {
-				if reflect.DeepEqual(actual.Spec.HostprotSubj, desired.Spec.HostprotSubj) {
-					if !reflect.DeepEqual(actual.Spec.NetworkPolicies, desired.Spec.NetworkPolicies) {
+				if apiequality.Semantic.DeepEqual(actual.Spec.HostprotSubj, desired.Spec.HostprotSubj) {
+					if !apiequality.Semantic.DeepEqual(actual.Spec.NetworkPolicies, desired.Spec.NetworkPolicies) {
 						// Until the NP sync and HPP cache build is complete, we don't have the full
 						// desired list of network policies to compare against, so we can't determine
 						// if an update is needed.
@@ -2215,7 +2216,7 @@ func (cont *AciController) handleHppUpdate(hppName string) bool {
 			}
 		} else {
 			// Both exist — compare and update if changed.
-			if reflect.DeepEqual(actual.Spec, desired.Spec) {
+			if apiequality.Semantic.DeepEqual(actual.Spec, desired.Spec) {
 				return false // no-op
 			}
 		}

--- a/pkg/controller/network_policy_test.go
+++ b/pkg/controller/network_policy_test.go
@@ -5108,6 +5108,92 @@ func TestUpdateHostprotPol(t *testing.T) {
 	assert.False(t, ret)
 }
 
+func TestHandleHppUpdateEquatesNilAndEmptyRules(t *testing.T) {
+	const (
+		ns      = "test-namespace"
+		hppName = "test-shared-hpp"
+	)
+	t.Setenv("SYSTEM_NAMESPACE", ns)
+
+	tests := []struct {
+		name            string
+		syncEnabled     bool
+		actualOwners    []string
+		desiredOwners   []string
+		expectedRequeue bool
+	}{
+		{
+			name:            "before checkpoint defers ownership-only update",
+			actualOwners:    []string{"test-ns/np-a", "test-ns/np-b"},
+			desiredOwners:   []string{"test-ns/np-a"},
+			expectedRequeue: true,
+		},
+		{
+			name:            "after checkpoint treats full spec as unchanged",
+			syncEnabled:     true,
+			actualOwners:    []string{"test-ns/np-a", "test-ns/np-b"},
+			desiredOwners:   []string{"test-ns/np-a", "test-ns/np-b"},
+			expectedRequeue: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cont := getContWithEnabledLocalHpp()
+			hppClient := cont.env.(*K8sEnvironment).hppClient.(*fake.Clientset)
+
+			actual := &hppv1.HostprotPol{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      hppName,
+					Namespace: ns,
+				},
+				Spec: hppv1.HostprotPolSpec{
+					Name:            "test_shared_hpp",
+					NetworkPolicies: tt.actualOwners,
+					HostprotSubj: []hppv1.HostprotSubj{
+						{
+							Name:         "networkpolicy-ingress",
+							HostprotRule: nil,
+						},
+						{
+							Name: "networkpolicy-egress",
+							HostprotRule: []hppv1.HostprotRule{
+								{
+									Name:      "allow-dns",
+									Direction: "egress",
+									Protocol:  "udp",
+									FromPort:  "53",
+								},
+							},
+						},
+					},
+				},
+			}
+			created, err := hppClient.AciV1().HostprotPols(ns).Create(
+				context.TODO(), actual, metav1.CreateOptions{})
+			assert.NoError(t, err)
+			assert.NoError(t, cont.hppInformer.GetIndexer().Add(created))
+
+			desired := actual.DeepCopy()
+			desired.Spec.NetworkPolicies = tt.desiredOwners
+			desired.Spec.HostprotSubj[0].HostprotRule = []hppv1.HostprotRule{}
+			cont.hppDirRef[hppName] = hppDirReference{
+				RefCount: uint(len(tt.desiredOwners)),
+				Npkeys:   tt.desiredOwners,
+				HppCr:    *desired,
+			}
+			cont.hppSyncEnabled.Store(tt.syncEnabled)
+
+			hppClient.ClearActions()
+			requeue := cont.handleHppUpdate(hppName)
+
+			assert.Equal(t, tt.expectedRequeue, requeue)
+			assert.Empty(t, hppClient.Actions(),
+				"semantic nil/empty equality must not issue an HPP API update")
+		})
+	}
+}
+
 func TestDeleteHostprotPol(t *testing.T) {
 	cont := getContWithEnabledLocalHpp()
 	cont.run()


### PR DESCRIPTION
The API may return empty HPP rule lists as nil while rebuilt state uses empty slices. reflect.DeepEqual treats these as different, causing unchanged shared HPPs to be updated and netpol files to be recreated.

Use Kubernetes semantic equality for HPP comparisons and add regression coverage for empty ingress rules with non-empty egress rules.

(cherry picked from commit da5e9d4260dcd05efaa24b5db8a9aaef478f5894)