### PR TITLE
[mmr-6.1.1] Revert "Fix(apicapi): prevent invalid delete of APIC owned helper MOs"

### DIFF
--- a/pkg/apicapi/apic_metadata.go
+++ b/pkg/apicapi/apic_metadata.go
@@ -277,6 +277,9 @@ var metadata = map[string]*apicMeta{
 		},
 	},
 	"infraGeneric": {
+		hints: map[string]interface{}{
+			"deletable": false,
+		},
 		attributes: map[string]interface{}{
 			"name":      "",
 			"nameAlias": "",
@@ -311,6 +314,9 @@ var metadata = map[string]*apicMeta{
 		children: []string{},
 	},
 	"fvRsBd": {
+		hints: map[string]interface{}{
+			"deletable": false,
+		},
 		attributes: map[string]interface{}{
 			"tnFvBDName": "",
 		},
@@ -336,6 +342,9 @@ var metadata = map[string]*apicMeta{
 		},
 	},
 	"fvRsCtx": {
+		hints: map[string]interface{}{
+			"deletable": false,
+		},
 		attributes: map[string]interface{}{
 			"tnFvCtxName": "",
 		},

--- a/pkg/apicapi/apic_sync.go
+++ b/pkg/apicapi/apic_sync.go
@@ -77,11 +77,6 @@ func (conn *ApicConnection) apicBodyAttrCmp(class string,
 	return true
 }
 
-func (conn *ApicConnection) localSyncTag(obj ApicObject) (string, bool) {
-	tag := obj.GetTag()
-	return tag, conn.isSyncTag(tag)
-}
-
 func (conn *ApicConnection) apicCntCmp(current ApicObject,
 	desired ApicObject) bool {
 	for classc, bodyc := range current {
@@ -115,7 +110,13 @@ func (conn *ApicConnection) apicObjCmp(current ApicObject,
 			for i < len(bodyc.Children) && j < len(bodyd.Children) {
 				cmp := cmpApicObject(bodyc.Children[i], bodyd.Children[j])
 				if cmp < 0 {
-					_, deletable := conn.localSyncTag(bodyc.Children[i])
+					deletable := true
+					for class := range bodyc.Children[i] {
+						deletable = conn.checkNonDeletable(class)
+						if !deletable {
+							break
+						}
+					}
 					if !deletable {
 						i++
 						continue
@@ -138,7 +139,13 @@ func (conn *ApicConnection) apicObjCmp(current ApicObject,
 				}
 			}
 			for i < len(bodyc.Children) {
-				_, deletable := conn.localSyncTag(bodyc.Children[i])
+				deletable := true
+				for class := range bodyc.Children[i] {
+					deletable = conn.checkNonDeletable(class)
+					if !deletable {
+						break
+					}
+				}
 				if !deletable {
 					i++
 					continue
@@ -154,6 +161,21 @@ func (conn *ApicConnection) apicObjCmp(current ApicObject,
 	return
 }
 
+func (conn *ApicConnection) checkNonDeletable(class string) bool {
+	deletable := true
+	if _, ok := metadata[class]; ok {
+		if metadata[class].hints != nil {
+			if val, ok := metadata[class].hints["deletable"]; ok {
+				deletableValue, ok := val.(bool)
+				if ok && deletableValue == false {
+					deletable = false
+				}
+			}
+		}
+	}
+	return deletable
+}
+
 func (conn *ApicConnection) diffApicState(currentState ApicSlice,
 	desiredState ApicSlice) (updates ApicSlice, deletes, localDeletes []string) {
 	i := 0
@@ -165,7 +187,13 @@ func (conn *ApicConnection) diffApicState(currentState ApicSlice,
 	for i < len(currentState) && j < len(desiredState) {
 		cmp := cmpApicObject(currentState[i], desiredState[j])
 		if cmp < 0 {
-			_, deletable := conn.localSyncTag(currentState[i])
+			deletable := true
+			for class := range currentState[i] {
+				deletable = conn.checkNonDeletable(class)
+				if !deletable {
+					break
+				}
+			}
 			if !deletable {
 				localDeletes = append(localDeletes, currentState[i].GetDn())
 				i++
@@ -190,7 +218,13 @@ func (conn *ApicConnection) diffApicState(currentState ApicSlice,
 					updates = append(updates, desiredState[j])
 					update = true
 				}
-				_, deletable := conn.localSyncTag(currentState[i])
+				deletable := true
+				for class := range currentState[i] {
+					deletable = conn.checkNonDeletable(class)
+					if !deletable {
+						break
+					}
+				}
 				if !deletable {
 					localDeletes = append(localDeletes, currentState[i].GetDn())
 					i++
@@ -207,7 +241,13 @@ func (conn *ApicConnection) diffApicState(currentState ApicSlice,
 	}
 	// extra old objects
 	for i < len(currentState) {
-		_, deletable := conn.localSyncTag(currentState[i])
+		deletable := true
+		for class := range currentState[i] {
+			deletable = conn.checkNonDeletable(class)
+			if !deletable {
+				break
+			}
+		}
 		if !deletable {
 			i++
 			localDeletes = append(localDeletes, currentState[i].GetDn())
@@ -559,14 +599,10 @@ func (conn *ApicConnection) reconcileApicObject(aci ApicObject) {
 			}
 		}
 	} else {
-		tag, owned := conn.localSyncTag(aci)
-		if owned {
-			conn.log.WithFields(logrus.Fields{
-				"mod":     "APICAPI",
-				"DN":      dn,
-				"tag":     tag,
-				"context": "reconcile",
-			}).Warning("Deleting unexpected ACI object")
+		tag := aci.GetTag()
+		if conn.isSyncTag(tag) {
+			conn.log.WithFields(logrus.Fields{"mod": "APICAPI", "DN": dn}).
+				Warning("Deleting unexpected ACI object")
 			deletes = append(deletes, dn)
 		}
 	}

--- a/pkg/apicapi/apic_sync_test.go
+++ b/pkg/apicapi/apic_sync_test.go
@@ -201,125 +201,39 @@ func TestApicCntCmp(t *testing.T) {
 	})
 }
 
-func TestLocalSyncTag(t *testing.T) {
+func TestCheckNonDeletable(t *testing.T) {
 	server := newTestServer()
 	defer server.server.Close()
 	conn, err := server.testConn(nil)
 	assert.Nil(t, err)
 
-	tag := getTagFromKey(conn.prefix, "key-local-tag")
-	objDn := "uni/tn-common/brc-openupi_snat_svcgraph/rtfvProv-[x]"
+	t.Run("Non-Deletable Class", func(t *testing.T) {
+		class := "infraGeneric"
+		expected := false
 
-	t.Run("Has local sync tag annotation", func(t *testing.T) {
-		obj := ApicObject{
-			"vzRtProv": &ApicObjectBody{
-				Attributes: map[string]interface{}{
-					"dn": objDn,
-				},
-				Children: ApicSlice{
-					NewTagAnnotation(objDn, aciContainersAnnotKey).SetAttr("value", tag),
-				},
-			},
-		}
+		result := conn.checkNonDeletable(class)
 
-		actualTag, owned := conn.localSyncTag(obj)
-		assert.Equal(t, tag, actualTag)
-		assert.True(t, owned)
+		assert.Equal(t, expected, result)
 	})
 
-	t.Run("Missing local tag annotation", func(t *testing.T) {
-		obj := ApicObject{
-			"vzRtProv": &ApicObjectBody{
-				Attributes: map[string]interface{}{
-					"dn": objDn,
-				},
-			},
-		}
+	t.Run("Deletable Class", func(t *testing.T) {
+		class := "fvTenant"
+		expected := true
 
-		actualTag, owned := conn.localSyncTag(obj)
-		assert.Equal(t, "", actualTag)
-		assert.False(t, owned)
+		result := conn.checkNonDeletable(class)
+
+		assert.Equal(t, expected, result)
 	})
 
-	t.Run("Tag annotation belongs to parent DN", func(t *testing.T) {
-		parentDn := "uni/tn-common/brc-openupi_snat_svcgraph"
-		obj := ApicObject{
-			"vzRtProv": &ApicObjectBody{
-				Attributes: map[string]interface{}{
-					"dn": objDn,
-				},
-				Children: ApicSlice{
-					NewTagAnnotation(parentDn, aciContainersAnnotKey).SetAttr("value", tag),
-				},
-			},
-		}
+	t.Run("Unknown Class", func(t *testing.T) {
+		class := "unknownClass"
+		expected := true
 
-		actualTag, owned := conn.localSyncTag(obj)
-		assert.Equal(t, tag, actualTag)
-		assert.True(t, owned)
+		result := conn.checkNonDeletable(class)
+
+		assert.Equal(t, expected, result)
 	})
 }
-
-func TestApicObjCmpChildDeleteUsesLocalTag(t *testing.T) {
-	server := newTestServer()
-	defer server.server.Close()
-	conn, err := server.testConn(nil)
-	assert.Nil(t, err)
-
-	tenantDn := "uni/tn-common"
-	childDn := "uni/tn-common/brc-openupi_snat_svcgraph/rtfvProv-[x]"
-	tag := getTagFromKey(conn.prefix, "key-child-delete")
-
-	t.Run("Untagged child is not deleted", func(t *testing.T) {
-		current := ApicObject{
-			"fvTenant": &ApicObjectBody{
-				Attributes: map[string]interface{}{"dn": tenantDn},
-				Children: ApicSlice{
-					{
-						"vzRtProv": &ApicObjectBody{
-							Attributes: map[string]interface{}{"dn": childDn},
-						},
-					},
-				},
-			},
-		}
-		desired := ApicObject{
-			"fvTenant": &ApicObjectBody{
-				Attributes: map[string]interface{}{"dn": tenantDn},
-			},
-		}
-
-		_, deletes := conn.apicObjCmp(current, desired)
-		assert.Empty(t, deletes)
-	})
-
-	t.Run("Tagged child is deleted", func(t *testing.T) {
-		current := ApicObject{
-			"fvTenant": &ApicObjectBody{
-				Attributes: map[string]interface{}{"dn": tenantDn},
-				Children: ApicSlice{
-					{
-						"vzRtProv": &ApicObjectBody{
-							Attributes: map[string]interface{}{"dn": childDn},
-							Children: ApicSlice{
-								NewTagAnnotation(childDn, aciContainersAnnotKey).SetAttr("value", tag),
-							},
-						},
-					},
-				},
-			},
-		}
-		desired := ApicObject{
-			"fvTenant": &ApicObjectBody{
-				Attributes: map[string]interface{}{"dn": tenantDn},
-			},
-		}
-
-		_, deletes := conn.apicObjCmp(current, desired)
-		assert.Equal(t, []string{childDn}, deletes)
-	})
-}
-
 func TestRemoveFromDnIndex(t *testing.T) {
 	server := newTestServer()
 	defer server.server.Close()


### PR DESCRIPTION
This reverts commit 1c7b93708ba150bb33252832b3d4948e394973b7.

(cherry picked from commit 108882ebcb6080ec6babfb503338cf9fb7a7586b)